### PR TITLE
[Member] 팀원 프로필 페이지 상세 조회 기능

### DIFF
--- a/src/main/java/umc/lightup/api/ApiResponse.java
+++ b/src/main/java/umc/lightup/api/ApiResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import umc.lightup.api.code.BaseCode;
 import umc.lightup.api.code.status.ErrorStatus;
@@ -12,6 +13,7 @@ import umc.lightup.api.code.status.SuccessStatus;
 @Getter
 @AllArgsConstructor
 @JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+@EqualsAndHashCode
 public class ApiResponse<T> {
 
     @JsonProperty("isSuccess")

--- a/src/main/java/umc/lightup/config/SecurityConfig.java
+++ b/src/main/java/umc/lightup/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests((requests) -> requests
-                        .requestMatchers("api/members/info").authenticated()
+                        .requestMatchers("/api/v1/members/me").authenticated()
                         .anyRequest().permitAll()
                 )
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -20,7 +20,7 @@ public class MemberRestController {
 
 
     @PostMapping("/join")
-    @Operation(summary = "유저 회원가입 API",description = "유저가 회원가입하는 API입니다.")
+    @Operation(summary = "유저 비밀번호 회원가입 API",description = "유저가 비밀번호로 회원가입하는 API입니다.")
     public ApiResponse<MemberResponseDTO.JoinResultDTO> join(@RequestBody @Valid MemberRequestDTO.JoinDto request) {
         Member member = memberCommandService.joinMember(request);
         return ApiResponse.onSuccess(MemberResponseDTO.joinResultDTOBuilder()
@@ -30,7 +30,7 @@ public class MemberRestController {
     }
 
     @PostMapping("/login")
-    @Operation(summary = "유저 로그인 API",description = "유저가 로그인하는 API입니다.")
+    @Operation(summary = "유저 비밀번호 로그인 API",description = "유저가 비밀번호로 로그인하는 API입니다.")
     public ApiResponse<MemberResponseDTO.LoginResultDTO> login
             (@RequestBody @Valid MemberRequestDTO.PasswordLoginRequestDTO request) {
         return ApiResponse.onSuccess(memberCommandService.loginMember(request));
@@ -38,7 +38,7 @@ public class MemberRestController {
 
     @GetMapping("/me")
     @Operation(
-            summary = "회원 정보 조회 API",
+            summary = "내 정보 조회 API",
             description = "자신의 회원 정보를 조회하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN")}
     )
@@ -50,7 +50,7 @@ public class MemberRestController {
 
     @GetMapping("/{memberId}")
     @Operation(
-            summary = "회원 정보 조회 API",
+            summary = "회원(타인) 정보 조회 API",
             description = "타인의 회원 정보를 조회하는 API입니다." +
                     " 프로젝트에 참여했을 때 일부 데이터를 추가로 공개하는 작업은 아직 진행하지 않았습니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN")}

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -20,6 +20,7 @@ public class MemberRestController {
 
 
     @PostMapping("/join")
+    @Operation(summary = "유저 회원가입 API",description = "유저가 회원가입하는 API입니다.")
     public ApiResponse<MemberResponseDTO.JoinResultDTO> join(@RequestBody @Valid MemberRequestDTO.JoinDto request) {
         Member member = memberCommandService.joinMember(request);
         return ApiResponse.onSuccess(MemberResponseDTO.joinResultDTOBuilder()
@@ -35,15 +36,30 @@ public class MemberRestController {
         return ApiResponse.onSuccess(memberCommandService.loginMember(request));
     }
 
-    @GetMapping("/info")
+    @GetMapping("/my")
     @Operation(
             summary = "회원 정보 조회 API",
-            description = "테스트용 회원 정보를 조회하는 API입니다.",
+            description = "자신의 회원 정보를 조회하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN")}
     )
-    public ApiResponse<MemberResponseDTO.MemberInfoDTO> getMemberInfo(Authentication authentication) {
+    public ApiResponse<MemberResponseDTO.MyInfoDTO> getMyInfo(Authentication authentication) {
         String email = authentication.getName();
         Member member = memberCommandService.getMember(email);
-        return ApiResponse.onSuccess(MemberResponseDTO.toMemberInfoDTO(member));
+        return ApiResponse.onSuccess(MemberResponseDTO.toMyInfoDTO(member));
+    }
+
+    @GetMapping("/my/{id}")
+    @Operation(
+            summary = "회원 정보 조회 API",
+            description = "타인의 회원 정보를 조회하는 API입니다." +
+                    " 프로젝트에 참여했을 때 일부 데이터를 추가로 공개하는 작업은 아직 진행하지 않았습니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.MemberInfoDTO> getMemberInfo(Authentication authentication,
+                                                                  @PathVariable("id") long id) {
+        String email = null;
+        if (authentication != null)
+            email = authentication.getName();
+        return ApiResponse.onSuccess(memberCommandService.getMember(id, email));
     }
 }

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -14,7 +14,7 @@ import umc.lightup.member.service.MemberCommandService;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/members")
+@RequestMapping("/api/v1/members")
 public class MemberRestController {
     private final MemberCommandService memberCommandService;
 
@@ -36,7 +36,7 @@ public class MemberRestController {
         return ApiResponse.onSuccess(memberCommandService.loginMember(request));
     }
 
-    @GetMapping("/my")
+    @GetMapping("/me")
     @Operation(
             summary = "회원 정보 조회 API",
             description = "자신의 회원 정보를 조회하는 API입니다.",
@@ -48,7 +48,7 @@ public class MemberRestController {
         return ApiResponse.onSuccess(MemberResponseDTO.toMyInfoDTO(member));
     }
 
-    @GetMapping("/my/{id}")
+    @GetMapping("/{memberId}")
     @Operation(
             summary = "회원 정보 조회 API",
             description = "타인의 회원 정보를 조회하는 API입니다." +
@@ -56,7 +56,7 @@ public class MemberRestController {
             security = { @SecurityRequirement(name = "JWT TOKEN")}
     )
     public ApiResponse<MemberResponseDTO.MemberInfoDTO> getMemberInfo(Authentication authentication,
-                                                                  @PathVariable("id") long id) {
+                                                                  @PathVariable("memberId") long id) {
         String email = null;
         if (authentication != null)
             email = authentication.getName();

--- a/src/main/java/umc/lightup/member/domain/Credential.java
+++ b/src/main/java/umc/lightup/member/domain/Credential.java
@@ -15,7 +15,7 @@ import umc.lightup.member.enums.CredentialType;
 @AllArgsConstructor
 public class Credential extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy =  GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)

--- a/src/main/java/umc/lightup/member/domain/Member.java
+++ b/src/main/java/umc/lightup/member/domain/Member.java
@@ -1,10 +1,7 @@
 package umc.lightup.member.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.security.core.GrantedAuthority;
@@ -22,8 +19,8 @@ import java.util.List;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -68,6 +65,15 @@ public class Member extends BaseEntity implements UserDetails {
 
 //    @OneToMany(mappedBy = "member", orphanRemoval = true)
 //    private List<Credential> credentials;
+
+//    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, orphanRemoval = true)
+//    private List<MemberSkill> skills;
+//
+//    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, orphanRemoval = true)
+//    private List<MemberStrength> strengths;
+//
+//    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, orphanRemoval = true)
+//    private List<Portfolio> portfolios;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/umc/lightup/member/domain/MemberRegion.java
+++ b/src/main/java/umc/lightup/member/domain/MemberRegion.java
@@ -1,10 +1,17 @@
 package umc.lightup.member.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import umc.lightup.common.BaseEntity;
 import umc.lightup.region.domain.Region;
 
 @Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberRegion extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/lightup/member/domain/MemberSkill.java
+++ b/src/main/java/umc/lightup/member/domain/MemberSkill.java
@@ -1,10 +1,17 @@
 package umc.lightup.member.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import umc.lightup.common.BaseEntity;
 import umc.lightup.skill.domain.Skill;
 
 @Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberSkill extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/lightup/member/domain/MemberStrength.java
+++ b/src/main/java/umc/lightup/member/domain/MemberStrength.java
@@ -1,10 +1,17 @@
 package umc.lightup.member.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import umc.lightup.common.BaseEntity;
 import umc.lightup.strength.domain.Strength;
 
 @Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberStrength extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/lightup/member/domain/Portfolio.java
+++ b/src/main/java/umc/lightup/member/domain/Portfolio.java
@@ -1,9 +1,14 @@
 package umc.lightup.member.domain;
 
 import jakarta.persistence.*;
+import lombok.*;
 import umc.lightup.common.BaseEntity;
 
 @Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Portfolio extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
@@ -1,8 +1,7 @@
 package umc.lightup.member.dto;
 
 import jakarta.validation.constraints.*;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import umc.lightup.member.domain.Credential;
 import umc.lightup.member.domain.Member;
@@ -20,6 +19,9 @@ public class MemberRequestDTO {
 
     @Getter
     @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
     public static class JoinDto{
         @NotEmpty
         private String name;
@@ -72,6 +74,9 @@ public class MemberRequestDTO {
 
     @Getter
     @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
     public static class PasswordLoginRequestDTO{
         @NotBlank(message = "이메일은 필수입니다.")
         @Email(message = "올바른 이메일 형식이어야 합니다.")

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -7,6 +7,7 @@ import umc.lightup.member.enums.Role;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class MemberResponseDTO {
     @Builder
@@ -31,7 +32,7 @@ public class MemberResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class MemberInfoDTO {
+    public static class MyInfoDTO {
         private long id;
         private String name;
         private String nickname;
@@ -47,6 +48,38 @@ public class MemberResponseDTO {
         private String profileImageUrl;
     }
 
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberInfoDTO {
+        private String name;
+        private String nickname;
+        private int age;
+        private boolean gender;
+        private LocalDate birth;
+        private Role role;
+        private Mbti mbti;
+        private String career;
+        private String school;
+        private List<String> skills;
+        private List<String> strengths;
+        private List<String> regions;
+        private List<PortfolioInfoDTO> portfolios;
+        private String email;
+        private String phoneNumber;
+        private String profileImageUrl;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PortfolioInfoDTO {
+        private String name;
+        private String fileUrl;
+    }
+
     public static LoginResultDTO.LoginResultDTOBuilder loginResultDTOBuilder() {
         return LoginResultDTO.builder();
     }
@@ -55,8 +88,8 @@ public class MemberResponseDTO {
         return JoinResultDTO.builder();
     }
 
-    public static MemberInfoDTO toMemberInfoDTO(Member member) {
-        return MemberInfoDTO.builder()
+    public static MyInfoDTO toMyInfoDTO(Member member) {
+        return MyInfoDTO.builder()
                 .id(member.getId())
                 .name(member.getName())
                 .email(member.getEmail())

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -75,6 +75,7 @@ public class MemberResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @EqualsAndHashCode
     public static class PortfolioInfoDTO {
         private String name;
         private String fileUrl;

--- a/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
+++ b/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
@@ -1,0 +1,60 @@
+package umc.lightup.member.dto;
+
+import lombok.*;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.Portfolio;
+import umc.lightup.region.domain.Region;
+
+import java.util.List;
+
+/**
+ * Member의 정보와 이 정보가 어디까지 보이는지에 대한 정보.
+ * MemberInfoDTO를 만들기 위한 DTO.
+ * DTO를 위한 DTO를 따로 뺀 이유는 저 DTO를 만드는 데 너무 많은 인자가 필요해서임.
+ * Builder pattern 쓰는 이유가 인자 순서에 문제 없다는 건데 이 의미를 살리기 위함.
+ * 물론 본인도 처음 써보는 방식이라 적절한 설계인지는 생각이 필요함.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberViewInfo {
+    private Member member;
+    private List<String> skills;
+    private List<String> strengths;
+    private List<Region> regions;
+    private List<Portfolio> portfolios;
+    private boolean emailOpen = false;
+    private boolean phoneOpen = false;
+    private boolean pictureOpen = false;
+
+    public MemberResponseDTO.MemberInfoDTO toMemberInfoDTO() {
+        return MemberResponseDTO.MemberInfoDTO.builder()
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .age(member.getAge())
+                .role(member.getRole())
+                .mbti(member.getMbti())
+                .birth(member.getBirth())
+                .gender(member.getGender())
+                .school(member.getSchool())
+                .career(member.getCareer())
+
+                .skills(skills)
+                .strengths(strengths)
+                .regions(regions.stream()
+                        .map(r->r.getSido()+" "+r.getSigungu())
+                        .toList())
+                .portfolios(portfolios.stream()
+                        .map(portfolio -> MemberResponseDTO.PortfolioInfoDTO.builder()
+                                .name(portfolio.getName())
+                                .fileUrl(portfolio.getFileUrl())
+                                .build())
+                        .toList())
+
+                .email(emailOpen?member.getEmail():null)
+                .phoneNumber(phoneOpen?member.getPhoneNumber():null)
+                .profileImageUrl(pictureOpen?member.getProfileImageUrl():null)
+                .build();
+    }
+}

--- a/src/main/java/umc/lightup/member/repository/MemberRegionRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberRegionRepository.java
@@ -1,16 +1,9 @@
 package umc.lightup.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberRegion;
-import umc.lightup.region.domain.Region;
-
-import java.util.List;
 
 @Repository
 public interface MemberRegionRepository extends JpaRepository<MemberRegion, Long> {
-    @Query("select r from MemberRegion mr join mr.region r where mr.member=:member")
-    List<Region> findByMember(Member member);
 }

--- a/src/main/java/umc/lightup/member/repository/MemberRegionRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberRegionRepository.java
@@ -1,0 +1,16 @@
+package umc.lightup.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.MemberRegion;
+import umc.lightup.region.domain.Region;
+
+import java.util.List;
+
+@Repository
+public interface MemberRegionRepository extends JpaRepository<MemberRegion, Long> {
+    @Query("select r from MemberRegion mr join mr.region r where mr.member=:member")
+    List<Region> findByMember(Member member);
+}

--- a/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
@@ -1,16 +1,9 @@
 package umc.lightup.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberSkill;
-
-import java.util.List;
 
 @Repository
 public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
-    // 이게 성능은 좋지만 설계 관점에서는 SkillRepository에 있어야 하지 않을까...
-    @Query("select s.name from MemberSkill ms join ms.skill s where ms.member=:member")
-    List<String> findNameByMember(Member member);
 }

--- a/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
@@ -1,0 +1,16 @@
+package umc.lightup.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.MemberSkill;
+
+import java.util.List;
+
+@Repository
+public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
+    // 이게 성능은 좋지만 설계 관점에서는 SkillRepository에 있어야 하지 않을까...
+    @Query("select s.name from MemberSkill ms join ms.skill s where ms.member=:member")
+    List<String> findNameByMember(Member member);
+}

--- a/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
@@ -1,0 +1,15 @@
+package umc.lightup.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.MemberStrength;
+
+import java.util.List;
+
+@Repository
+public interface MemberStrengthRepository extends JpaRepository<MemberStrength, Long> {
+    @Query("select s.name from MemberStrength ms join ms.strength s where ms.member=:member")
+    List<String> findNameByMember(Member member);
+}

--- a/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
@@ -1,15 +1,9 @@
 package umc.lightup.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberStrength;
-
-import java.util.List;
 
 @Repository
 public interface MemberStrengthRepository extends JpaRepository<MemberStrength, Long> {
-    @Query("select s.name from MemberStrength ms join ms.strength s where ms.member=:member")
-    List<String> findNameByMember(Member member);
 }

--- a/src/main/java/umc/lightup/member/repository/PortfolioRepository.java
+++ b/src/main/java/umc/lightup/member/repository/PortfolioRepository.java
@@ -1,0 +1,13 @@
+package umc.lightup.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.Portfolio;
+
+import java.util.List;
+
+@Repository
+public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+    List<Portfolio> findByMember(Member member);
+}

--- a/src/main/java/umc/lightup/member/service/MemberCommandService.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandService.java
@@ -6,11 +6,9 @@ import umc.lightup.member.dto.MemberResponseDTO;
 
 public interface MemberCommandService {
     Member joinMember(MemberRequestDTO.JoinDto request);
-
     MemberResponseDTO.LoginResultDTO loginMember(MemberRequestDTO.PasswordLoginRequestDTO request);
-
     Member getMember(String email);
-
+    MemberResponseDTO.MemberInfoDTO getMember(long id, String viewerEmail);
     boolean isNicknameExist(String nickname);
     boolean isEmailExist(String email);
     boolean isPhoneNumberExist(String phoneNumber);

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -11,13 +11,16 @@ import umc.lightup.config.JwtTokenProvider;
 import umc.lightup.exception.handler.GeneralHandler;
 import umc.lightup.member.domain.Credential;
 import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.Portfolio;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
+import umc.lightup.member.dto.MemberViewInfo;
 import umc.lightup.member.enums.CredentialType;
-import umc.lightup.member.repository.CredentialRepository;
-import umc.lightup.member.repository.MemberRepository;
+import umc.lightup.member.repository.*;
+import umc.lightup.region.domain.Region;
 
 import java.util.Collections;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +28,10 @@ import java.util.Collections;
 public class MemberCommandServiceImpl implements MemberCommandService {
     private final MemberRepository memberRepository;
     private final CredentialRepository credentialRepository;
+    private final MemberSkillRepository memberSkillRepository;
+    private final MemberStrengthRepository memberStrengthRepository;
+    private final MemberRegionRepository memberRegionRepository;
+    private final PortfolioRepository portfolioRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -68,6 +75,27 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     public Member getMember(String email){
         return memberRepository.findByEmail(email)
                 .orElseThrow(()-> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    @Override
+    public MemberResponseDTO.MemberInfoDTO getMember(long id, String viewerEmail){
+        // 한 번에 반환하기 위해 DTO 반환을 사용했는데 좋은 설계 방식인지는 한번 고민할 필요가 있음
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        List<String> skills = memberSkillRepository.findNameByMember(member);
+        List<String> strengths = memberStrengthRepository.findNameByMember(member);
+        List<Region> regions = memberRegionRepository.findByMember(member);
+        List<Portfolio> portfolios = portfolioRepository.findByMember(member);
+        return MemberViewInfo.builder()
+                .member(member)
+                .skills(skills)
+                .strengths(strengths)
+                .regions(regions)
+                .portfolios(portfolios)
+                .emailOpen(false)
+                .phoneOpen(false)
+                .pictureOpen(false)
+                .build().toMemberInfoDTO();
     }
 
     @Override

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -18,6 +18,9 @@ import umc.lightup.member.dto.MemberViewInfo;
 import umc.lightup.member.enums.CredentialType;
 import umc.lightup.member.repository.*;
 import umc.lightup.region.domain.Region;
+import umc.lightup.region.repository.RegionRepository;
+import umc.lightup.skill.repository.SkillRepository;
+import umc.lightup.strength.repository.StrengthRepository;
 
 import java.util.Collections;
 import java.util.List;
@@ -28,9 +31,9 @@ import java.util.List;
 public class MemberCommandServiceImpl implements MemberCommandService {
     private final MemberRepository memberRepository;
     private final CredentialRepository credentialRepository;
-    private final MemberSkillRepository memberSkillRepository;
-    private final MemberStrengthRepository memberStrengthRepository;
-    private final MemberRegionRepository memberRegionRepository;
+    private final RegionRepository regionRepository;
+    private final SkillRepository skillRepository;
+    private final StrengthRepository strengthRepository;
     private final PortfolioRepository portfolioRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
@@ -82,9 +85,9 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         // 한 번에 반환하기 위해 DTO 반환을 사용했는데 좋은 설계 방식인지는 한번 고민할 필요가 있음
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
-        List<String> skills = memberSkillRepository.findNameByMember(member);
-        List<String> strengths = memberStrengthRepository.findNameByMember(member);
-        List<Region> regions = memberRegionRepository.findByMember(member);
+        List<String> skills = skillRepository.findNameByMember(member);
+        List<String> strengths = strengthRepository.findNameByMember(member);
+        List<Region> regions = regionRepository.findByMember(member);
         List<Portfolio> portfolios = portfolioRepository.findByMember(member);
         return MemberViewInfo.builder()
                 .member(member)

--- a/src/main/java/umc/lightup/member/validation/validator/UniqueEmailValidator.java
+++ b/src/main/java/umc/lightup/member/validation/validator/UniqueEmailValidator.java
@@ -21,6 +21,7 @@ public class UniqueEmailValidator implements ConstraintValidator<UniqueEmail, St
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return true; // null 여부는 여기서는 확인 안함
         boolean isValid = !memberCommandService.isEmailExist(value);
 
         if (!isValid) {

--- a/src/main/java/umc/lightup/member/validation/validator/UniqueNicknameValidator.java
+++ b/src/main/java/umc/lightup/member/validation/validator/UniqueNicknameValidator.java
@@ -21,7 +21,7 @@ public class UniqueNicknameValidator implements ConstraintValidator<UniqueNickna
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
-        if (value == null) return true; // nullable임
+        if (value == null) return true; // null 여부는 여기서는 확인 안함
         boolean isValid = !memberCommandService.isNicknameExist(value);
 
         if (!isValid) {

--- a/src/main/java/umc/lightup/member/validation/validator/UniquePhoneNumberValidator.java
+++ b/src/main/java/umc/lightup/member/validation/validator/UniquePhoneNumberValidator.java
@@ -21,6 +21,7 @@ public class UniquePhoneNumberValidator implements ConstraintValidator<UniquePho
 
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return true; // null 여부는 여기서는 확인 안함
         boolean isValid = !memberCommandService.isPhoneNumberExist(value);
 
         if (!isValid) {

--- a/src/main/java/umc/lightup/region/domain/Region.java
+++ b/src/main/java/umc/lightup/region/domain/Region.java
@@ -1,11 +1,13 @@
 package umc.lightup.region.domain;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import umc.lightup.common.BaseEntity;
+import lombok.*;
 
 @Getter
 @Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Region {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/lightup/region/repository/RegionRepository.java
+++ b/src/main/java/umc/lightup/region/repository/RegionRepository.java
@@ -2,6 +2,8 @@ package umc.lightup.region.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import umc.lightup.member.domain.Member;
 import umc.lightup.region.domain.Region;
 
 import java.util.List;
@@ -12,4 +14,7 @@ public interface RegionRepository extends JpaRepository<Region, Long> {
     List<String> findDistinctSido();
 
     List<Region> findBySido(String sido);
+
+    @Query("select r from MemberRegion mr join mr.region r where mr.member=:member")
+    List<Region> findByMember(@Param("member") Member member);
 }

--- a/src/main/java/umc/lightup/skill/domain/Skill.java
+++ b/src/main/java/umc/lightup/skill/domain/Skill.java
@@ -1,9 +1,14 @@
 package umc.lightup.skill.domain;
 
 import jakarta.persistence.*;
+import lombok.*;
 import umc.lightup.common.BaseEntity;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Skill extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/lightup/skill/repository/SkillRepository.java
+++ b/src/main/java/umc/lightup/skill/repository/SkillRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import umc.lightup.member.domain.Member;
 import umc.lightup.skill.domain.Skill;
 
 import java.util.List;
@@ -12,4 +13,6 @@ import java.util.List;
 public interface SkillRepository extends JpaRepository<Skill, Long> {
 //    @Query("select s.name from Skill s where s.id in :ids")
 //    List<String> findAllNameById(@Param("ids") List<Long> ids);
+    @Query("select s.name from MemberSkill ms join ms.skill s where ms.member=:member")
+    List<String> findNameByMember(@Param("member") Member member);
 }

--- a/src/main/java/umc/lightup/skill/repository/SkillRepository.java
+++ b/src/main/java/umc/lightup/skill/repository/SkillRepository.java
@@ -1,0 +1,15 @@
+package umc.lightup.skill.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import umc.lightup.skill.domain.Skill;
+
+import java.util.List;
+
+@Repository
+public interface SkillRepository extends JpaRepository<Skill, Long> {
+//    @Query("select s.name from Skill s where s.id in :ids")
+//    List<String> findAllNameById(@Param("ids") List<Long> ids);
+}

--- a/src/main/java/umc/lightup/strength/domain/Strength.java
+++ b/src/main/java/umc/lightup/strength/domain/Strength.java
@@ -1,9 +1,14 @@
 package umc.lightup.strength.domain;
 
 import jakarta.persistence.*;
+import lombok.*;
 import umc.lightup.common.BaseEntity;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Strength extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/lightup/strength/repository/StrengthRepository.java
+++ b/src/main/java/umc/lightup/strength/repository/StrengthRepository.java
@@ -1,0 +1,15 @@
+package umc.lightup.strength.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import umc.lightup.strength.domain.Strength;
+
+import java.util.List;
+
+@Repository
+public interface StrengthRepository extends JpaRepository<Strength, Long> {
+//    @Query("select s.name from Strength s where s.id in :ids")
+//    List<String> findAllNameById(@Param("ids") List<Long> ids);
+}

--- a/src/main/java/umc/lightup/strength/repository/StrengthRepository.java
+++ b/src/main/java/umc/lightup/strength/repository/StrengthRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import umc.lightup.member.domain.Member;
 import umc.lightup.strength.domain.Strength;
 
 import java.util.List;
@@ -12,4 +13,6 @@ import java.util.List;
 public interface StrengthRepository extends JpaRepository<Strength, Long> {
 //    @Query("select s.name from Strength s where s.id in :ids")
 //    List<String> findAllNameById(@Param("ids") List<Long> ids);
+    @Query("select s.name from MemberStrength ms join ms.strength s where ms.member=:member")
+    List<String> findNameByMember(@Param("member") Member member);
 }

--- a/src/test/java/umc/lightup/members/MemberTest.java
+++ b/src/test/java/umc/lightup/members/MemberTest.java
@@ -1,0 +1,586 @@
+package umc.lightup.members;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import umc.lightup.api.ApiResponse;
+import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.member.controller.MemberRestController;
+import umc.lightup.member.domain.*;
+import umc.lightup.member.dto.MemberRequestDTO;
+import umc.lightup.member.dto.MemberResponseDTO;
+import umc.lightup.member.enums.Mbti;
+import umc.lightup.member.enums.Role;
+import umc.lightup.member.repository.*;
+import umc.lightup.member.service.MemberCommandService;
+import umc.lightup.region.domain.Region;
+import umc.lightup.region.repository.RegionRepository;
+import umc.lightup.skill.domain.Skill;
+import umc.lightup.skill.repository.SkillRepository;
+import umc.lightup.strength.domain.Strength;
+import umc.lightup.strength.repository.StrengthRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class MemberTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    MemberRegionRepository memberRegionRepository;
+    @Autowired
+    MemberSkillRepository memberSkillRepository;
+    @Autowired
+    MemberStrengthRepository memberStrengthRepository;
+    @Autowired
+    PortfolioRepository portfolioRepository;
+    @Autowired
+    SkillRepository skillRepository;
+    @Autowired
+    RegionRepository regionRepository;
+    @Autowired
+    StrengthRepository strengthRepository;
+    @Autowired
+    MemberCommandService memberCommandService;
+    @Autowired
+    MemberRestController memberRestController;
+    @Autowired
+    private ObjectMapper jacksonObjectMapper;
+
+    @BeforeAll
+    void setup() {
+        Member member1 = memberCommandService.joinMember(MemberRequestDTO.JoinDto.builder()
+                .name("기본값1")
+                .nickname("닉네임1")
+                .gender(true)
+                .birth(LocalDate.of(1980, Month.AUGUST, 1))
+                .role(Role.LEADER)
+                .mbti(Mbti.ENFJ)
+                .email("someone@example.com")
+                .phoneNumber("010-5555-6666")
+                .password("password")
+                .build());
+        assertSame(1L, member1.getId());
+
+        Member member2 = memberCommandService.joinMember(MemberRequestDTO.JoinDto.builder()
+                .name("기본값2")
+                .nickname("닉네임2")
+                .gender(false)
+                .birth(LocalDate.of(2000, Month.JANUARY, 1))
+                .role(Role.TEAMMATE)
+                .mbti(Mbti.ISTP)
+                .email("someone2@example.com")
+                .phoneNumber("010-2222-2222")
+                .password("password")
+                .build());
+        assertSame(2L, member2.getId());
+
+        Skill skill1 = Skill.builder()
+                .name("스킬1")
+                .build();
+        skillRepository.save(skill1);
+        assertSame(1L, skill1.getId());
+
+        Skill skill2 = Skill.builder()
+                .name("스킬2")
+                .build();
+        skillRepository.save(skill2);
+        assertSame(2L, skill2.getId());
+
+        Skill skill3 = Skill.builder()
+                .name("스킬3")
+                .build();
+        skillRepository.save(skill3);
+        assertSame(3L, skill3.getId());
+
+        Strength strength1 = Strength.builder()
+                .name("강점1")
+                .build();
+        strengthRepository.save(strength1);
+        assertSame(1L, strength1.getId());
+
+        Strength strength2 = Strength.builder()
+                .name("강점2")
+                .build();
+        strengthRepository.save(strength2);
+        assertSame(2L, strength2.getId());
+
+        Strength strength3 = Strength.builder()
+                .name("강점3")
+                .build();
+        strengthRepository.save(strength3);
+        assertSame(3L, strength3.getId());
+
+        //지역 데이터가 아직 없으므로 이것도 넣어 주어야 함
+        //Region에 Builder 넣기 싫은데...
+
+        Region region1 = Region.builder()
+                .sido("시도1")
+                .sigungu("시군구1")
+                .build();
+        regionRepository.save(region1);
+        assertSame(1L, region1.getId());
+
+        Region region2 = Region.builder()
+                .sido("시도2")
+                .sigungu("시군구2")
+                .build();
+        regionRepository.save(region2);
+        assertSame(2L, region2.getId());
+
+        Region region3 = Region.builder()
+                .sido("시도3")
+                .sigungu("시군구3")
+                .build();
+        regionRepository.save(region3);
+        assertSame(3L, region3.getId());
+    }
+
+    /**
+     * 닉네임 중복 회원가입 테스트에서 응답을 받기 위한 임시 클래스
+     */
+    static class NicknameCheck {
+        private String nickname;
+
+        public String getNickname() {
+            return nickname;
+        }
+
+        public void setNickname(String nickname) {
+            this.nickname = nickname;
+        }
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 회원가입 테스트")
+    void joinDuplicateNicknameTest() throws Exception {
+        //Given
+        MemberRequestDTO.JoinDto joinDto = MemberRequestDTO.JoinDto.builder()
+                .name("이름2")
+                .nickname("닉네임2")
+                .gender(true)
+                .birth(LocalDate.of(2006, Month.DECEMBER, 31))
+                .role(Role.LEADER)
+                .mbti(Mbti.INTJ)
+                .email("someone5@example.com")
+                .phoneNumber("02-000-5555")
+                .password("password")
+                .build();
+
+        //When
+        String content = mockMvc.perform(post("/api/v1/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(joinDto)))
+
+        //Then (따지자면 여기서부터가 Then이 맞긴 함)
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        System.out.println(content);
+
+
+        ApiResponse<NicknameCheck> response =
+                jacksonObjectMapper.readValue(content,
+                        new TypeReference<ApiResponse<NicknameCheck>>(){});
+        assertEquals(ErrorStatus.DUPLICATE_NICKNAME.toString(), response.getResult().getNickname());
+    }
+
+
+    /**
+     * 휴대전화 형식 외 회원가입 테스트에서 응답을 받기 위한 임시 클래스
+     */
+    static class PhoneCheck {
+        private String phoneNumber;
+
+        public String getPhoneNumber() {
+            return phoneNumber;
+        }
+
+        public void setPhoneNumber(String phoneNumber) {
+            this.phoneNumber = phoneNumber;
+        }
+    }
+
+    @Test
+    @DisplayName("휴대전화 형식 외 회원가입 테스트")
+    void joinPhonePatternTest() throws Exception {
+
+        //Given
+        MemberRequestDTO.JoinDto joinDto = MemberRequestDTO.JoinDto.builder()
+                .name("이름2")
+                .nickname("닉네임4")
+                .gender(true)
+                .birth(LocalDate.of(2006, Month.DECEMBER, 31))
+                .role(Role.LEADER)
+                .mbti(Mbti.INTJ)
+                .email("someone5@example.com")
+                .phoneNumber("jewnhfdwnshed")
+                .password("password")
+                .build();
+
+        //When
+        String content = mockMvc.perform(post("/api/v1/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(joinDto)))
+
+        //Then
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        System.out.println(content);
+
+        ApiResponse<PhoneCheck> response =
+                jacksonObjectMapper.readValue(content,
+                        new TypeReference<ApiResponse<PhoneCheck>>(){});
+        assertNotNull(response.getResult().getPhoneNumber());
+    }
+
+    /**
+     * 4개 테스트 때려박았는데, 원래 이게 좋은 방식은 아닌 걸로 알고 있음
+     */
+    @Test
+    @DisplayName("전체적인 API 테스트")
+    void joinLoginMyInfoAndEmptyMemberInfo() throws Exception {
+
+        //Given
+        String email3 = "someone3@example.com";
+        String password3 = "password";
+        String name3 = "이름3";
+        String nickname3 = "닉네임3";
+        LocalDate birth3 = LocalDate.of(2006, Month.DECEMBER, 31);
+        Role role3 = Role.LEADER;
+        Mbti mbti3 = Mbti.INTJ;
+        String phoneNumber3 = "02-000-0000";
+        boolean gender3 = true;
+        MemberRequestDTO.JoinDto joinDto = MemberRequestDTO.JoinDto.builder()
+                .name(name3)
+                .nickname(nickname3)
+                .gender(gender3)
+                .birth(birth3)
+                .role(role3)
+                .mbti(mbti3)
+                .email(email3)
+                .phoneNumber(phoneNumber3)
+                .password(password3)
+                .build();
+
+        //When
+        LocalDateTime before = LocalDateTime.now();
+        String joinResult = mockMvc.perform(post("/api/v1/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(joinDto)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        LocalDateTime after = LocalDateTime.now();
+        ApiResponse<MemberResponseDTO.JoinResultDTO> joinResponse =
+                jacksonObjectMapper.readValue(joinResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.JoinResultDTO>>(){});
+
+        //Then
+        assertEquals(3L, joinResponse.getResult().getMemberId());
+        assertTrue(before.isBefore(joinResponse.getResult().getCreatedAt()) ||
+                before.isEqual(joinResponse.getResult().getCreatedAt()));
+        assertTrue(after.isAfter(joinResponse.getResult().getCreatedAt()) ||
+                after.isEqual(joinResponse.getResult().getCreatedAt()));
+
+        //When
+        String loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email(email3)
+                                .password(password3)
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse =
+                jacksonObjectMapper.readValue(loginResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>(){});
+
+        //Then
+        assertEquals(3L, loginResponse.getResult().getMemberId());
+
+
+        String accessToken = loginResponse.getResult().getAccessToken();
+
+        //When
+        String myInfoResult = mockMvc.perform(get("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.MyInfoDTO> myInfoResponse =
+                jacksonObjectMapper.readValue(myInfoResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.MyInfoDTO>>(){});
+
+        //Then
+        int age3 = (int) birth3.until(before, ChronoUnit.YEARS);
+        assertAll("MyInfo check",
+                () -> assertEquals(3L, myInfoResponse.getResult().getId()),
+                () -> assertEquals(name3, myInfoResponse.getResult().getName()),
+                () -> assertEquals(nickname3, myInfoResponse.getResult().getNickname()),
+                () -> assertEquals(gender3, myInfoResponse.getResult().isGender()),
+                () -> assertEquals(age3, myInfoResponse.getResult().getAge()),
+                () -> assertEquals(birth3, myInfoResponse.getResult().getBirth()),
+                () -> assertEquals(role3, myInfoResponse.getResult().getRole()),
+                () -> assertEquals(mbti3, myInfoResponse.getResult().getMbti()),
+                () -> assertEquals(email3, myInfoResponse.getResult().getEmail()),
+                () -> assertEquals(phoneNumber3, myInfoResponse.getResult().getPhoneNumber()),
+                () -> assertNull(myInfoResponse.getResult().getSchool()),
+                () -> assertNull(myInfoResponse.getResult().getCareer()),
+                () -> assertNull(myInfoResponse.getResult().getProfileImageUrl())
+        );
+
+        //When
+        String content = mockMvc.perform(get("/api/v1/members/3"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.MemberInfoDTO> response =
+                jacksonObjectMapper.readValue(content,
+                        new TypeReference<ApiResponse<MemberResponseDTO.MemberInfoDTO>>(){});
+
+        //Then
+        MemberResponseDTO.MemberInfoDTO result = response.getResult();
+        assertAll("member information by id approach",
+                () -> assertEquals(name3, result.getName()),
+                () -> assertEquals(nickname3, result.getNickname()),
+                () -> assertEquals(age3, result.getAge()),
+                () -> assertEquals(gender3, result.isGender()),
+                () -> assertEquals(role3, result.getRole()),
+                () -> assertEquals(mbti3, result.getMbti()),
+                () -> assertNull(result.getCareer()),
+                () -> assertNull(result.getSchool()),
+                () -> assertIterableEquals(List.of(), result.getSkills()),
+                () -> assertIterableEquals(List.of(), result.getStrengths()),
+                () -> assertIterableEquals(List.of(), result.getRegions()),
+                () -> assertIterableEquals(List.of(), result.getPortfolios()),
+                () -> assertNull(result.getEmail()),
+                () -> assertNull(result.getPhoneNumber()),
+                () -> assertNull(result.getProfileImageUrl())
+        );
+    }
+
+    @Test
+    @DisplayName("회원 ID로 조회 테스트 1")
+    void memberInfoWithMemberIdTest1() throws Exception {
+        //Given
+        Member member = memberRepository.findById(1L).get();
+        List<Long> skillSet = List.of(1L, 2L);
+        List<Long> strengthSet = List.of(1L, 3L);
+        List<Long> regionSet = List.of(2L, 3L);
+        List<Portfolio> portfolioSet = List.of(
+                Portfolio.builder()
+                        .member(member)
+                        .name("포트폴리오1")
+                        .fileUrl("url1")
+                        .build(),
+                Portfolio.builder()
+                        .member(member)
+                        .name("포트폴리오2")
+                        .fileUrl("url2")
+                        .build());
+
+        skillSet.forEach(skillId->memberSkillRepository.save(MemberSkill.builder()
+                .member(member)
+                .skill(skillRepository.findById(skillId).get())
+                .build()));
+        strengthSet.forEach(strengthId->memberStrengthRepository.save(MemberStrength.builder()
+                .member(member)
+                .strength(strengthRepository.findById(strengthId).get())
+                .build()));
+        regionSet.forEach(regionId->memberRegionRepository.save(MemberRegion.builder()
+                .member(member)
+                .region(regionRepository.findById(regionId).get())
+                .build()));
+        portfolioRepository.saveAll(portfolioSet);
+
+        //When
+        String content = mockMvc.perform(get("/api/v1/members/1"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.MemberInfoDTO> response =
+                jacksonObjectMapper.readValue(content,
+                        new TypeReference<ApiResponse<MemberResponseDTO.MemberInfoDTO>>(){});
+
+        //Then
+        MemberResponseDTO.MemberInfoDTO result = response.getResult();
+        assertAll("basic member information",
+                ()->assertEquals(member.getName(), result.getName()),
+                ()->assertEquals(member.getNickname(), result.getNickname()),
+                ()->assertEquals(member.getAge(), result.getAge()),
+                ()->assertEquals(member.getGender(), result.isGender()),
+                ()->assertEquals(member.getRole(), result.getRole()),
+                ()->assertEquals(member.getMbti(), result.getMbti()),
+                ()->assertEquals(member.getCareer(), result.getCareer()),
+                ()->assertEquals(member.getSchool(), result.getSchool())
+        );
+
+        assertIterableEquals(
+                skillSet.stream().map(skillId->skillRepository.findById(skillId).get().getName()).toList(),
+                result.getSkills(),
+                "skills information"); //순서도 같도록 의도한 것
+
+        assertIterableEquals(
+                strengthSet.stream().map(strengthId->strengthRepository.findById(strengthId).get().getName()).toList(),
+                result.getStrengths(),
+                "strengths information"); //순서도 같도록 의도한 것
+
+        assertIterableEquals(
+                regionSet.stream().map(regionId-> {
+                    Region region = regionRepository.findById(regionId).get();
+                    return region.getSido() + " " + region.getSigungu();
+                }).toList(),
+                result.getRegions(),
+                "region information"); //순서도 같도록 의도한 것
+
+        assertIterableEquals(
+                portfolioSet.stream().map(portfolio -> MemberResponseDTO.PortfolioInfoDTO.builder()
+                        .name(portfolio.getName())
+                        .fileUrl(portfolio.getFileUrl())
+                        .build()).toList(),
+                result.getPortfolios(),
+                "portfolio information"); //순서도 같도록 의도한 것
+
+//        assertIterableEquals(
+//                portfolioSet.stream().map(Portfolio::getName).toList(),
+//                response.getResult().getPortfolios().stream().map(MemberResponseDTO.PortfolioInfoDTO::getName).toList(),
+//                "portfolio information"); //순서도 같도록 의도한 것
+//        assertIterableEquals(
+//                portfolioSet.stream().map(Portfolio::getFileUrl).toList(),
+//                response.getResult().getPortfolios().stream().map(MemberResponseDTO.PortfolioInfoDTO::getFileUrl).toList(),
+//                "portfolio information"); //순서도 같도록 의도한 것
+
+        assertAll("hidden information",
+                ()->assertNull(result.getEmail()),
+                ()->assertNull(result.getPhoneNumber()),
+                ()->assertNull(result.getProfileImageUrl())
+        );
+    }
+
+    @Test
+    @DisplayName("회원 ID로 조회 테스트 2")
+    void memberInfoWithMemberIdTest2() throws Exception {
+        //Given
+        Member member = memberRepository.findById(2L).get();
+        List<Long> skillSet = List.of(2L, 3L);
+        List<Long> strengthSet = List.of(2L);
+        List<Long> regionSet = List.of(1L);
+        List<Portfolio> portfolioSet = List.of(
+                Portfolio.builder()
+                        .member(member)
+                        .name("포트폴리오2-1")
+                        .fileUrl("url2-1")
+                        .build());
+
+        skillSet.forEach(skillId->memberSkillRepository.save(MemberSkill.builder()
+                .member(member)
+                .skill(skillRepository.findById(skillId).get())
+                .build()));
+        strengthSet.forEach(strengthId->memberStrengthRepository.save(MemberStrength.builder()
+                .member(member)
+                .strength(strengthRepository.findById(strengthId).get())
+                .build()));
+        regionSet.forEach(regionId->memberRegionRepository.save(MemberRegion.builder()
+                .member(member)
+                .region(regionRepository.findById(regionId).get())
+                .build()));
+        portfolioRepository.saveAll(portfolioSet);
+
+        //When
+        String content = mockMvc.perform(get("/api/v1/members/2"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.MemberInfoDTO> response =
+                jacksonObjectMapper.readValue(content,
+                        new TypeReference<ApiResponse<MemberResponseDTO.MemberInfoDTO>>(){});
+
+        //Then
+        MemberResponseDTO.MemberInfoDTO result = response.getResult();
+        assertAll("basic member information",
+                ()->assertEquals(member.getName(), result.getName()),
+                ()->assertEquals(member.getNickname(), result.getNickname()),
+                ()->assertEquals(member.getAge(), result.getAge()),
+                ()->assertEquals(member.getGender(), result.isGender()),
+                ()->assertEquals(member.getRole(), result.getRole()),
+                ()->assertEquals(member.getMbti(), result.getMbti()),
+                ()->assertEquals(member.getCareer(), result.getCareer()),
+                ()->assertEquals(member.getSchool(), result.getSchool())
+        );
+
+        assertIterableEquals(
+                skillSet.stream().map(skillId->skillRepository.findById(skillId).get().getName()).toList(),
+                result.getSkills(),
+                "skills information"); //순서도 같도록 의도한 것
+
+        assertIterableEquals(
+                strengthSet.stream().map(strengthId->strengthRepository.findById(strengthId).get().getName()).toList(),
+                result.getStrengths(),
+                "strengths information"); //순서도 같도록 의도한 것
+
+        assertIterableEquals(
+                regionSet.stream().map(regionId-> {
+                    Region region = regionRepository.findById(regionId).get();
+                    return region.getSido() + " " + region.getSigungu();
+                }).toList(),
+                result.getRegions(),
+                "region information"); //순서도 같도록 의도한 것
+
+        assertIterableEquals(
+                portfolioSet.stream().map(portfolio -> MemberResponseDTO.PortfolioInfoDTO.builder()
+                        .name(portfolio.getName())
+                        .fileUrl(portfolio.getFileUrl())
+                        .build()).toList(),
+                result.getPortfolios(),
+                "portfolio information"); //순서도 같도록 의도한 것
+
+//        assertIterableEquals(
+//                portfolioSet.stream().map(Portfolio::getName).toList(),
+//                response.getResult().getPortfolios().stream().map(MemberResponseDTO.PortfolioInfoDTO::getName).toList(),
+//                "portfolio information"); //순서도 같도록 의도한 것
+//        assertIterableEquals(
+//                portfolioSet.stream().map(Portfolio::getFileUrl).toList(),
+//                response.getResult().getPortfolios().stream().map(MemberResponseDTO.PortfolioInfoDTO::getFileUrl).toList(),
+//                "portfolio information"); //순서도 같도록 의도한 것
+
+        assertAll("hidden information",
+                ()->assertNull(result.getEmail()),
+                ()->assertNull(result.getPhoneNumber()),
+                ()->assertNull(result.getProfileImageUrl())
+        );
+    }
+
+//    @Test
+//    void myPageApi_ShouldReturnUserInfo_WhenValidJwt() throws Exception {
+//        Authentication authentication = new UsernamePasswordAuthenticationToken(
+//                "user@example.com",
+//                null,
+//                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+//        );
+//
+//        String token = jwtTokenProvider.generateToken(authentication);
+//
+//        mockMvc.perform(get("/api/mypage")
+//                        .header("Authorization", "Bearer " + token))
+//                .andExpect(status().isOk())
+//                .andExpect((ResultMatcher) jsonPath("$.email").value("user@example.com"));
+//    }
+}


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 팀원 프로필 페이지 상세 조회 기능

---

## 🔧 작업 내용 요약
- 사용자의 ID(PK)로 해당 사용자의 정보와 스킬, 강점, 지역, 포트폴리오 제공
- 테스트를 위해 strength나 skills의 repository 제작
- 이외에 설명 없던 API 설명 추가 등 진행


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 테스트 코드
- Repository의 내용이 적절한지

---

## 🔗 관련 이슈
- closes #14 

---

## 📝 기타 참고 사항
- 프로젝트 구현이 아직 안 되어 팀원 여부를 확인할 수 없으므로 연락처나 사진은 모든 상황에서 가리도록 진행