### PR TITLE
[Item] 프로젝트 생성 기능 구현 & S3 설정 파일 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/umc/lightup/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/umc/lightup/aws/s3/AmazonS3Manager.java
@@ -1,0 +1,43 @@
+package umc.lightup.aws.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import umc.lightup.common.Uuid;
+import umc.lightup.common.repository.UuidRepository;
+import umc.lightup.config.AmazonConfig;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AmazonS3Manager {
+
+    private final AmazonS3 amazonS3;
+
+    private final AmazonConfig amazonConfig;
+
+    private final UuidRepository uuidRepository;
+
+    public String uploadFile(String keyName, MultipartFile file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+        try {
+            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
+        } catch (IOException e) {
+            log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
+        }
+
+        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+    public String generateItemFileKeyName(Uuid uuid) {
+        return amazonConfig.getItemFilePath() + '/' + uuid.getUuid();
+    }
+}

--- a/src/main/java/umc/lightup/aws/s3/converter/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/umc/lightup/aws/s3/converter/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,32 @@
+package umc.lightup.aws.s3.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+
+}

--- a/src/main/java/umc/lightup/common/Uuid.java
+++ b/src/main/java/umc/lightup/common/Uuid.java
@@ -1,0 +1,18 @@
+package umc.lightup.common;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Uuid extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String uuid;
+}

--- a/src/main/java/umc/lightup/common/repository/UuidRepository.java
+++ b/src/main/java/umc/lightup/common/repository/UuidRepository.java
@@ -1,0 +1,7 @@
+package umc.lightup.common.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.lightup.common.Uuid;
+
+public interface UuidRepository extends JpaRepository<Uuid, Long> {
+}

--- a/src/main/java/umc/lightup/config/AmazonConfig.java
+++ b/src/main/java/umc/lightup/config/AmazonConfig.java
@@ -1,0 +1,53 @@
+package umc.lightup.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class AmazonConfig {
+
+    private AWSCredentials awsCredentials;
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey = "";
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey = "";
+
+    @Value("${cloud.aws.region.static}")
+    private String region = "ap-northeast-2";
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.path.profileImage}")
+    private String profileImagePath;
+
+    @Value("${cloud.aws.s3.path.itemFile}")
+    private String itemFilePath;
+
+    @PostConstruct
+    public void init() {this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey); }
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+    @Bean
+    public AWSCredentialsProvider awsCredentialsProvider() { return new AWSStaticCredentialsProvider(awsCredentials); }
+}

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -1,0 +1,42 @@
+package umc.lightup.item.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import umc.lightup.api.ApiResponse;
+import umc.lightup.item.converter.ItemConverter;
+import umc.lightup.item.domain.Item;
+import umc.lightup.item.dto.ItemRequestDTO;
+import umc.lightup.item.dto.ItemResponseDTO;
+import umc.lightup.item.service.ItemCommandService;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.service.MemberCommandService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/items")
+public class ItemRestController {
+
+    private final ItemCommandService itemCommandService;
+    private final MemberCommandService memberCommandService;
+
+    @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Operation(summary = "Item을 생성하는 API 입니다.", description = "Item을 생성할 수 있으며 이미지도 업로드 가능합니다.")
+    public ApiResponse<ItemResponseDTO.ItemJoinResultDTO> createItem(Authentication authentication,
+                                                   @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+                                                                     @RequestPart("request") @Valid ItemRequestDTO.ItemJoinRequestDTO request,
+                                                   @RequestPart("itemImage")MultipartFile itemImage) {
+        Member member = memberCommandService.getMember(authentication.getName());
+        Item item = itemCommandService.createItem(member, request, itemImage);
+        return ApiResponse.onSuccess(ItemConverter.toItemJoinResultDTO(member, item));
+    }
+}

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -34,7 +34,7 @@ public class ItemRestController {
     public ApiResponse<ItemResponseDTO.ItemJoinResultDTO> createItem(Authentication authentication,
                                                    @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                                      @RequestPart("request") @Valid ItemRequestDTO.ItemJoinRequestDTO request,
-                                                   @RequestPart("itemImage")MultipartFile itemImage) {
+                                                   @RequestPart(value = "itemImage", required = false)MultipartFile itemImage) {
         Member member = memberCommandService.getMember(authentication.getName());
         Item item = itemCommandService.createItem(member, request, itemImage);
         return ApiResponse.onSuccess(ItemConverter.toItemJoinResultDTO(member, item));

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -1,0 +1,37 @@
+package umc.lightup.item.converter;
+
+import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.ItemImage;
+import umc.lightup.item.dto.ItemRequestDTO;
+import umc.lightup.item.dto.ItemResponseDTO;
+import umc.lightup.member.domain.Member;
+
+public class ItemConverter {
+    public static ItemResponseDTO.ItemJoinResultDTO toItemJoinResultDTO(Member member, Item item) {
+        return ItemResponseDTO.ItemJoinResultDTO.builder()
+                .memberId(member.getId())
+                .itemName(item.getName())
+                .build();
+    }
+
+    public static Item toItem(ItemRequestDTO.ItemJoinRequestDTO request, Member member) {
+        return Item.builder()
+                .member(member)
+                .name(request.getName())
+                .introduce(request.getIntroduce())
+                .projectStatus(request.getProjectStatus())
+                .collaboration(request.getCollaboration())
+                .address(request.getAddress())
+                .office(request.isOffice())
+                .preferMbti(request.getPreferMbti())
+                .description(request.getDescription())
+                .build();
+    }
+
+    public static ItemImage toItemImage(Item item, String imageUrl) {
+        return ItemImage.builder()
+                .item(item)
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/src/main/java/umc/lightup/item/domain/Item.java
+++ b/src/main/java/umc/lightup/item/domain/Item.java
@@ -1,10 +1,15 @@
 package umc.lightup.item.domain;
 
 import jakarta.persistence.*;
+import lombok.*;
 import umc.lightup.common.BaseEntity;
 import umc.lightup.member.domain.Member;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Item extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/lightup/item/domain/ItemImage.java
+++ b/src/main/java/umc/lightup/item/domain/ItemImage.java
@@ -1,0 +1,23 @@
+package umc.lightup.item.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.lightup.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemImage extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Column(length = 255)
+    private String imageUrl;
+}

--- a/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
@@ -1,0 +1,30 @@
+package umc.lightup.item.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+public class ItemRequestDTO {
+
+    @Getter
+    @Setter
+    public static class ItemJoinRequestDTO {
+        @NotBlank
+        private String name;
+        @NotBlank
+        private String introduce;
+        @NotBlank
+        private String projectStatus;
+        @NotBlank
+        private String collaboration;
+        @NotBlank
+        private String address;
+        @NotNull
+        private boolean office;
+        @NotBlank
+        private String preferMbti;
+        @NotBlank
+        private String description;
+    }
+}

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -1,0 +1,18 @@
+package umc.lightup.item.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ItemResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemJoinResultDTO {
+        Long memberId;
+        String itemName;
+    }
+}

--- a/src/main/java/umc/lightup/item/repository/ItemImageRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemImageRepository.java
@@ -1,0 +1,9 @@
+package umc.lightup.item.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.lightup.item.domain.ItemImage;
+
+@Repository
+public interface ItemImageRepository extends JpaRepository<ItemImage, Long> {
+}

--- a/src/main/java/umc/lightup/item/repository/ItemRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepository.java
@@ -1,0 +1,9 @@
+package umc.lightup.item.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.lightup.item.domain.Item;
+
+@Repository
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -1,0 +1,10 @@
+package umc.lightup.item.service;
+
+import org.springframework.web.multipart.MultipartFile;
+import umc.lightup.item.domain.Item;
+import umc.lightup.item.dto.ItemRequestDTO;
+import umc.lightup.member.domain.Member;
+
+public interface ItemCommandService {
+    Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile file);
+}

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -1,0 +1,48 @@
+package umc.lightup.item.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import umc.lightup.aws.s3.AmazonS3Manager;
+import umc.lightup.common.Uuid;
+import umc.lightup.common.repository.UuidRepository;
+import umc.lightup.item.converter.ItemConverter;
+import umc.lightup.item.domain.Item;
+import umc.lightup.item.dto.ItemRequestDTO;
+import umc.lightup.item.repository.ItemImageRepository;
+import umc.lightup.item.repository.ItemRepository;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.repository.MemberRepository;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ItemCommandServiceImpl implements ItemCommandService {
+
+    private final ItemRepository itemRepository;
+    private final MemberRepository memberRepository;
+    private final ItemImageRepository itemImageRepository;
+
+    private final AmazonS3Manager s3Manager;
+    private final UuidRepository uuidRepository;
+
+    @Override
+    @Transactional
+    public Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile file) {
+        Item item = ItemConverter.toItem(request, member);
+
+        Item saveditem = itemRepository.save(item);
+
+        String uuid = UUID.randomUUID().toString();
+        Uuid savedUuid = uuidRepository.save(Uuid.builder()
+                .uuid(uuid).build());
+
+        String fileUrl = s3Manager.uploadFile(s3Manager.generateItemFileKeyName(savedUuid), file);
+        itemImageRepository.save(ItemConverter.toItemImage(item, fileUrl));
+
+        return saveditem;
+    }
+}

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -36,12 +36,14 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
         Item saveditem = itemRepository.save(item);
 
-        String uuid = UUID.randomUUID().toString();
-        Uuid savedUuid = uuidRepository.save(Uuid.builder()
-                .uuid(uuid).build());
+        if (file != null) {
+            String uuid = UUID.randomUUID().toString();
+            Uuid savedUuid = uuidRepository.save(Uuid.builder()
+                    .uuid(uuid).build());
 
-        String fileUrl = s3Manager.uploadFile(s3Manager.generateItemFileKeyName(savedUuid), file);
-        itemImageRepository.save(ItemConverter.toItemImage(item, fileUrl));
+            String fileUrl = s3Manager.uploadFile(s3Manager.generateItemFileKeyName(savedUuid), file);
+            itemImageRepository.save(ItemConverter.toItemImage(item, fileUrl));
+        }
 
         return saveditem;
     }


### PR DESCRIPTION
## 💫 PR 제목
- [Item] 프로젝트 생성 기능 구현 & S3 설정 파일 추가

---

## 🔧 작업 내용 요약
- S3 구축 완료 했습니다! 이제 S3에 파일 업로드 가능합니다!
- S3 테스트 겸으로 Item을 생성할 때 파일 업로드 기능을 포함해서 동작하는지 확인해봤습니다


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 처음에 S3 테스트 할때는 (사진 png 파일로 테스트) S3에 파일이 올라가긴 했는데 파일 확장자를 인식하지 못하는 현상이 있었습니다.
- AmazonS3Manager 클래스의 metadata에 업로드한 파일이 어떤 확장자인지 metadata.setContentType(file.getContentType()); 이런식으로 알려줄 수 있다고 해서 써봤는데 맞는 방식인지 확실하지는 않습니다.

---

## 🔗 관련 이슈
- closes #24 

---

## 📝 기타 참고 사항
-
