### PR TITLE
[Region] 지역 선택 기능

### DIFF
--- a/src/main/java/umc/lightup/region/controller/RegionController.java
+++ b/src/main/java/umc/lightup/region/controller/RegionController.java
@@ -1,0 +1,33 @@
+package umc.lightup.region.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import umc.lightup.api.ApiResponse;
+import umc.lightup.region.converter.RegionConverter;
+import umc.lightup.region.dto.RegionReponseDTO;
+import umc.lightup.region.service.RegionService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/regions")
+public class RegionController {
+
+    private final RegionService regionService;
+
+    @GetMapping("/sido")
+    public ApiResponse<RegionReponseDTO.SiDoListDTO> getSiDo() {
+        List<String> siDoList = regionService.getSiDoList();
+        return ApiResponse.onSuccess(RegionConverter.toSiDoResultDTO(siDoList));
+    }
+
+    @GetMapping("/sigungu")
+    public ApiResponse<RegionReponseDTO.SiGunGuListDTO> getSiGunGu(@RequestParam String sido) {
+        List<String> siGunGuList = regionService.getSiGunGuList(sido);
+        return ApiResponse.onSuccess(RegionConverter.toSiGunGuResultDTO(siGunGuList));
+    }
+}

--- a/src/main/java/umc/lightup/region/converter/RegionConverter.java
+++ b/src/main/java/umc/lightup/region/converter/RegionConverter.java
@@ -1,0 +1,20 @@
+package umc.lightup.region.converter;
+
+import umc.lightup.region.dto.RegionReponseDTO;
+
+import java.util.List;
+
+public class RegionConverter {
+
+    public static RegionReponseDTO.SiDoListDTO toSiDoResultDTO(List<String> sidoList) {
+        return RegionReponseDTO.SiDoListDTO.builder()
+                .sido(sidoList)
+                .build();
+    }
+
+    public static RegionReponseDTO.SiGunGuListDTO toSiGunGuResultDTO(List<String> sigunguList) {
+        return RegionReponseDTO.SiGunGuListDTO.builder()
+                .sigungu(sigunguList)
+                .build();
+    }
+}

--- a/src/main/java/umc/lightup/region/domain/Region.java
+++ b/src/main/java/umc/lightup/region/domain/Region.java
@@ -1,8 +1,10 @@
 package umc.lightup.region.domain;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import umc.lightup.common.BaseEntity;
 
+@Getter
 @Entity
 public class Region {
     @Id

--- a/src/main/java/umc/lightup/region/dto/RegionReponseDTO.java
+++ b/src/main/java/umc/lightup/region/dto/RegionReponseDTO.java
@@ -1,0 +1,27 @@
+package umc.lightup.region.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class RegionReponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SiDoListDTO {
+        List<String> sido;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SiGunGuListDTO {
+        List<String> sigungu;
+    }
+}

--- a/src/main/java/umc/lightup/region/repository/RegionRepository.java
+++ b/src/main/java/umc/lightup/region/repository/RegionRepository.java
@@ -1,0 +1,15 @@
+package umc.lightup.region.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import umc.lightup.region.domain.Region;
+
+import java.util.List;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+
+    @Query("SELECT DISTINCT r.sido FROM Region r")
+    List<String> findDistinctSido();
+
+    List<Region> findBySido(String sido);
+}

--- a/src/main/java/umc/lightup/region/service/RegionService.java
+++ b/src/main/java/umc/lightup/region/service/RegionService.java
@@ -1,0 +1,27 @@
+package umc.lightup.region.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.lightup.region.domain.Region;
+import umc.lightup.region.repository.RegionRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RegionService {
+
+    private final RegionRepository regionRepository;
+
+    public List<String> getSiDoList() {
+        return regionRepository.findDistinctSido();
+    }
+
+    public List<String> getSiGunGuList(String sido) {
+        List<Region> regionList = regionRepository.findBySido(sido);
+        return regionList.stream()
+                .map(Region::getSigungu)
+                .distinct()
+                .toList();
+    }
+}


### PR DESCRIPTION
## 💫 PR 제목
- [Region] 지역 선택 기능

---

## 🔧 작업 내용 요약
- 사용자가 첫번째 위치 드롭다운을 클릭하면 시/도 리스트가 쭉 나오고 두번째 위치 드롭다운을 클릭하면 이전 드롭다운에서 클릭한 시/도의 시/군/구 리스트가 쭉 나옵니다.
- 사용자는 첫번째, 두번째 드롭다운을 각각 클릭하여 위치를 지정할 수 있습니다.
- ex ) 서울특별시 종로구

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 

---

## 🔗 관련 이슈
-  closes #12 

---

## 📝 기타 참고 사항
- 첫번째 드롭다운은 요청 파라미터가 없어서 실행하면 바로 전국 시/도 리스트가 나오고 두번째 드롭다운은 요청 파라미터에 시/도를 String 으로 넣어주면 정상 동작합니다. 
