### PR TITLE
[Member] 회원 정보 수정 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/SuccessStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/SuccessStatus.java
@@ -10,7 +10,8 @@ import umc.lightup.api.code.ReasonDTO;
 @AllArgsConstructor
 public enum SuccessStatus implements BaseCode {
 
-    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+    _NO_CONTENT(HttpStatus.NO_CONTENT, "COMMON204", "성공입니다. 반환할 데이터가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/lightup/config/SecurityConfig.java
+++ b/src/main/java/umc/lightup/config/SecurityConfig.java
@@ -26,7 +26,9 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests((requests) -> requests
-                        .requestMatchers("/api/v1/members/me").authenticated()
+                        .requestMatchers("/api/v1/members/me",
+                                "/api/v1/members/password/change")
+                        .authenticated()
                         .anyRequest().permitAll()
                 )
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -91,4 +91,18 @@ public class MemberRestController {
                 .deletePositionName(positionName)
                 .build());
     }
+
+    @PutMapping("/me")
+    @Operation(
+            summary = "회원 정보 변경 API",
+            description = "회원 정보를 변경하는 API입니다. 이메일도 변경이 가능하나 인증과 관련된 사항이기에 반드시 logout을 시행해 주셔야 합니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.MyInfoDTO> changeMemberInfo(Authentication authentication,
+                                                                         @RequestBody @Valid MemberRequestDTO.ChangeDto request) {
+        //반환값을 설정하는 게 맞나? 201 No Content를 반환하는 것도 괜찮았을 것 같은데... 특히 이메일 변경되면 로그아웃이 필수가 되어 버렸기 때문에...
+        //반환값은 단순 디버그용 그 이상이 아니게 될 수도 있음(정작 Test 코드에선 return 값을 아주 잘 활용 중)
+        String email = authentication.getName();
+        return ApiResponse.onSuccess(MemberResponseDTO.toMyInfoDTO(memberCommandService.putMember(email, request)));
+    }
 }

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -3,6 +3,8 @@ package umc.lightup.member.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -122,5 +124,17 @@ public class MemberRestController {
         Credential credential = credentialQueryService.updatePasswordByEmail(email, request);
         //나중에 이거 어차피 converter 형식으로 바꿔야 함, 아직 converter 클래스가 없는 버전이라 일단은 이렇게 둠(물론 이렇게 두는 방식이 좋은 방식은 아니지만 귀찮아서...)
         return ApiResponse.onSuccess(new MemberResponseDTO.PasswordChangeResultDTO(credential.getMember().getId(), credential.getUpdatedAt()));
+    }
+
+    @PostMapping("/email/exist")
+    @Operation(
+            summary = "이메일 존재 여부 확인 API",
+            description = "이메일 존재 여부를 확인하는 API입니다. 회원가입 시 중복 여부나 로그인 시 메일 존재 여부 확인 등의 용도로 사용할 수 있습니다."
+    )
+    public ApiResponse<MemberResponseDTO.EmailExistResultDTO> emailExist(@RequestParam @NotBlank @Email String email) {
+        //항상 DTO 쓰다 여기에만 RequestParam 쓰니 이상하긴 하네...
+        //아 그냥 ApiResponse<Boolean> 반환해버리고 싶다
+        boolean emailExist = memberCommandService.isEmailExist(email);
+        return ApiResponse.onSuccess(new MemberResponseDTO.EmailExistResultDTO(emailExist));
     }
 }

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -7,9 +7,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import umc.lightup.api.ApiResponse;
+import umc.lightup.member.domain.Credential;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
+import umc.lightup.member.service.CredentialQueryService;
 import umc.lightup.member.service.MemberCommandService;
 
 import static umc.lightup.member.dto.MemberResponseDTO.memberPositionDeleteResultDTOBuilder;
@@ -20,6 +22,7 @@ import static umc.lightup.member.dto.MemberResponseDTO.memberPositionResultDTOBu
 @RequestMapping("/api/v1/members")
 public class MemberRestController {
     private final MemberCommandService memberCommandService;
+    private final CredentialQueryService credentialQueryService;
 
 
     @PostMapping("/join")
@@ -99,10 +102,25 @@ public class MemberRestController {
             security = { @SecurityRequirement(name = "JWT TOKEN")}
     )
     public ApiResponse<MemberResponseDTO.MyInfoDTO> changeMemberInfo(Authentication authentication,
-                                                                         @RequestBody @Valid MemberRequestDTO.ChangeDto request) {
+                                                                     @RequestBody @Valid MemberRequestDTO.ChangeDto request) {
         //반환값을 설정하는 게 맞나? 201 No Content를 반환하는 것도 괜찮았을 것 같은데... 특히 이메일 변경되면 로그아웃이 필수가 되어 버렸기 때문에...
         //반환값은 단순 디버그용 그 이상이 아니게 될 수도 있음(정작 Test 코드에선 return 값을 아주 잘 활용 중)
         String email = authentication.getName();
         return ApiResponse.onSuccess(MemberResponseDTO.toMyInfoDTO(memberCommandService.putMember(email, request)));
+    }
+
+    @PostMapping("/password/change")
+    @Operation(
+            summary = "비밀번호 변경 API",
+            description = "비밀번호를 변경하는 API입니다. 로그아웃이 필요하지는 않습니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.PasswordChangeResultDTO> passwordChange(Authentication authentication,
+                                                                                 @RequestBody @Valid MemberRequestDTO.PasswordChangeRequestDTO request) {
+        //반환값을 설정하는 게 맞나? 201 No Content를 반환하는 것도 괜찮았을 것 같은데...
+        String email = authentication.getName();
+        Credential credential = credentialQueryService.updatePasswordByEmail(email, request);
+        //나중에 이거 어차피 converter 형식으로 바꿔야 함, 아직 converter 클래스가 없는 버전이라 일단은 이렇게 둠(물론 이렇게 두는 방식이 좋은 방식은 아니지만 귀찮아서...)
+        return ApiResponse.onSuccess(new MemberResponseDTO.PasswordChangeResultDTO(credential.getMember().getId(), credential.getUpdatedAt()));
     }
 }

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -6,9 +6,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import umc.lightup.api.ApiResponse;
+import umc.lightup.api.code.status.SuccessStatus;
 import umc.lightup.member.domain.Credential;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.dto.MemberRequestDTO;
@@ -105,25 +107,27 @@ public class MemberRestController {
     )
     public ApiResponse<MemberResponseDTO.MyInfoDTO> changeMemberInfo(Authentication authentication,
                                                                      @RequestBody @Valid MemberRequestDTO.ChangeDto request) {
-        //반환값을 설정하는 게 맞나? 201 No Content를 반환하는 것도 괜찮았을 것 같은데... 특히 이메일 변경되면 로그아웃이 필수가 되어 버렸기 때문에...
+        //반환값을 설정하는 게 맞나? 204 No Content를 반환하는 것도 괜찮았을 것 같은데... 특히 이메일 변경되면 로그아웃이 필수가 되어 버렸기 때문에...
         //반환값은 단순 디버그용 그 이상이 아니게 될 수도 있음(정작 Test 코드에선 return 값을 아주 잘 활용 중)
+        //여기서 주의할 점은 이메일 변경되면 로그아웃이 필수이지만 백엔드에서는 아무런 처리를 해 주지 않는다는 것. 알아서 기존 token 지우고 다시 로그인 해야 함.
+        //로그아웃이 필수인 이유가 jwt에 이메일을 저장하기 때문인데, 이 때문에 A와 B가 서로의 비밀번호를 몰라도 서로 이메일을 바꾸면 A는 B 계정에, B는 A 계정에 접속할 수 있음.
         String email = authentication.getName();
         return ApiResponse.onSuccess(MemberResponseDTO.toMyInfoDTO(memberCommandService.putMember(email, request)));
     }
 
     @PostMapping("/password/change")
+    @ResponseStatus(HttpStatus.NO_CONTENT) //명시적으로 쓰기 싫었는데 안 쓰니 200 OK가 나가버리네...
     @Operation(
             summary = "비밀번호 변경 API",
             description = "비밀번호를 변경하는 API입니다. 로그아웃이 필요하지는 않습니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN")}
     )
-    public ApiResponse<MemberResponseDTO.PasswordChangeResultDTO> passwordChange(Authentication authentication,
-                                                                                 @RequestBody @Valid MemberRequestDTO.PasswordChangeRequestDTO request) {
-        //반환값을 설정하는 게 맞나? 201 No Content를 반환하는 것도 괜찮았을 것 같은데...
+    public ApiResponse<Void> passwordChange(Authentication authentication,
+                                            @RequestBody @Valid MemberRequestDTO.PasswordChangeRequestDTO request) {
         String email = authentication.getName();
-        Credential credential = credentialQueryService.updatePasswordByEmail(email, request);
-        //나중에 이거 어차피 converter 형식으로 바꿔야 함, 아직 converter 클래스가 없는 버전이라 일단은 이렇게 둠(물론 이렇게 두는 방식이 좋은 방식은 아니지만 귀찮아서...)
-        return ApiResponse.onSuccess(new MemberResponseDTO.PasswordChangeResultDTO(credential.getMember().getId(), credential.getUpdatedAt()));
+        credentialQueryService.updatePasswordByEmail(email, request);
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+        //null 반환이 과연 옳은가? 물론 이 null 안 쓰려면 응답 통일 형식부터 갈아엎어야 하는 대공사가 필요하긴 함
     }
 
     @PostMapping("/email/exist")

--- a/src/main/java/umc/lightup/member/domain/Credential.java
+++ b/src/main/java/umc/lightup/member/domain/Credential.java
@@ -1,10 +1,7 @@
 package umc.lightup.member.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import umc.lightup.common.BaseEntity;
 import umc.lightup.member.enums.CredentialType;
 
@@ -26,6 +23,7 @@ public class Credential extends BaseEntity {
     @Column(nullable = false)
     private CredentialType credentialType;
 
+    @Setter //별로 열고 싶지는 않았는데...
     @Column(nullable = false)
     private String credential;
 }

--- a/src/main/java/umc/lightup/member/domain/Member.java
+++ b/src/main/java/umc/lightup/member/domain/Member.java
@@ -10,7 +10,7 @@ import umc.lightup.AppConfig;
 import umc.lightup.common.BaseEntity;
 import umc.lightup.member.enums.Mbti;
 import umc.lightup.member.enums.Role;
-import umc.lightup.member.service.CredentialQueryServiceImpl;
+import umc.lightup.member.service.CredentialQueryService;
 
 import java.time.LocalDate;
 import java.util.Collection;
@@ -86,7 +86,7 @@ public class Member extends BaseEntity implements UserDetails {
         // Bean을 수동으로 가져와 Credential 알아내는 코드
         // AppConfig 클래스가 필요함
         ApplicationContext applicationContext = new AnnotationConfigApplicationContext(AppConfig.class);
-        CredentialQueryServiceImpl credentialQueryService = applicationContext.getBean(CredentialQueryServiceImpl.class);
+        CredentialQueryService credentialQueryService = applicationContext.getBean(CredentialQueryService.class);
         return credentialQueryService.findByEmail(getEmail()).getCredential();
     }
 

--- a/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
@@ -72,6 +72,50 @@ public class MemberRequestDTO {
         }
     }
 
+    // Unique check을 하지 않은 상태
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ChangeDto{
+        @NotEmpty
+        private String name;
+        private String nickname;
+        @NotNull
+        private Boolean gender;
+        @NotNull
+        @Past
+        private LocalDate birth;
+        @NotNull
+        private Role role;
+        @NotNull
+        private Mbti mbti;
+        @NotEmpty
+        @Email
+        private String email;
+        private String school;
+        @NotEmpty
+        @Pattern(regexp = "0[1-8]\\d{0,1}-\\d{3,4}-\\d{4,5}")
+        private String phoneNumber;
+
+        public Member toMember(long id){
+            return Member.builder()
+                    .id(id)
+                    .name(this.name)
+                    .nickname(this.nickname)
+                    .gender(this.gender)
+                    .birth(this.birth)
+                    .role(this.role)
+                    .mbti(this.mbti)
+                    .email(this.email)
+                    .school(this.school)
+                    .phoneNumber(this.phoneNumber)
+                    .age((int) this.birth.until(LocalDate.now(), ChronoUnit.YEARS))
+                    .build();
+        }
+    }
+
     @Getter
     @Setter
     @Builder

--- a/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
@@ -132,6 +132,19 @@ public class MemberRequestDTO {
 
     @Getter
     @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class PasswordChangeRequestDTO{
+        @NotBlank(message = "기존 패스워드는 필수입니다.")
+        private String prevPassword;
+
+        @NotBlank(message = "새로운 패스워드는 필수입니다.")
+        private String newPassword;
+    }
+
+    @Getter
+    @Setter
     public static class MemberPositionRequestDTO {
 
         @NotEmpty

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -108,6 +108,14 @@ public class MemberResponseDTO {
         LocalDateTime updatedAt;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmailExistResultDTO{
+        boolean exist;
+    }
+
     public static LoginResultDTO.LoginResultDTOBuilder loginResultDTOBuilder() {
         return LoginResultDTO.builder();
     }

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -103,15 +103,6 @@ public class MemberResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class PasswordChangeResultDTO{
-        long memberId;
-        LocalDateTime updatedAt;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class EmailExistResultDTO{
         boolean exist;
     }

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -99,6 +99,15 @@ public class MemberResponseDTO {
         private String fileUrl;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PasswordChangeResultDTO{
+        long memberId;
+        LocalDateTime updatedAt;
+    }
+
     public static LoginResultDTO.LoginResultDTOBuilder loginResultDTOBuilder() {
         return LoginResultDTO.builder();
     }

--- a/src/main/java/umc/lightup/member/service/CredentialQueryService.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryService.java
@@ -1,0 +1,10 @@
+package umc.lightup.member.service;
+
+import org.springframework.transaction.annotation.Transactional;
+import umc.lightup.member.domain.Credential;
+import umc.lightup.member.dto.MemberRequestDTO;
+
+public interface CredentialQueryService {
+    Credential findByEmail(String email);
+    Credential updatePasswordByEmail(String email, MemberRequestDTO.PasswordChangeRequestDTO request);
+}

--- a/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
@@ -1,11 +1,13 @@
 package umc.lightup.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.lightup.api.code.status.ErrorStatus;
 import umc.lightup.exception.handler.GeneralHandler;
 import umc.lightup.member.domain.Credential;
+import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.enums.CredentialType;
 import umc.lightup.member.repository.CredentialRepository;
 
@@ -14,9 +16,11 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class CredentialQueryServiceImpl {
+public class CredentialQueryServiceImpl implements CredentialQueryService {
     private final CredentialRepository credentialRepository;
+    private final PasswordEncoder passwordEncoder;
 
+    @Override
     public Credential findByEmail(String email) {
         Optional<Credential> credential;
         for(CredentialType credentialType : CredentialType.values()) {
@@ -24,5 +28,18 @@ public class CredentialQueryServiceImpl {
             if (credential.isPresent()) return credential.get();
         }
         throw new GeneralHandler(ErrorStatus.NO_CREDENTIAL);
+    }
+
+    @Override
+    @Transactional
+    public Credential updatePasswordByEmail(String email, MemberRequestDTO.PasswordChangeRequestDTO request) {
+        Credential target = credentialRepository.findByCredentialTypeAndEmail(CredentialType.PASSWORD, email)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        if (!passwordEncoder.matches(request.getPrevPassword(), target.getCredential())) {
+            throw new GeneralHandler(ErrorStatus.INVALID_PASSWORD);
+        }
+        target.setCredential(passwordEncoder.encode(request.getNewPassword()));
+        credentialRepository.save(target);
+        return target;
     }
 }

--- a/src/main/java/umc/lightup/member/service/MemberCommandService.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandService.java
@@ -9,11 +9,11 @@ public interface MemberCommandService {
     MemberResponseDTO.LoginResultDTO loginMember(MemberRequestDTO.PasswordLoginRequestDTO request);
     Member getMember(String email);
     MemberResponseDTO.MemberInfoDTO getMember(long id, String viewerEmail);
-  
+    Member putMember(String email, MemberRequestDTO.ChangeDto request);
     boolean isNicknameExist(String nickname);
     boolean isEmailExist(String email);
     boolean isPhoneNumberExist(String phoneNumber);
-  
+
     void selectPosition(Long memberId, String positionName);
     void deletePosition(Long memberId, String positionName);
 }

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -24,7 +24,6 @@ import umc.lightup.position.domain.Position;
 import umc.lightup.position.repository.PositionRepository;
 
 import java.util.Collections;
-import java.util.Optional;
 
 import umc.lightup.member.repository.*;
 import umc.lightup.region.domain.Region;
@@ -32,7 +31,6 @@ import umc.lightup.region.repository.RegionRepository;
 import umc.lightup.skill.repository.SkillRepository;
 import umc.lightup.strength.repository.StrengthRepository;
 
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -141,6 +139,23 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .phoneOpen(false)
                 .pictureOpen(false)
                 .build().toMemberInfoDTO();
+    }
+
+    @Override
+    @Transactional
+    public Member putMember(String email, MemberRequestDTO.ChangeDto request) {
+        Member member = getMember(email);
+        if (!member.getEmail().equals(request.getEmail()) &&
+                isEmailExist(request.getEmail()))
+            throw new GeneralHandler(ErrorStatus.DUPLICATE_EMAIL);
+        if (!member.getPhoneNumber().equals(request.getPhoneNumber()) &&
+                isPhoneNumberExist(request.getPhoneNumber()))
+            throw new GeneralHandler(ErrorStatus.DUPLICATE_PHONE_NUMBER);
+        if (member.getNickname() != null &&
+                !member.getNickname().equals(request.getNickname()) &&
+                isNicknameExist(request.getNickname()))
+            throw new GeneralHandler(ErrorStatus.DUPLICATE_NICKNAME);
+        return memberRepository.save(request.toMember(member.getId()));
     }
 
     @Override

--- a/src/test/java/umc/lightup/members/MemberTest.java
+++ b/src/test/java/umc/lightup/members/MemberTest.java
@@ -2,10 +2,7 @@ package umc.lightup.members;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -195,7 +192,7 @@ public class MemberTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jacksonObjectMapper.writeValueAsString(joinDto)))
 
-        //Then (따지자면 여기서부터가 Then이 맞긴 함)
+                //Then (따지자면 여기서부터가 Then이 맞긴 함)
                 .andExpect(status().isBadRequest())
                 .andReturn().getResponse().getContentAsString();
         System.out.println(content);
@@ -203,7 +200,8 @@ public class MemberTest {
 
         ApiResponse<NicknameCheck> response =
                 jacksonObjectMapper.readValue(content,
-                        new TypeReference<ApiResponse<NicknameCheck>>(){});
+                        new TypeReference<ApiResponse<NicknameCheck>>() {
+                        });
         assertEquals(ErrorStatus.DUPLICATE_NICKNAME.toString(), response.getResult().getNickname());
     }
 
@@ -245,14 +243,15 @@ public class MemberTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jacksonObjectMapper.writeValueAsString(joinDto)))
 
-        //Then
+                //Then
                 .andExpect(status().isBadRequest())
                 .andReturn().getResponse().getContentAsString();
         System.out.println(content);
 
         ApiResponse<PhoneCheck> response =
                 jacksonObjectMapper.readValue(content,
-                        new TypeReference<ApiResponse<PhoneCheck>>(){});
+                        new TypeReference<ApiResponse<PhoneCheck>>() {
+                        });
         assertNotNull(response.getResult().getPhoneNumber());
     }
 
@@ -261,6 +260,7 @@ public class MemberTest {
      */
     @Test
     @DisplayName("전체적인 API 테스트")
+    @Order(1)
     void joinLoginMyInfoAndEmptyMemberInfo() throws Exception {
 
         //Given
@@ -295,7 +295,8 @@ public class MemberTest {
         LocalDateTime after = LocalDateTime.now();
         ApiResponse<MemberResponseDTO.JoinResultDTO> joinResponse =
                 jacksonObjectMapper.readValue(joinResult,
-                        new TypeReference<ApiResponse<MemberResponseDTO.JoinResultDTO>>(){});
+                        new TypeReference<ApiResponse<MemberResponseDTO.JoinResultDTO>>() {
+                        });
 
         //Then
         assertEquals(3L, joinResponse.getResult().getMemberId());
@@ -315,7 +316,8 @@ public class MemberTest {
                 .andReturn().getResponse().getContentAsString();
         ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse =
                 jacksonObjectMapper.readValue(loginResult,
-                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>(){});
+                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>() {
+                        });
 
         //Then
         assertEquals(3L, loginResponse.getResult().getMemberId());
@@ -330,7 +332,8 @@ public class MemberTest {
                 .andReturn().getResponse().getContentAsString();
         ApiResponse<MemberResponseDTO.MyInfoDTO> myInfoResponse =
                 jacksonObjectMapper.readValue(myInfoResult,
-                        new TypeReference<ApiResponse<MemberResponseDTO.MyInfoDTO>>(){});
+                        new TypeReference<ApiResponse<MemberResponseDTO.MyInfoDTO>>() {
+                        });
 
         //Then
         int age3 = (int) birth3.until(before, ChronoUnit.YEARS);
@@ -356,7 +359,8 @@ public class MemberTest {
                 .andReturn().getResponse().getContentAsString();
         ApiResponse<MemberResponseDTO.MemberInfoDTO> response =
                 jacksonObjectMapper.readValue(content,
-                        new TypeReference<ApiResponse<MemberResponseDTO.MemberInfoDTO>>(){});
+                        new TypeReference<ApiResponse<MemberResponseDTO.MemberInfoDTO>>() {
+                        });
 
         //Then
         MemberResponseDTO.MemberInfoDTO result = response.getResult();
@@ -399,15 +403,15 @@ public class MemberTest {
                         .fileUrl("url2")
                         .build());
 
-        skillSet.forEach(skillId->memberSkillRepository.save(MemberSkill.builder()
+        skillSet.forEach(skillId -> memberSkillRepository.save(MemberSkill.builder()
                 .member(member)
                 .skill(skillRepository.findById(skillId).get())
                 .build()));
-        strengthSet.forEach(strengthId->memberStrengthRepository.save(MemberStrength.builder()
+        strengthSet.forEach(strengthId -> memberStrengthRepository.save(MemberStrength.builder()
                 .member(member)
                 .strength(strengthRepository.findById(strengthId).get())
                 .build()));
-        regionSet.forEach(regionId->memberRegionRepository.save(MemberRegion.builder()
+        regionSet.forEach(regionId -> memberRegionRepository.save(MemberRegion.builder()
                 .member(member)
                 .region(regionRepository.findById(regionId).get())
                 .build()));
@@ -419,33 +423,34 @@ public class MemberTest {
                 .andReturn().getResponse().getContentAsString();
         ApiResponse<MemberResponseDTO.MemberInfoDTO> response =
                 jacksonObjectMapper.readValue(content,
-                        new TypeReference<ApiResponse<MemberResponseDTO.MemberInfoDTO>>(){});
+                        new TypeReference<ApiResponse<MemberResponseDTO.MemberInfoDTO>>() {
+                        });
 
         //Then
         MemberResponseDTO.MemberInfoDTO result = response.getResult();
         assertAll("basic member information",
-                ()->assertEquals(member.getName(), result.getName()),
-                ()->assertEquals(member.getNickname(), result.getNickname()),
-                ()->assertEquals(member.getAge(), result.getAge()),
-                ()->assertEquals(member.getGender(), result.isGender()),
-                ()->assertEquals(member.getRole(), result.getRole()),
-                ()->assertEquals(member.getMbti(), result.getMbti()),
-                ()->assertEquals(member.getCareer(), result.getCareer()),
-                ()->assertEquals(member.getSchool(), result.getSchool())
+                () -> assertEquals(member.getName(), result.getName()),
+                () -> assertEquals(member.getNickname(), result.getNickname()),
+                () -> assertEquals(member.getAge(), result.getAge()),
+                () -> assertEquals(member.getGender(), result.isGender()),
+                () -> assertEquals(member.getRole(), result.getRole()),
+                () -> assertEquals(member.getMbti(), result.getMbti()),
+                () -> assertEquals(member.getCareer(), result.getCareer()),
+                () -> assertEquals(member.getSchool(), result.getSchool())
         );
 
         assertIterableEquals(
-                skillSet.stream().map(skillId->skillRepository.findById(skillId).get().getName()).toList(),
+                skillSet.stream().map(skillId -> skillRepository.findById(skillId).get().getName()).toList(),
                 result.getSkills(),
                 "skills information"); //순서도 같도록 의도한 것
 
         assertIterableEquals(
-                strengthSet.stream().map(strengthId->strengthRepository.findById(strengthId).get().getName()).toList(),
+                strengthSet.stream().map(strengthId -> strengthRepository.findById(strengthId).get().getName()).toList(),
                 result.getStrengths(),
                 "strengths information"); //순서도 같도록 의도한 것
 
         assertIterableEquals(
-                regionSet.stream().map(regionId-> {
+                regionSet.stream().map(regionId -> {
                     Region region = regionRepository.findById(regionId).get();
                     return region.getSido() + " " + region.getSigungu();
                 }).toList(),
@@ -470,9 +475,9 @@ public class MemberTest {
 //                "portfolio information"); //순서도 같도록 의도한 것
 
         assertAll("hidden information",
-                ()->assertNull(result.getEmail()),
-                ()->assertNull(result.getPhoneNumber()),
-                ()->assertNull(result.getProfileImageUrl())
+                () -> assertNull(result.getEmail()),
+                () -> assertNull(result.getPhoneNumber()),
+                () -> assertNull(result.getProfileImageUrl())
         );
     }
 
@@ -491,15 +496,15 @@ public class MemberTest {
                         .fileUrl("url2-1")
                         .build());
 
-        skillSet.forEach(skillId->memberSkillRepository.save(MemberSkill.builder()
+        skillSet.forEach(skillId -> memberSkillRepository.save(MemberSkill.builder()
                 .member(member)
                 .skill(skillRepository.findById(skillId).get())
                 .build()));
-        strengthSet.forEach(strengthId->memberStrengthRepository.save(MemberStrength.builder()
+        strengthSet.forEach(strengthId -> memberStrengthRepository.save(MemberStrength.builder()
                 .member(member)
                 .strength(strengthRepository.findById(strengthId).get())
                 .build()));
-        regionSet.forEach(regionId->memberRegionRepository.save(MemberRegion.builder()
+        regionSet.forEach(regionId -> memberRegionRepository.save(MemberRegion.builder()
                 .member(member)
                 .region(regionRepository.findById(regionId).get())
                 .build()));
@@ -511,33 +516,34 @@ public class MemberTest {
                 .andReturn().getResponse().getContentAsString();
         ApiResponse<MemberResponseDTO.MemberInfoDTO> response =
                 jacksonObjectMapper.readValue(content,
-                        new TypeReference<ApiResponse<MemberResponseDTO.MemberInfoDTO>>(){});
+                        new TypeReference<ApiResponse<MemberResponseDTO.MemberInfoDTO>>() {
+                        });
 
         //Then
         MemberResponseDTO.MemberInfoDTO result = response.getResult();
         assertAll("basic member information",
-                ()->assertEquals(member.getName(), result.getName()),
-                ()->assertEquals(member.getNickname(), result.getNickname()),
-                ()->assertEquals(member.getAge(), result.getAge()),
-                ()->assertEquals(member.getGender(), result.isGender()),
-                ()->assertEquals(member.getRole(), result.getRole()),
-                ()->assertEquals(member.getMbti(), result.getMbti()),
-                ()->assertEquals(member.getCareer(), result.getCareer()),
-                ()->assertEquals(member.getSchool(), result.getSchool())
+                () -> assertEquals(member.getName(), result.getName()),
+                () -> assertEquals(member.getNickname(), result.getNickname()),
+                () -> assertEquals(member.getAge(), result.getAge()),
+                () -> assertEquals(member.getGender(), result.isGender()),
+                () -> assertEquals(member.getRole(), result.getRole()),
+                () -> assertEquals(member.getMbti(), result.getMbti()),
+                () -> assertEquals(member.getCareer(), result.getCareer()),
+                () -> assertEquals(member.getSchool(), result.getSchool())
         );
 
         assertIterableEquals(
-                skillSet.stream().map(skillId->skillRepository.findById(skillId).get().getName()).toList(),
+                skillSet.stream().map(skillId -> skillRepository.findById(skillId).get().getName()).toList(),
                 result.getSkills(),
                 "skills information"); //순서도 같도록 의도한 것
 
         assertIterableEquals(
-                strengthSet.stream().map(strengthId->strengthRepository.findById(strengthId).get().getName()).toList(),
+                strengthSet.stream().map(strengthId -> strengthRepository.findById(strengthId).get().getName()).toList(),
                 result.getStrengths(),
                 "strengths information"); //순서도 같도록 의도한 것
 
         assertIterableEquals(
-                regionSet.stream().map(regionId-> {
+                regionSet.stream().map(regionId -> {
                     Region region = regionRepository.findById(regionId).get();
                     return region.getSido() + " " + region.getSigungu();
                 }).toList(),
@@ -562,9 +568,9 @@ public class MemberTest {
 //                "portfolio information"); //순서도 같도록 의도한 것
 
         assertAll("hidden information",
-                ()->assertNull(result.getEmail()),
-                ()->assertNull(result.getPhoneNumber()),
-                ()->assertNull(result.getProfileImageUrl())
+                () -> assertNull(result.getEmail()),
+                () -> assertNull(result.getPhoneNumber()),
+                () -> assertNull(result.getProfileImageUrl())
         );
     }
 
@@ -583,4 +589,367 @@ public class MemberTest {
 //                .andExpect(status().isOk())
 //                .andExpect((ResultMatcher) jsonPath("$.email").value("user@example.com"));
 //    }
+
+
+    @Test
+    @DisplayName("회원정보 수정 테스트")
+    void putMyInfoTest() throws Exception {
+
+        //Given
+        String email4 = "someone4@example.com";
+        String password4 = "password";
+        String name4 = "이름4";
+        String nickname4 = "닉네임4";
+        LocalDate birth4 = LocalDate.of(2006, Month.DECEMBER, 31);
+        Role role4 = Role.LEADER;
+        Mbti mbti4 = Mbti.INTJ;
+        String phoneNumber4 = "02-000-0000";
+        boolean gender4 = true;
+        MemberRequestDTO.JoinDto joinDto = MemberRequestDTO.JoinDto.builder()
+                .name(name4)
+                .nickname(nickname4)
+                .gender(gender4)
+                .birth(birth4)
+                .role(role4)
+                .mbti(mbti4)
+                .email(email4)
+                .phoneNumber(phoneNumber4)
+                .password(password4)
+                .build();
+
+
+        LocalDateTime before = LocalDateTime.now();
+        String joinResult = mockMvc.perform(post("/api/v1/members/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(joinDto)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        LocalDateTime after = LocalDateTime.now();
+        ApiResponse<MemberResponseDTO.JoinResultDTO> joinResponse =
+                jacksonObjectMapper.readValue(joinResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.JoinResultDTO>>() {
+                        });
+
+        assertEquals(4L, joinResponse.getResult().getMemberId());
+        assertTrue(before.isBefore(joinResponse.getResult().getCreatedAt()) ||
+                before.isEqual(joinResponse.getResult().getCreatedAt()));
+        assertTrue(after.isAfter(joinResponse.getResult().getCreatedAt()) ||
+                after.isEqual(joinResponse.getResult().getCreatedAt()));
+
+        String loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email(email4)
+                                .password(password4)
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse =
+                jacksonObjectMapper.readValue(loginResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>() {
+                        });
+
+        assertEquals(4L, loginResponse.getResult().getMemberId());
+
+
+        String accessToken = loginResponse.getResult().getAccessToken();
+
+        String myInfoResult = mockMvc.perform(get("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.MyInfoDTO> myInfoResponse =
+                jacksonObjectMapper.readValue(myInfoResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.MyInfoDTO>>() {
+                        });
+
+        int age4 = (int) birth4.until(before, ChronoUnit.YEARS);
+        MemberResponseDTO.MyInfoDTO myInfoResponseResult = myInfoResponse.getResult();
+        assertAll("MyInfo check",
+                () -> assertEquals(4L, myInfoResponseResult.getId()),
+                () -> assertEquals(name4, myInfoResponseResult.getName()),
+                () -> assertEquals(nickname4, myInfoResponseResult.getNickname()),
+                () -> assertEquals(gender4, myInfoResponseResult.isGender()),
+                () -> assertEquals(age4, myInfoResponseResult.getAge()),
+                () -> assertEquals(birth4, myInfoResponseResult.getBirth()),
+                () -> assertEquals(role4, myInfoResponseResult.getRole()),
+                () -> assertEquals(mbti4, myInfoResponseResult.getMbti()),
+                () -> assertEquals(email4, myInfoResponseResult.getEmail()),
+                () -> assertEquals(phoneNumber4, myInfoResponseResult.getPhoneNumber()),
+                () -> assertNull(myInfoResponseResult.getSchool()),
+                () -> assertNull(myInfoResponseResult.getCareer()),
+                () -> assertNull(myInfoResponseResult.getProfileImageUrl())
+        );
+
+        //When
+        //변경사항 없음
+        MemberRequestDTO.ChangeDto change1 = MemberRequestDTO.ChangeDto.builder()
+                .name(name4)
+                .nickname(nickname4)
+                .gender(gender4)
+                .birth(birth4)
+                .role(role4)
+                .mbti(mbti4)
+                .email(email4)
+                .phoneNumber(phoneNumber4)
+                .build();
+
+
+        String change1Result = mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(change1))
+                )
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.MyInfoDTO> change1Response =
+                jacksonObjectMapper.readValue(change1Result,
+                        new TypeReference<ApiResponse<MemberResponseDTO.MyInfoDTO>>() {
+                        });
+
+        //Then
+        MemberResponseDTO.MyInfoDTO change1ResponseResult = change1Response.getResult();
+        assertAll("MyInfo check without change",
+                () -> assertEquals(4L, change1ResponseResult.getId()),
+                () -> assertEquals(name4, change1ResponseResult.getName()),
+                () -> assertEquals(nickname4, change1ResponseResult.getNickname()),
+                () -> assertEquals(gender4, change1ResponseResult.isGender()),
+                () -> assertEquals(age4, change1ResponseResult.getAge()),
+                () -> assertEquals(birth4, change1ResponseResult.getBirth()),
+                () -> assertEquals(role4, change1ResponseResult.getRole()),
+                () -> assertEquals(mbti4, change1ResponseResult.getMbti()),
+                () -> assertEquals(email4, change1ResponseResult.getEmail()),
+                () -> assertEquals(phoneNumber4, change1ResponseResult.getPhoneNumber()),
+                () -> assertNull(change1ResponseResult.getSchool()),
+                () -> assertNull(change1ResponseResult.getCareer()),
+                () -> assertNull(change1ResponseResult.getProfileImageUrl())
+        );
+
+
+        //When
+        //중복 조건 없는 새로운 변경사항
+        LocalDate changedBirth = LocalDate.of(1996, Month.JANUARY, 1);
+        MemberRequestDTO.ChangeDto change2 = MemberRequestDTO.ChangeDto.builder()
+                .name("name4")
+                .nickname(nickname4)
+                .gender(false)
+                .birth(changedBirth)
+                .role(Role.TEAMMATE)
+                .mbti(Mbti.ENFJ)
+                .email(email4)
+                .phoneNumber(phoneNumber4)
+                .build();
+
+
+        String change2Result = mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(change2))
+                )
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.MyInfoDTO> change2Response =
+                jacksonObjectMapper.readValue(change2Result,
+                        new TypeReference<ApiResponse<MemberResponseDTO.MyInfoDTO>>() {
+                        });
+
+        //Then
+        MemberResponseDTO.MyInfoDTO change2ResponseResult = change2Response.getResult();
+        int changedAge = (int) changedBirth.until(before, ChronoUnit.YEARS);
+        assertAll("MyInfo check with non-unique changes",
+                () -> assertEquals(4L, change2ResponseResult.getId()),
+                () -> assertEquals("name4", change2ResponseResult.getName()),
+                () -> assertEquals(nickname4, change2ResponseResult.getNickname()),
+                () -> assertEquals(false, change2ResponseResult.isGender()),
+                () -> assertEquals(changedAge, change2ResponseResult.getAge()),
+                () -> assertEquals(changedBirth, change2ResponseResult.getBirth()),
+                () -> assertEquals(Role.TEAMMATE, change2ResponseResult.getRole()),
+                () -> assertEquals(Mbti.ENFJ, change2ResponseResult.getMbti()),
+                () -> assertEquals(email4, change2ResponseResult.getEmail()),
+                () -> assertEquals(phoneNumber4, change2ResponseResult.getPhoneNumber()),
+                () -> assertNull(change2ResponseResult.getSchool()),
+                () -> assertNull(change2ResponseResult.getCareer()),
+                () -> assertNull(change2ResponseResult.getProfileImageUrl())
+        );
+
+        //When
+        //중복 조건 변경사항
+        MemberRequestDTO.ChangeDto change3 = MemberRequestDTO.ChangeDto.builder()
+                .name(name4)
+                .nickname(null)
+                .gender(gender4)
+                .birth(birth4)
+                .role(role4)
+                .mbti(mbti4)
+                .email("newEmail@example.com")
+                .phoneNumber("010-1111-2222")
+                .build();
+
+
+        String change3Result = mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(change3))
+                )
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.MyInfoDTO> change3Response =
+                jacksonObjectMapper.readValue(change3Result,
+                        new TypeReference<ApiResponse<MemberResponseDTO.MyInfoDTO>>() {
+                        });
+
+        //Then
+        MemberResponseDTO.MyInfoDTO change3ResponseResult = change3Response.getResult();
+        assertAll("MyInfo check with unique changes",
+                () -> assertEquals(4L, change3ResponseResult.getId()),
+                () -> assertEquals(name4, change3ResponseResult.getName()),
+                () -> assertNull(change3ResponseResult.getNickname()),
+                () -> assertEquals(gender4, change3ResponseResult.isGender()),
+                () -> assertEquals(age4, change3ResponseResult.getAge()),
+                () -> assertEquals(birth4, change3ResponseResult.getBirth()),
+                () -> assertEquals(role4, change3ResponseResult.getRole()),
+                () -> assertEquals(mbti4, change3ResponseResult.getMbti()),
+                () -> assertEquals("newEmail@example.com", change3ResponseResult.getEmail()),
+                () -> assertEquals("010-1111-2222", change3ResponseResult.getPhoneNumber()),
+                () -> assertNull(change3ResponseResult.getSchool()),
+                () -> assertNull(change3ResponseResult.getCareer()),
+                () -> assertNull(change3ResponseResult.getProfileImageUrl())
+        );
+
+        //이제 이메일이 바뀌었으니 에러가 나야 함
+        mockMvc.perform(get("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
+                )
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("중복 조건 회원정보수정 테스트")
+    void putMyInfoDuplicatedTest() throws Exception {
+        //Given
+        //BeforeAll에 있던 거
+        String loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone2@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse =
+                jacksonObjectMapper.readValue(loginResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>() {
+                        });
+
+        assertEquals(2L, loginResponse.getResult().getMemberId());
+
+
+        String accessToken = loginResponse.getResult().getAccessToken();
+
+        String myInfoResult = mockMvc.perform(get("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.MyInfoDTO> myInfoResponse =
+                jacksonObjectMapper.readValue(myInfoResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.MyInfoDTO>>() {
+                        });
+        MemberResponseDTO.MyInfoDTO myInfoResponseResult = myInfoResponse.getResult();
+
+        //When
+        //닉네임
+        MemberRequestDTO.ChangeDto change1 = MemberRequestDTO.ChangeDto.builder()
+                .name(myInfoResponseResult.getName())
+                .nickname("닉네임1")
+                .gender(myInfoResponseResult.isGender())
+                .birth(myInfoResponseResult.getBirth())
+                .role(myInfoResponseResult.getRole())
+                .mbti(myInfoResponseResult.getMbti())
+                .email(myInfoResponseResult.getEmail())
+                .phoneNumber(myInfoResponseResult.getPhoneNumber())
+                .build();
+
+
+        String change1Result = mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(change1))
+                )
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<Void> change1Response =
+                jacksonObjectMapper.readValue(change1Result,
+                        new TypeReference<ApiResponse<Void>>() {
+                        });
+
+        //Then
+        assertAll("MyInfo check with duplicated nickname",
+                () -> assertEquals(ErrorStatus.DUPLICATE_NICKNAME.getCode(), change1Response.getCode()),
+                () -> assertEquals(ErrorStatus.DUPLICATE_NICKNAME.getMessage(), change1Response.getMessage())
+        );
+
+        //When
+        //이메일 중복
+        MemberRequestDTO.ChangeDto change2 = MemberRequestDTO.ChangeDto.builder()
+                .name(myInfoResponseResult.getName())
+                .nickname(myInfoResponseResult.getNickname())
+                .gender(myInfoResponseResult.isGender())
+                .birth(myInfoResponseResult.getBirth())
+                .role(myInfoResponseResult.getRole())
+                .mbti(myInfoResponseResult.getMbti())
+                .email("someone@example.com")
+                .phoneNumber(myInfoResponseResult.getPhoneNumber())
+                .build();
+
+
+        String change2Result = mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(change2))
+                )
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<Void> change2Response =
+                jacksonObjectMapper.readValue(change2Result,
+                        new TypeReference<ApiResponse<Void>>() {
+                        });
+
+        //Then
+        assertAll("MyInfo check with duplicated email",
+                () -> assertEquals(ErrorStatus.DUPLICATE_EMAIL.getCode(), change2Response.getCode()),
+                () -> assertEquals(ErrorStatus.DUPLICATE_EMAIL.getMessage(), change2Response.getMessage())
+        );
+
+        //When
+        //휴대전화 중복
+        MemberRequestDTO.ChangeDto change3 = MemberRequestDTO.ChangeDto.builder()
+                .name(myInfoResponseResult.getName())
+                .nickname(myInfoResponseResult.getNickname())
+                .gender(myInfoResponseResult.isGender())
+                .birth(myInfoResponseResult.getBirth())
+                .role(myInfoResponseResult.getRole())
+                .mbti(myInfoResponseResult.getMbti())
+                .email(myInfoResponseResult.getEmail())
+                .phoneNumber("010-5555-6666")
+                .build();
+
+
+        String change3Result = mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(change3))
+                )
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<Void> change3Response =
+                jacksonObjectMapper.readValue(change3Result,
+                        new TypeReference<ApiResponse<Void>>() {
+                        });
+
+        //Then
+        assertAll("MyInfo check with duplicated phone number",
+                () -> assertEquals(ErrorStatus.DUPLICATE_PHONE_NUMBER.getCode(), change3Response.getCode()),
+                () -> assertEquals(ErrorStatus.DUPLICATE_PHONE_NUMBER.getMessage(), change3Response.getMessage())
+        );
+    }
 }

--- a/src/test/java/umc/lightup/members/MemberTest.java
+++ b/src/test/java/umc/lightup/members/MemberTest.java
@@ -1109,4 +1109,60 @@ public class MemberTest {
                 () -> assertEquals(ErrorStatus.INVALID_PASSWORD.getMessage(), change1Response.getMessage())
         );
     }
+
+    @Test
+    @DisplayName("이미 존재하는 이메일에 대한 이메일 존재 여부 확인 테스트 1")
+    void emailExistTrueTest1() throws Exception {
+        //When
+        String content1 = mockMvc.perform(post("/api/v1/members/email/exist")
+                        .param("email", "someone@example.com"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.EmailExistResultDTO> change1Response =
+                jacksonObjectMapper.readValue(content1,
+                        new TypeReference<ApiResponse<MemberResponseDTO.EmailExistResultDTO>>(){});
+
+        //Then
+        assertTrue(change1Response.getResult().isExist());
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 이메일에 대한 이메일 존재 여부 확인 테스트 2")
+    void emailExistTrueTest2() throws Exception {
+        //When
+        String content1 = mockMvc.perform(post("/api/v1/members/email/exist")
+                        .param("email", "someone2@example.com"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.EmailExistResultDTO> change1Response =
+                jacksonObjectMapper.readValue(content1,
+                        new TypeReference<ApiResponse<MemberResponseDTO.EmailExistResultDTO>>(){});
+
+        //Then
+        assertTrue(change1Response.getResult().isExist());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이메일에 대한 이메일 존재 여부 확인 테스트")
+    void emailExistFalseTest() throws Exception {
+        //When
+        String content1 = mockMvc.perform(post("/api/v1/members/email/exist")
+                        .param("email", "none@example.com"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.EmailExistResultDTO> change1Response =
+                jacksonObjectMapper.readValue(content1,
+                        new TypeReference<ApiResponse<MemberResponseDTO.EmailExistResultDTO>>(){});
+
+        //Then
+        assertFalse(change1Response.getResult().isExist());
+    }
+
+    @Test
+    @DisplayName("이메일이 아닌 형식에 대한 이메일 존재 여부 확인 테스트")
+    void emailExistErrorTest() throws Exception {
+        mockMvc.perform(post("/api/v1/members/email/exist")
+                        .param("email", "jdnosfajdn"))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/umc/lightup/members/MemberTest.java
+++ b/src/test/java/umc/lightup/members/MemberTest.java
@@ -981,23 +981,13 @@ public class MemberTest {
                         .newPassword("password1234")
                         .build();
 
-        LocalDateTime before = LocalDateTime.now();
-        String content1 = mockMvc.perform(post("/api/v1/members/password/change")
+        mockMvc.perform(post("/api/v1/members/password/change")
                         .header("Authorization", "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jacksonObjectMapper.writeValueAsString(change1)))
-                .andExpect(status().isOk())
-                .andReturn().getResponse().getContentAsString();
-        LocalDateTime after = LocalDateTime.now();
-        ApiResponse<MemberResponseDTO.PasswordChangeResultDTO> change1Response =
-                jacksonObjectMapper.readValue(content1,
-                        new TypeReference<ApiResponse<MemberResponseDTO.PasswordChangeResultDTO>>(){});
+                .andExpect(status().isNoContent());
 
         //Then
-        assertEquals(1L, change1Response.getResult().getMemberId());
-        assertTrue(before.isBefore(change1Response.getResult().getUpdatedAt()) ||
-                after.isAfter(change1Response.getResult().getUpdatedAt()));
-
         mockMvc.perform(post("/api/v1/members/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
@@ -1030,23 +1020,15 @@ public class MemberTest {
                         .newPassword("password")
                         .build();
 
-        before = LocalDateTime.now();
-        String content2 = mockMvc.perform(post("/api/v1/members/password/change")
+        String content = mockMvc.perform(post("/api/v1/members/password/change")
                         .header("Authorization", "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jacksonObjectMapper.writeValueAsString(change2)))
-                .andExpect(status().isOk())
+                .andExpect(status().isNoContent())
                 .andReturn().getResponse().getContentAsString();
-        after = LocalDateTime.now();
-        ApiResponse<MemberResponseDTO.PasswordChangeResultDTO> change2Response =
-                jacksonObjectMapper.readValue(content2,
-                        new TypeReference<ApiResponse<MemberResponseDTO.PasswordChangeResultDTO>>(){});
 
         //Then
-        assertEquals(1L, change2Response.getResult().getMemberId());
-        assertTrue(before.isBefore(change2Response.getResult().getUpdatedAt()) ||
-                after.isAfter(change2Response.getResult().getUpdatedAt()));
-
+        System.out.println("content = " + content);
         mockMvc.perform(post("/api/v1/members/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()

--- a/src/test/java/umc/lightup/members/MemberTest.java
+++ b/src/test/java/umc/lightup/members/MemberTest.java
@@ -952,4 +952,161 @@ public class MemberTest {
                 () -> assertEquals(ErrorStatus.DUPLICATE_PHONE_NUMBER.getMessage(), change3Response.getMessage())
         );
     }
+
+    @Test
+    @DisplayName("비밀번호 변경 및 원상복귀 테스트")
+    void passwordChangeTest() throws Exception {
+        //귀찮아서 이렇게 했지만 원래는 member 새로 만드는 것부터 하는 게 좋긴 함
+        String loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse =
+                jacksonObjectMapper.readValue(loginResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>() {
+                        });
+
+        assertEquals(1L, loginResponse.getResult().getMemberId());
+
+        String accessToken = loginResponse.getResult().getAccessToken();
+
+        //When
+        MemberRequestDTO.PasswordChangeRequestDTO change1 =
+                MemberRequestDTO.PasswordChangeRequestDTO.builder()
+                        .prevPassword("password")
+                        .newPassword("password1234")
+                        .build();
+
+        LocalDateTime before = LocalDateTime.now();
+        String content1 = mockMvc.perform(post("/api/v1/members/password/change")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(change1)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        LocalDateTime after = LocalDateTime.now();
+        ApiResponse<MemberResponseDTO.PasswordChangeResultDTO> change1Response =
+                jacksonObjectMapper.readValue(content1,
+                        new TypeReference<ApiResponse<MemberResponseDTO.PasswordChangeResultDTO>>(){});
+
+        //Then
+        assertEquals(1L, change1Response.getResult().getMemberId());
+        assertTrue(before.isBefore(change1Response.getResult().getUpdatedAt()) ||
+                after.isAfter(change1Response.getResult().getUpdatedAt()));
+
+        mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().is4xxClientError());
+
+        //Token 다시 받아오기
+        loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone@example.com")
+                                .password("password1234")
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        loginResponse = jacksonObjectMapper.readValue(loginResult,
+                new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>(){});
+
+        assertEquals(1L, loginResponse.getResult().getMemberId());
+
+        //accessToken = loginResponse.getResult().getAccessToken();
+
+        //다시 돌려놓아야 다른 테스트에서 문제가 발생하지 않음
+        //When
+        MemberRequestDTO.PasswordChangeRequestDTO change2 =
+                MemberRequestDTO.PasswordChangeRequestDTO.builder()
+                        .prevPassword("password1234")
+                        .newPassword("password")
+                        .build();
+
+        before = LocalDateTime.now();
+        String content2 = mockMvc.perform(post("/api/v1/members/password/change")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(change2)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        after = LocalDateTime.now();
+        ApiResponse<MemberResponseDTO.PasswordChangeResultDTO> change2Response =
+                jacksonObjectMapper.readValue(content2,
+                        new TypeReference<ApiResponse<MemberResponseDTO.PasswordChangeResultDTO>>(){});
+
+        //Then
+        assertEquals(1L, change2Response.getResult().getMemberId());
+        assertTrue(before.isBefore(change2Response.getResult().getUpdatedAt()) ||
+                after.isAfter(change2Response.getResult().getUpdatedAt()));
+
+        mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone@example.com")
+                                .password("password1234")
+                                .build())))
+                .andExpect(status().is4xxClientError());
+
+        mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 테스트(비밀번호 불일치)")
+    void passwordChangeFailTest() throws Exception {
+        //귀찮아서 이렇게 했지만 원래는 member 새로 만드는 것부터 하는 게 좋긴 함
+        String loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone2@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse =
+                jacksonObjectMapper.readValue(loginResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>() {
+                        });
+
+        assertEquals(2L, loginResponse.getResult().getMemberId());
+
+        String accessToken = loginResponse.getResult().getAccessToken();
+
+
+        //When
+        MemberRequestDTO.PasswordChangeRequestDTO change1 =
+                MemberRequestDTO.PasswordChangeRequestDTO.builder()
+                        .prevPassword("password1234")
+                        .newPassword("password")
+                        .build();
+
+        String content1 = mockMvc.perform(post("/api/v1/members/password/change")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(change1)))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<Void> change1Response =
+                jacksonObjectMapper.readValue(content1,
+                        new TypeReference<ApiResponse<Void>>(){});
+
+        //Then
+        assertAll("Password change with wrong old password",
+                () -> assertEquals(ErrorStatus.INVALID_PASSWORD.getCode(), change1Response.getCode()),
+                () -> assertEquals(ErrorStatus.INVALID_PASSWORD.getMessage(), change1Response.getMessage())
+        );
+    }
 }


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 회원 정보 수정 기능 구현

---

## 🔧 작업 내용 요약
- 회원가입 시 입력했던 정보 수정 기능
- 로그인 이후 비밀번호를 수정하는 기능

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- API의 반환값이 적절한지
- 이메일 변경 시 로그아웃이 강제되는 현재 상황이 적절한지(단, 로그아웃이 필요 없도록 이를 수정하려면 jwt 관련 코드를 만져야 함)

---

## 🔗 관련 이슈
- closes #17 

---

## 📝 기타 참고 사항
- 아직 converter 방식이 적용되지 않았을 수 있음