### PR TITLE
[Alarm] 알림목록 조회 api 구현

### DIFF
--- a/src/main/java/umc/lightup/notification/controller/NotificationRestController.java
+++ b/src/main/java/umc/lightup/notification/controller/NotificationRestController.java
@@ -2,11 +2,15 @@ package umc.lightup.notification.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import umc.lightup.api.ApiResponse;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.service.MemberCommandService;
 import umc.lightup.notification.converter.NotificationConverter;
 import umc.lightup.notification.domain.Notification;
 import umc.lightup.notification.dto.NotificationResponseDTO;
@@ -18,14 +22,20 @@ import umc.lightup.notification.service.NotificationQueryService;
 public class NotificationRestController {
 
   private final NotificationQueryService notificationQueryService;
+  private final MemberCommandService memberCommandService;
 
   @GetMapping("")
-  @Operation(summary = "알림 목록 불러오기 API", description = "수신 받은 알림 조회를 위한 API 이며, 페이징을 포함합니다. query String으로 page 번호와 size 크기 값을 주세요")
+  @Operation(
+          summary = "알림 목록 불러오기 API",
+          description = "수신 받은 알림 조회를 위한 API 이며, 페이징을 포함합니다. query String으로 page 번호와 size 크기 값을 주세요",
+          security = { @SecurityRequirement(name = "JWT TOKEN")}
+  )
   @ApiResponses({
           @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
   })
-  public ApiResponse<NotificationResponseDTO.NotificationListDTO> getNotificationList(@Valid @RequestParam(name= "userId") Long userId, @RequestParam(name = "page") Integer page, @RequestParam(name = "size") Integer size){
-    Page<Notification> notificationList = notificationQueryService.getNotificationList(userId, page, size);
+  public ApiResponse<NotificationResponseDTO.NotificationListDTO> getNotificationList(Authentication authentication, @Valid @RequestParam(name = "page") Integer page, @RequestParam(name = "size") Integer size){
+    Member member = memberCommandService.getMember(authentication.getName());
+    Page<Notification> notificationList = notificationQueryService.getNotificationList(member.getId(), page, size);
     return ApiResponse.onSuccess(NotificationConverter.notificationListDTO(notificationList));
   }
 }

--- a/src/main/java/umc/lightup/notification/controller/NotificationRestController.java
+++ b/src/main/java/umc/lightup/notification/controller/NotificationRestController.java
@@ -1,0 +1,31 @@
+package umc.lightup.notification.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
+import umc.lightup.api.ApiResponse;
+import umc.lightup.notification.converter.NotificationConverter;
+import umc.lightup.notification.domain.Notification;
+import umc.lightup.notification.dto.NotificationResponseDTO;
+import umc.lightup.notification.service.NotificationQueryService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notification")
+public class NotificationRestController {
+
+  private final NotificationQueryService notificationQueryService;
+
+  @GetMapping("")
+  @Operation(summary = "알림 목록 불러오기 API", description = "수신 받은 알림 조회를 위한 API 이며, 페이징을 포함합니다. query String으로 page 번호와 size 크기 값을 주세요")
+  @ApiResponses({
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+  })
+  public ApiResponse<NotificationResponseDTO.NotificationListDTO> getNotificationList(@Valid @RequestParam(name= "userId") Long userId, @RequestParam(name = "page") Integer page, @RequestParam(name = "size") Integer size){
+    Page<Notification> notificationList = notificationQueryService.getNotificationList(userId, page, size);
+    return ApiResponse.onSuccess(NotificationConverter.notificationListDTO(notificationList));
+  }
+}

--- a/src/main/java/umc/lightup/notification/controller/NotificationRestController.java
+++ b/src/main/java/umc/lightup/notification/controller/NotificationRestController.java
@@ -4,6 +4,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.Authentication;
@@ -33,9 +36,9 @@ public class NotificationRestController {
   @ApiResponses({
           @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
   })
-  public ApiResponse<NotificationResponseDTO.NotificationListDTO> getNotificationList(Authentication authentication, @Valid @RequestParam(name = "page") Integer page, @RequestParam(name = "size") Integer size){
+  public ApiResponse<NotificationResponseDTO.NotificationListDTO> getNotificationList(Authentication authentication, @NotNull @Min(0) @RequestParam(name = "page") Integer page, @RequestParam(name = "size") Integer size){
     Member member = memberCommandService.getMember(authentication.getName());
-    Page<Notification> notificationList = notificationQueryService.getNotificationList(member.getId(), page, size);
+    Page<Notification> notificationList = notificationQueryService.getNotificationList(member, page, size);
     return ApiResponse.onSuccess(NotificationConverter.notificationListDTO(notificationList));
   }
 }

--- a/src/main/java/umc/lightup/notification/controller/NotificationRestController.java
+++ b/src/main/java/umc/lightup/notification/controller/NotificationRestController.java
@@ -36,7 +36,7 @@ public class NotificationRestController {
   @ApiResponses({
           @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
   })
-  public ApiResponse<NotificationResponseDTO.NotificationListDTO> getNotificationList(Authentication authentication, @NotNull @Min(0) @RequestParam(name = "page") Integer page, @RequestParam(name = "size") Integer size){
+  public ApiResponse<NotificationResponseDTO.NotificationListDTO> getNotificationList(Authentication authentication, @NotNull @Min(0) @RequestParam(name = "page") Integer page, @Min(1) @RequestParam(name = "size", required = false, defaultValue = "10") Integer size){
     Member member = memberCommandService.getMember(authentication.getName());
     Page<Notification> notificationList = notificationQueryService.getNotificationList(member, page, size);
     return ApiResponse.onSuccess(NotificationConverter.notificationListDTO(notificationList));

--- a/src/main/java/umc/lightup/notification/converter/NotificationConverter.java
+++ b/src/main/java/umc/lightup/notification/converter/NotificationConverter.java
@@ -1,0 +1,34 @@
+package umc.lightup.notification.converter;
+
+import org.springframework.data.domain.Page;
+import umc.lightup.notification.domain.Notification;
+import umc.lightup.notification.dto.NotificationResponseDTO;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class NotificationConverter {
+
+  public static NotificationResponseDTO.NotificationDTO notificationDTO(Notification notification){
+    return NotificationResponseDTO.NotificationDTO.builder()
+            .notificationId(notification.getId())
+            .message(notification.getMessage())
+            .notificationType(String.valueOf(notification.getType()))
+            .isRead(notification.getIsRead())
+            .build();
+  }
+
+  public static NotificationResponseDTO.NotificationListDTO notificationListDTO(Page<Notification> notificationList){
+    List<NotificationResponseDTO.NotificationDTO> notificationListDTO = notificationList.stream()
+            .map(NotificationConverter::notificationDTO).collect(Collectors.toList());
+    return NotificationResponseDTO.NotificationListDTO.builder()
+            .isLast(notificationList.isLast())
+            .isFirst(notificationList.isFirst())
+            .totalPage(notificationList.getTotalPages())
+            .totalElements(notificationList.getTotalElements())
+            .listSize(notificationListDTO.size())
+            .notificationList(notificationListDTO)
+            .build();
+  }
+}

--- a/src/main/java/umc/lightup/notification/domain/Notification.java
+++ b/src/main/java/umc/lightup/notification/domain/Notification.java
@@ -1,11 +1,13 @@
 package umc.lightup.notification.domain;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import umc.lightup.common.BaseEntity;
 import umc.lightup.notification.enums.NotificationType;
 import umc.lightup.notification.enums.ReferenceType;
 import umc.lightup.member.domain.Member;
 
+@Getter
 @Entity
 public class Notification extends BaseEntity {
     @Id

--- a/src/main/java/umc/lightup/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/umc/lightup/notification/dto/NotificationResponseDTO.java
@@ -1,0 +1,34 @@
+package umc.lightup.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class NotificationResponseDTO {
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class NotificationListDTO {
+    List<NotificationDTO> notificationList;
+    Integer listSize;
+    Integer totalPage;
+    Long totalElements;
+    Boolean isFirst;
+    Boolean isLast;
+  }
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class NotificationDTO {
+    Long notificationId;  // 알림 Id
+    String message;       // 알림 메시지 내용
+    String notificationType;  // 알림 종류
+    Boolean isRead;           // 알림 읽음 여부
+  }
+}

--- a/src/main/java/umc/lightup/notification/repository/NotificationRepostiory.java
+++ b/src/main/java/umc/lightup/notification/repository/NotificationRepostiory.java
@@ -1,0 +1,11 @@
+package umc.lightup.notification.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.lightup.member.domain.Member;
+import umc.lightup.notification.domain.Notification;
+
+public interface NotificationRepostiory extends JpaRepository<Notification, Long> {
+  Page<Notification> findAllByReceiver(Member member, PageRequest pageRequest);
+}

--- a/src/main/java/umc/lightup/notification/service/NotificationQueryService.java
+++ b/src/main/java/umc/lightup/notification/service/NotificationQueryService.java
@@ -1,0 +1,8 @@
+package umc.lightup.notification.service;
+
+import org.springframework.data.domain.Page;
+import umc.lightup.notification.domain.Notification;
+
+public interface NotificationQueryService {
+  Page<Notification> getNotificationList(Long userId, Integer page, Integer size);
+}

--- a/src/main/java/umc/lightup/notification/service/NotificationQueryService.java
+++ b/src/main/java/umc/lightup/notification/service/NotificationQueryService.java
@@ -1,8 +1,9 @@
 package umc.lightup.notification.service;
 
 import org.springframework.data.domain.Page;
+import umc.lightup.member.domain.Member;
 import umc.lightup.notification.domain.Notification;
 
 public interface NotificationQueryService {
-  Page<Notification> getNotificationList(Long userId, Integer page, Integer size);
+  Page<Notification> getNotificationList(Member member, Integer page, Integer size);
 }

--- a/src/main/java/umc/lightup/notification/service/NotificationQueryServiceImpl.java
+++ b/src/main/java/umc/lightup/notification/service/NotificationQueryServiceImpl.java
@@ -18,8 +18,7 @@ public class NotificationQueryServiceImpl implements NotificationQueryService {
   private final NotificationRepostiory notificationRepostiory;
 
   @Override
-  public Page<Notification> getNotificationList(Long userId, Integer page, Integer size) {
-    Member member = memberRepository.findById(userId).get();
+  public Page<Notification> getNotificationList(Member member, Integer page, Integer size) {
     Page<Notification> NotificationPage = notificationRepostiory.findAllByReceiver(member, PageRequest.of(page, size));
     return NotificationPage;
   }

--- a/src/main/java/umc/lightup/notification/service/NotificationQueryServiceImpl.java
+++ b/src/main/java/umc/lightup/notification/service/NotificationQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package umc.lightup.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.crossstore.ChangeSetPersister;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.repository.MemberRepository;
+import umc.lightup.notification.domain.Notification;
+import umc.lightup.notification.repository.NotificationRepostiory;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationQueryServiceImpl implements NotificationQueryService {
+
+  private final MemberRepository memberRepository;
+  private final NotificationRepostiory notificationRepostiory;
+
+  @Override
+  public Page<Notification> getNotificationList(Long userId, Integer page, Integer size) {
+    Member member = memberRepository.findById(userId).get();
+    Page<Notification> NotificationPage = notificationRepostiory.findAllByReceiver(member, PageRequest.of(page, size));
+    return NotificationPage;
+  }
+}


### PR DESCRIPTION
## 💫 PR 제목
- [도메인명] 간단한 요약 (예: [Post] 게시글 작성 기능 구현)
[Alarm] 알림목록 조회 api 구현
---

## 🔧 작업 내용 요약
- 어떤 기능을 구현했는지, 어떤 이슈를 해결했는지 간단히 작성해주세요.
page 번호와 Size를 보내면, 자신에게 전달된 알림 목록을 불러올 수 있도록 api 작업을 진행했습니다. 
umc 워크북 기준으로, 커서기반이 아닌 페이지네이션 기반으로 작업했고 Authentication 인자 사용해서, 로그인한 사용자의 알림을 받아오도록 구현했습니다. 

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요.
- 예: 로직이 복잡한 부분 / 설계 고민한 부분 / 리팩토링한 코드 등
- 현재 화면 설계가 완성되지 않아서 바뀔수 있는 점이 있고
- 좋아요 누를때, 프로젝트 제안보냈을때 의 경우 알림을 보낼것으로 예상하는데 이는 다른분이 작업하다보니, 어떻게 구현해야 하나의 코드로 다른 분들도 쉽게 알림 디비에 저장할 수 있을지 고민중에 있습니다!

---

## 🔗 관련 이슈
- 관련된 이슈 번호나 기능 이름을 작성해주세요.
- ex) closes #12
- 현재 sse 기능도 같이 구현하도록 이슈를 파놔아서 sse 구현이 닫겠습니다. 

---

## 📝 기타 참고 사항
- 참고 자료, 테스트 방법 등 필요 시 자유롭게 작성
