### PR TITLE
[Item] 전체 프로젝트 목록 조회 & 내 프로젝트 목록 조회 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -30,7 +30,7 @@ public class ItemRestController {
     private final MemberCommandService memberCommandService;
 
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    @Operation(summary = "Item을 생성하는 API 입니다.", description = "Item을 생성할 수 있으며 이미지도 업로드 가능합니다.")
+    @Operation(summary = "Item 생성 API", description = "Item을 생성할 수 있으며 이미지도 업로드 가능합니다. (이미지 업로드는 필수 X)")
     public ApiResponse<ItemResponseDTO.ItemJoinResultDTO> createItem(Authentication authentication,
                                                    @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                                      @RequestPart("request") @Valid ItemRequestDTO.ItemJoinRequestDTO request,

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -4,13 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.api.ApiResponse;
 import umc.lightup.item.converter.ItemConverter;
@@ -21,6 +22,8 @@ import umc.lightup.item.service.ItemCommandService;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.service.MemberCommandService;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/items")
@@ -29,8 +32,28 @@ public class ItemRestController {
     private final ItemCommandService itemCommandService;
     private final MemberCommandService memberCommandService;
 
+    private static final int DEFAULT_ITEM_PAGE_SIZE = 2;
+
+    @GetMapping("/search")
+    @Operation(summary = "전체 프로젝트 조회 API", description = "전체 프로젝트를 조회하는 API이며 페이징을 포함합니다. 요청 파라미터로 page 번호를 입력할 수 있습니다.")
+    public ApiResponse<ItemResponseDTO.ItemResultListDTO> viewAllItems(@RequestParam(defaultValue = "0") @Min(1) Integer page) {
+        Pageable pageable = PageRequest.of(page - 1, DEFAULT_ITEM_PAGE_SIZE, Sort.by("createdAt").descending());
+
+        List<ItemResponseDTO.ItemResultDTO> allItems = itemCommandService.getAllItems(pageable);
+        return ApiResponse.onSuccess(ItemConverter.toItemResultListDTO(allItems));
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "본인 프로젝트 조회 API", description = "사용자의 프로젝트를 조회하는 API 입니다. 등록한 사진이 없다면 itemImageUrl은 null을 반환합니다.")
+    public ApiResponse<ItemResponseDTO.MyItemResultListDTO> viewMyItems(Authentication authentication) {
+        Member member = memberCommandService.getMember(authentication.getName());
+
+        List<ItemResponseDTO.MyItemResultDTO> myItems = itemCommandService.getMyItems(member);
+        return ApiResponse.onSuccess(ItemConverter.toMyItemResultListDTO(myItems));
+    }
+
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    @Operation(summary = "Item 생성 API", description = "Item을 생성할 수 있으며 이미지도 업로드 가능합니다. (이미지 업로드는 필수 X)")
+    @Operation(summary = "본인 프로젝트 생성 API", description = "Item을 생성할 수 있으며 이미지도 업로드 가능합니다. (이미지 업로드는 필수 X)")
     public ApiResponse<ItemResponseDTO.ItemJoinResultDTO> createItem(Authentication authentication,
                                                    @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
                                                                      @RequestPart("request") @Valid ItemRequestDTO.ItemJoinRequestDTO request,

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -32,7 +32,7 @@ public class ItemRestController {
     private final ItemCommandService itemCommandService;
     private final MemberCommandService memberCommandService;
 
-    private static final int DEFAULT_ITEM_PAGE_SIZE = 2;
+    private static final int DEFAULT_ITEM_PAGE_SIZE = 12;
 
     @GetMapping("/search")
     @Operation(summary = "전체 프로젝트 조회 API", description = "전체 프로젝트를 조회하는 API이며 페이징을 포함합니다. 요청 파라미터로 page 번호를 입력할 수 있습니다.")

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -1,16 +1,47 @@
 package umc.lightup.item.converter;
 
+import org.springframework.data.domain.Page;
 import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemImage;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.member.domain.Member;
 
+import java.util.List;
+
 public class ItemConverter {
     public static ItemResponseDTO.ItemJoinResultDTO toItemJoinResultDTO(Member member, Item item) {
         return ItemResponseDTO.ItemJoinResultDTO.builder()
                 .memberId(member.getId())
                 .itemName(item.getName())
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemResultDTO toItemResultDTO(Item item, String itemImageUrl) {
+        return ItemResponseDTO.ItemResultDTO.builder()
+                .itemName(item.getName())
+                .memberName(item.getMember().getName())
+                .itemImageUrl(itemImageUrl)
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemResultListDTO toItemResultListDTO(List<ItemResponseDTO.ItemResultDTO> itemResultDTOList) {
+        return ItemResponseDTO.ItemResultListDTO.builder()
+                .items(itemResultDTOList)
+                .build();
+    }
+
+    public static ItemResponseDTO.MyItemResultDTO toMyItemResultDTO(Item item, String itemImageUrl) {
+        return ItemResponseDTO.MyItemResultDTO.builder()
+                .itemName(item.getName())
+                .introduce(item.getIntroduce())
+                .itemImageUrl(itemImageUrl)
+                .build();
+    }
+
+    public static ItemResponseDTO.MyItemResultListDTO toMyItemResultListDTO(List<ItemResponseDTO.MyItemResultDTO> myItemResultDTOList){
+        return ItemResponseDTO.MyItemResultListDTO.builder()
+                .items(myItemResultDTOList)
                 .build();
     }
 

--- a/src/main/java/umc/lightup/item/domain/Item.java
+++ b/src/main/java/umc/lightup/item/domain/Item.java
@@ -5,6 +5,8 @@ import lombok.*;
 import umc.lightup.common.BaseEntity;
 import umc.lightup.member.domain.Member;
 
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -42,4 +44,7 @@ public class Item extends BaseEntity {
 
     @Column(name = "prefer_mbti", nullable = false, length = 30)
     private String preferMbti;
+
+    @OneToMany(mappedBy = "item", fetch = FetchType.LAZY)
+    private List<ItemImage> itemImages;
 }

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class ItemResponseDTO {
 
     @Getter
@@ -14,5 +16,41 @@ public class ItemResponseDTO {
     public static class ItemJoinResultDTO {
         Long memberId;
         String itemName;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemResultDTO {
+        String itemName;
+        String memberName;
+        String itemImageUrl;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemResultListDTO {
+        List<ItemResultDTO> items;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyItemResultDTO {
+        String itemName;
+        String introduce;
+        String itemImageUrl;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyItemResultListDTO {
+        List<MyItemResultDTO> items;
     }
 }

--- a/src/main/java/umc/lightup/item/repository/ItemRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepository.java
@@ -1,9 +1,18 @@
 package umc.lightup.item.repository;
 
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import umc.lightup.item.domain.Item;
+import umc.lightup.member.domain.Member;
+
+import java.util.List;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long> {
+    List<Item> findByMember(Member member);
+
+    Page<Item> findAll(Pageable pageable);
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -1,10 +1,18 @@
 package umc.lightup.item.service;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.item.domain.Item;
 import umc.lightup.item.dto.ItemRequestDTO;
+import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.member.domain.Member;
+
+import java.util.List;
 
 public interface ItemCommandService {
     Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile file);
+
+    List<ItemResponseDTO.ItemResultDTO> getAllItems(Pageable pageable);
+
+    List<ItemResponseDTO.MyItemResultDTO> getMyItems(Member member);
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -1,6 +1,8 @@
 package umc.lightup.item.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,12 +11,15 @@ import umc.lightup.common.Uuid;
 import umc.lightup.common.repository.UuidRepository;
 import umc.lightup.item.converter.ItemConverter;
 import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.ItemImage;
 import umc.lightup.item.dto.ItemRequestDTO;
+import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.item.repository.ItemImageRepository;
 import umc.lightup.item.repository.ItemRepository;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.repository.MemberRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -46,5 +51,37 @@ public class ItemCommandServiceImpl implements ItemCommandService {
         }
 
         return saveditem;
+    }
+
+    @Override
+    public List<ItemResponseDTO.ItemResultDTO> getAllItems(Pageable pageable) {
+        Page<Item> itemPage = itemRepository.findAll(pageable);
+
+        return itemPage.stream()
+                .map(item -> {
+                    String itemImageUrl = item.getItemImages().stream()
+                            .findFirst()
+                            .map(ItemImage::getImageUrl)
+                            .orElse(null);
+
+                    return ItemConverter.toItemResultDTO(item, itemImageUrl);
+                }).toList();
+    }
+
+    @Override
+    public List<ItemResponseDTO.MyItemResultDTO> getMyItems(Member member) {
+        List<Item> myItemList = itemRepository.findByMember(member);
+
+        return myItemList.stream()
+            .map(item -> {
+                //item에 이미지 저장 방식이나 어떤 이미지를 item의 프로필 이미지로 설정할 것 인지에 따라서 수정해야할 가능성 있음
+                String itemImageUrl = item.getItemImages().stream()
+                        .findFirst()
+                        .map(ItemImage::getImageUrl)
+                        .orElse(null);
+
+                return ItemConverter.toMyItemResultDTO(item, itemImageUrl);
+            })
+            .toList();
     }
 }

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -75,6 +75,7 @@ public class MemberRestController {
     }
 
     @PostMapping("/position")
+    @Operation(summary = "포지션 선택 API", description = "유저가 포지션을 선택하는 API 입니다.")
     public ApiResponse<MemberResponseDTO.MemberPositionResultDTO> selectMemberPosition(Authentication authentication, @RequestParam String positionName) {
         String userName = authentication.getName();
         Member member = memberCommandService.getMember(userName);
@@ -88,6 +89,7 @@ public class MemberRestController {
     }
 
     @DeleteMapping("/position")
+    @Operation(summary = "포지션 취소 API", description = "유저가 포지션 선택을 취소할 때 호출되는 API 입니다.")
     public ApiResponse<MemberResponseDTO.MemberPositionDeleteResultDTO> deleteMemberPosition(Authentication authentication, @RequestParam String positionName) {
         String userName = authentication.getName();
         Member member = memberCommandService.getMember(userName);

--- a/src/main/java/umc/lightup/position/controller/PositionRestController.java
+++ b/src/main/java/umc/lightup/position/controller/PositionRestController.java
@@ -1,5 +1,6 @@
 package umc.lightup.position.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,6 +20,7 @@ public class PositionRestController {
     private final PositionService positionService;
 
     @GetMapping
+    @Operation(summary = "포지션 목록 조회 API", description = "유저가 선택할 수 있는 포지션을 조회하는 API입니다.")
     public ApiResponse<PositionResponseDTO.positionListDTO> getPositions() {
         List<String> positionsList = positionService.getPositionsList();
         return ApiResponse.onSuccess(PositionConverter.toPositionListDTO(positionsList));

--- a/src/main/java/umc/lightup/region/controller/RegionRestController.java
+++ b/src/main/java/umc/lightup/region/controller/RegionRestController.java
@@ -1,5 +1,6 @@
 package umc.lightup.region.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,12 +21,15 @@ public class RegionRestController {
     private final RegionService regionService;
 
     @GetMapping("/sido")
+    @Operation(summary = "시/도 단위 지역 조회 API", description = "시/도 단위로 지역을 조회할 수 있는 API 입니다.")
     public ApiResponse<RegionReponseDTO.SiDoListDTO> getSiDo() {
         List<String> siDoList = regionService.getSiDoList();
         return ApiResponse.onSuccess(RegionConverter.toSiDoResultDTO(siDoList));
     }
 
     @GetMapping("/sigungu")
+    @Operation(summary = "시/군/구 단위 지역 조회 API",
+            description = "시/군/구 단위로 지역을 조회할 수 있는 API 입니다. 요청 파라미터로 시/도 값을 받아 해당 시/도 하위의 시/군/구를 조회할 수 있습니다.")
     public ApiResponse<RegionReponseDTO.SiGunGuListDTO> getSiGunGu(@RequestParam String sido) {
         List<String> siGunGuList = regionService.getSiGunGuList(sido);
         return ApiResponse.onSuccess(RegionConverter.toSiGunGuResultDTO(siGunGuList));

--- a/src/main/java/umc/lightup/skill/controller/SkillRestController.java
+++ b/src/main/java/umc/lightup/skill/controller/SkillRestController.java
@@ -24,7 +24,7 @@ public class SkillRestController {
 
     @GetMapping
     @Operation(
-            summary = "유저가 스킬을 조회하는 API",
+            summary = "유저의 스킬 조회 API",
             description = "유저가 스킬을 선택하기 전에 드롭다운으로 스킬을 조회하는 API입니다."
     )
     public ApiResponse<SkillResponseDTO.skillListDTO> getSkills() {
@@ -34,7 +34,7 @@ public class SkillRestController {
 
     @PostMapping
     @Operation(
-            summary = "유저가 커스텀 스킬을 생성하는 API",
+            summary = "유저의 커스텀 스킬 생성 API",
             description = "유저가 직접 스킬을 생성하고 선택하는 API입니다. 유저가 생성한 스킬은 생성과 동시에 선택됩니다."
     )
     public ApiResponse<SkillResponseDTO.createdSkillResultDTO> createCustomSkill(Authentication authentication,

--- a/src/main/java/umc/lightup/strength/controller/StrengthRestController.java
+++ b/src/main/java/umc/lightup/strength/controller/StrengthRestController.java
@@ -24,7 +24,7 @@ public class StrengthRestController {
 
     @GetMapping
     @Operation(
-            summary = "유저가 강점을 조회하는 API",
+            summary = "유저의 강점 조회 API",
             description = "유저가 강점을 선택하기 전에 드롭다운으로 강점들을 조회하는 API입니다."
     )
     public ApiResponse<StrengthResponseDTO.strengthListDTO> getStrengths() {
@@ -34,7 +34,7 @@ public class StrengthRestController {
 
     @PostMapping
     @Operation(
-            summary = "유저가 커스텀 강점을 생성하는 API",
+            summary = "유저의 커스텀 강점 생성 API",
             description = "유저가 직접 강점을 생성하고 선택하는 API입니다. 유저가 생성한 강점은 생성과 동시에 선택됩니다."
     )
     public ApiResponse<StrengthResponseDTO.createdStrengthResultDTO> createCustomStrength(Authentication authentication,


### PR DESCRIPTION
## 💫 PR 제목
- [Item] 전체 프로젝트 목록 조회 & 내 프로젝트 목록 조회 기능 구현

---

## 🔧 작업 내용 요약
- 전체 프로젝트 목록 조회는 비로그인 사용자도 조회가 가능하도록 구현하였으며 페이징을 포함합니다.
- 페이징의 경우에는 일단 최근에 생성된 프로젝트부터 보이도록 sort 하였는데 이는 추후에 좋아요 개수 같은 조건으로 정렬될 수 있습니다.
- 내 프로젝트 목록 조회는 페이징이 필요할 정도로 프로젝트 개수가 많지 않을 것으로 예상하여 페이징을 포함하진 않았습니다.


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 프로젝트 목록을 반환할때 item 객체의 값들과 추가적으로 프로젝트에 첨부한 사진인 itemImage 객체의 url 값도 가져오는데 이 부분의 로직이 적절한지 봐주시면 좋겠습니다.

---

## 🔗 관련 이슈
- 관련된 이슈 번호나 기능 이름을 작성해주세요.
- ex) closes #12

---

## 📝 기타 참고 사항
- 
