### PR TITLE
[Region] 테이블 수정 및 @GeneratedValue 전략 변경

### DIFF
--- a/src/main/java/umc/lightup/item/domain/Item.java
+++ b/src/main/java/umc/lightup/item/domain/Item.java
@@ -7,7 +7,7 @@ import umc.lightup.member.domain.Member;
 @Entity
 public class Item extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/item/domain/ItemLike.java
+++ b/src/main/java/umc/lightup/item/domain/ItemLike.java
@@ -7,7 +7,7 @@ import umc.lightup.member.domain.Member;
 @Entity
 public class ItemLike extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/item/domain/ItemLikeGroup.java
+++ b/src/main/java/umc/lightup/item/domain/ItemLikeGroup.java
@@ -7,7 +7,7 @@ import umc.lightup.member.domain.Member;
 @Entity
 public class ItemLikeGroup extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/item/domain/ItemLikeGroupItem.java
+++ b/src/main/java/umc/lightup/item/domain/ItemLikeGroupItem.java
@@ -6,7 +6,7 @@ import umc.lightup.common.BaseEntity;
 @Entity
 public class ItemLikeGroupItem extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/item/domain/ItemTool.java
+++ b/src/main/java/umc/lightup/item/domain/ItemTool.java
@@ -7,7 +7,7 @@ import umc.lightup.tool.domain.Tool;
 @Entity
 public class ItemTool extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/item/domain/ItemViewHistory.java
+++ b/src/main/java/umc/lightup/item/domain/ItemViewHistory.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Entity
 public class ItemViewHistory { //extends 없음
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/item/domain/RecruitPosition.java
+++ b/src/main/java/umc/lightup/item/domain/RecruitPosition.java
@@ -7,7 +7,7 @@ import umc.lightup.position.domain.Position;
 @Entity
 public class RecruitPosition extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/item/domain/RequiredSkill.java
+++ b/src/main/java/umc/lightup/item/domain/RequiredSkill.java
@@ -7,7 +7,7 @@ import umc.lightup.skill.domain.Skill;
 @Entity
 public class RequiredSkill extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/member/domain/Member.java
+++ b/src/main/java/umc/lightup/member/domain/Member.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 @Entity
 public class Member extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(length = 20)

--- a/src/main/java/umc/lightup/member/domain/MemberLike.java
+++ b/src/main/java/umc/lightup/member/domain/MemberLike.java
@@ -6,7 +6,7 @@ import umc.lightup.common.BaseEntity;
 @Entity
 public class MemberLike extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/member/domain/MemberRegion.java
+++ b/src/main/java/umc/lightup/member/domain/MemberRegion.java
@@ -7,7 +7,7 @@ import umc.lightup.region.domain.Region;
 @Entity
 public class MemberRegion extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/member/domain/MemberSkill.java
+++ b/src/main/java/umc/lightup/member/domain/MemberSkill.java
@@ -7,7 +7,7 @@ import umc.lightup.skill.domain.Skill;
 @Entity
 public class MemberSkill extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/member/domain/MemberStrength.java
+++ b/src/main/java/umc/lightup/member/domain/MemberStrength.java
@@ -7,7 +7,7 @@ import umc.lightup.strength.domain.Strength;
 @Entity
 public class MemberStrength extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/member/domain/Portfolio.java
+++ b/src/main/java/umc/lightup/member/domain/Portfolio.java
@@ -6,7 +6,7 @@ import umc.lightup.common.BaseEntity;
 @Entity
 public class Portfolio extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/notification/domain/Notification.java
+++ b/src/main/java/umc/lightup/notification/domain/Notification.java
@@ -9,7 +9,7 @@ import umc.lightup.member.domain.Member;
 @Entity
 public class Notification extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/position/domain/Position.java
+++ b/src/main/java/umc/lightup/position/domain/Position.java
@@ -1,15 +1,12 @@
 package umc.lightup.position.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import umc.lightup.common.BaseEntity;
 
 @Entity
 public class Position extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(length = 30, nullable = false, unique = true)

--- a/src/main/java/umc/lightup/region/domain/Region.java
+++ b/src/main/java/umc/lightup/region/domain/Region.java
@@ -1,15 +1,12 @@
 package umc.lightup.region.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import umc.lightup.common.BaseEntity;
 
 @Entity
-public class Region extends BaseEntity {
+public class Region {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, length = 20)
@@ -18,6 +15,4 @@ public class Region extends BaseEntity {
     @Column(nullable = false, length = 30)
     private String sigungu;
 
-    @Column(unique = true, length = 50)
-    private String fullName;
 }

--- a/src/main/java/umc/lightup/skill/domain/Skill.java
+++ b/src/main/java/umc/lightup/skill/domain/Skill.java
@@ -1,15 +1,12 @@
 package umc.lightup.skill.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import umc.lightup.common.BaseEntity;
 
 @Entity
 public class Skill extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(length = 30, nullable = false, unique = true)

--- a/src/main/java/umc/lightup/strength/domain/Strength.java
+++ b/src/main/java/umc/lightup/strength/domain/Strength.java
@@ -1,15 +1,12 @@
 package umc.lightup.strength.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import umc.lightup.common.BaseEntity;
 
 @Entity
 public class Strength extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(length = 30, nullable = false, unique = true)

--- a/src/main/java/umc/lightup/tool/domain/Tool.java
+++ b/src/main/java/umc/lightup/tool/domain/Tool.java
@@ -7,7 +7,7 @@ import umc.lightup.tool.enums.ToolType;
 @Entity
 public class Tool extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(length = 30, nullable = false)


### PR DESCRIPTION
## 💫 PR 제목
- Region 테이블 수정 및 @GeneratedValue 전략 변경

---

## 🔧 작업 내용 요약
- 시도/시군구 데이터 작업 완료했고 @GeneratedValue를 그대로 두면 DB에 테이블마다 seq 테이블이 생겨서 strategy = GenerationType.IDENTITY 으로 모든 엔티티 변경했습니다.

---

## 🔍 중점적으로 리뷰받고 싶은 부분

---

## 🔗 관련 이슈


---

## 📝 기타 참고 사항