### PR TITLE
[Item & Region] 프로젝트 생성 기능 디자인에 맞게 구현

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -34,7 +34,13 @@ public enum ErrorStatus implements BaseErrorCode {
     //Strength 관련 에러
     DUPLICATED_STRENGTH_NAME(HttpStatus.BAD_REQUEST, "STRENGTH4000", "이미 존재하는 강점 이름입니다."),
     STRENGTH_NOT_FOUND(HttpStatus.NOT_FOUND, "STRENGTH4001", "강점이 존재하지 않습니다."),
-    DUPLICATED_STRENGTH_SELECT(HttpStatus.BAD_REQUEST, "STRENGTH4002", "이미 선택한 강점입니다.")
+    DUPLICATED_STRENGTH_SELECT(HttpStatus.BAD_REQUEST, "STRENGTH4002", "이미 선택한 강점입니다."),
+
+    //Item 관련 에러
+    ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM4000", "프로젝트가 존재하지 않습니다."),
+
+    //ItemImage 관련 에러
+    ITEM_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM_IMAGE4000", "아이템 이미지가 존재하지 않습니다.")
     ;
 
 

--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -22,6 +22,9 @@ public enum ErrorStatus implements BaseErrorCode {
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4004", "이미 존재하는 이메일입니다."),
     DUPLICATE_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "MEMBER4005", "이미 존재하는 휴대폰 번호입니다."),
     NO_CREDENTIAL(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER5000", "저장된 패스워드가 없습니다."),
+
+    //Region 관련 에러
+    REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION4000", "해당 지역이 존재하지 않습니다."),
   
     //Position 관련 에러
     POSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "POSITION4000", "포지션이 존재하지 않습니다."),

--- a/src/main/java/umc/lightup/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/umc/lightup/aws/s3/AmazonS3Manager.java
@@ -37,6 +37,10 @@ public class AmazonS3Manager {
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
     }
 
+    public String generateItemProfileImageKeyName(Uuid uuid) {
+        return amazonConfig.getItemProfileImagePath() + '/' + uuid.getUuid();
+    }
+
     public String generateItemFileKeyName(Uuid uuid) {
         return amazonConfig.getItemFilePath() + '/' + uuid.getUuid();
     }

--- a/src/main/java/umc/lightup/config/AmazonConfig.java
+++ b/src/main/java/umc/lightup/config/AmazonConfig.java
@@ -33,6 +33,9 @@ public class AmazonConfig {
     @Value("${cloud.aws.s3.path.profileImage}")
     private String profileImagePath;
 
+    @Value("${cloud.aws.s3.path.itemProfileImage}")
+    private String itemProfileImagePath;
+
     @Value("${cloud.aws.s3.path.itemFile}")
     private String itemFilePath;
 

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -53,14 +53,15 @@ public class ItemRestController {
     }
 
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
-    @Operation(summary = "본인 프로젝트 생성 API", description = "Item을 생성할 수 있으며 이미지도 업로드 가능합니다. (이미지 업로드는 필수 X)")
+    @Operation(summary = "본인 프로젝트 생성 API", description = "Item을 생성할 수 있으며 Item 프로필 이미지와 Item 기획서도 업로드 가능합니다. (요구사항이 Item 프로필 이미지, 기획서 업로드 필수)")
     public ApiResponse<ItemResponseDTO.ItemJoinResultDTO> createItem(
             Authentication authentication,
             @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
             @RequestPart("request") @Valid ItemRequestDTO.ItemJoinRequestDTO request,
-            @RequestPart(value = "itemImage", required = false)MultipartFile itemImage) {
+            @RequestPart(value = "itemProfileImage")MultipartFile itemProfileImage,
+            @RequestPart(value = "itemPlanFile")MultipartFile itemPlanFile) {
         Member member = memberCommandService.getMember(authentication.getName());
-        Item item = itemCommandService.createItem(member, request, itemImage);
+        Item item = itemCommandService.createItem(member, request, itemProfileImage, itemPlanFile);
         return ApiResponse.onSuccess(ItemConverter.toItemJoinResultDTO(member, item));
     }
 

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -54,12 +54,22 @@ public class ItemRestController {
 
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @Operation(summary = "본인 프로젝트 생성 API", description = "Item을 생성할 수 있으며 이미지도 업로드 가능합니다. (이미지 업로드는 필수 X)")
-    public ApiResponse<ItemResponseDTO.ItemJoinResultDTO> createItem(Authentication authentication,
-                                                   @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
-                                                                     @RequestPart("request") @Valid ItemRequestDTO.ItemJoinRequestDTO request,
-                                                   @RequestPart(value = "itemImage", required = false)MultipartFile itemImage) {
+    public ApiResponse<ItemResponseDTO.ItemJoinResultDTO> createItem(
+            Authentication authentication,
+            @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+            @RequestPart("request") @Valid ItemRequestDTO.ItemJoinRequestDTO request,
+            @RequestPart(value = "itemImage", required = false)MultipartFile itemImage) {
         Member member = memberCommandService.getMember(authentication.getName());
         Item item = itemCommandService.createItem(member, request, itemImage);
         return ApiResponse.onSuccess(ItemConverter.toItemJoinResultDTO(member, item));
+    }
+
+    @GetMapping("/{itemId}")
+    @Operation(summary = "특정 프로젝트 상세 조회 API", description = "특정 프로젝트를 상세 조회하는 API 입니다.")
+    public ApiResponse<ItemResponseDTO.ItemInfoDTO> getItemInfo(@PathVariable("itemId") @Min(1) Long itemId) {
+        Item findItem = itemCommandService.getSingleItem(itemId);
+        List<ItemResponseDTO.ItemRegionResultDTO> itemRegions = itemCommandService.getItemRegions(findItem);
+        List<ItemResponseDTO.RecruitPositionResultDTO> itemRecruitPositions = itemCommandService.getItemRecruitPositions(findItem);
+        return ApiResponse.onSuccess(ItemConverter.toItemInfoDTO(findItem, itemRegions, itemRecruitPositions));
     }
 }

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -1,6 +1,5 @@
 package umc.lightup.item.converter;
 
-import org.springframework.data.domain.Page;
 import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemImage;
 import umc.lightup.item.domain.RecruitPosition;
@@ -8,7 +7,6 @@ import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberRegion;
-import umc.lightup.region.domain.Region;
 
 import java.util.List;
 
@@ -67,8 +65,8 @@ public class ItemConverter {
 
     public static ItemResponseDTO.ItemRegionResultDTO toItemRegionResultDTO(MemberRegion memberRegion) {
         return ItemResponseDTO.ItemRegionResultDTO.builder()
-                .siDo(memberRegion.getRegion().getSido())
-                .siGunGu(memberRegion.getRegion().getSigungu())
+                .siDo(memberRegion.getRegion().getSiDo())
+                .siGunGu(memberRegion.getRegion().getSiGunGu())
                 .build();
     }
 
@@ -87,19 +85,17 @@ public class ItemConverter {
                 .member(member)
                 .name(request.getName())
                 .introduce(request.getIntroduce())
-                .projectStatus(request.getProjectStatus())
-                .collaboration(request.getCollaboration())
-                .address(request.getAddress())
-                .office(request.isOffice())
-                .preferMbti(request.getPreferMbti())
                 .description(request.getDescription())
+                .projectStatus(request.isProjectStatus())
+                .githubLink(request.getGithubLink())
+                .extraLinks(request.getExtraLinks())
                 .build();
     }
 
-    public static ItemImage toItemImage(Item item, String imageUrl) {
+/*    public static ItemImage toItemImage(Item item, String imageUrl) {
         return ItemImage.builder()
                 .item(item)
                 .imageUrl(imageUrl)
                 .build();
-    }
+    }*/
 }

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -3,9 +3,12 @@ package umc.lightup.item.converter;
 import org.springframework.data.domain.Page;
 import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemImage;
+import umc.lightup.item.domain.RecruitPosition;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.MemberRegion;
+import umc.lightup.region.domain.Region;
 
 import java.util.List;
 
@@ -42,6 +45,40 @@ public class ItemConverter {
     public static ItemResponseDTO.MyItemResultListDTO toMyItemResultListDTO(List<ItemResponseDTO.MyItemResultDTO> myItemResultDTOList){
         return ItemResponseDTO.MyItemResultListDTO.builder()
                 .items(myItemResultDTOList)
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemInfoDTO toItemInfoDTO(Item item, List<ItemResponseDTO.ItemRegionResultDTO> itemRegionResultDTOList, List<ItemResponseDTO.RecruitPositionResultDTO> recruitPositionResultDTOList) {
+        return ItemResponseDTO.ItemInfoDTO.builder()
+                .introduce(item.getIntroduce())
+                .itemName(item.getName())
+                .itemProfileImageUrl(item.getItemProfileImageUrl())
+                .memberName(item.getMember().getName())
+                .gender(item.getMember().getGender())
+                .age(item.getMember().getAge())
+                .mbti(item.getMember().getMbti())
+                .email(item.getMember().getEmail())
+                .school(item.getMember().getSchool())
+                .regions(itemRegionResultDTOList)
+                .description(item.getDescription())
+                .recruitPositions(recruitPositionResultDTOList)
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemRegionResultDTO toItemRegionResultDTO(MemberRegion memberRegion) {
+        return ItemResponseDTO.ItemRegionResultDTO.builder()
+                .siDo(memberRegion.getRegion().getSido())
+                .siGunGu(memberRegion.getRegion().getSigungu())
+                .build();
+    }
+
+    public static ItemResponseDTO.RecruitPositionResultDTO toRecruitPositionResultDTO(RecruitPosition recruitPosition) {
+        return ItemResponseDTO.RecruitPositionResultDTO.builder()
+                .positionName(recruitPosition.getPosition().getName())
+                .recruitNumber(recruitPosition.getRecruitNumber())
+                .mainTasks(recruitPosition.getMainTasks())
+                .preferentialTreatment(recruitPosition.getPreferentialTreatment())
+                .preferMbti(recruitPosition.getPreferMbti())
                 .build();
     }
 

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -87,8 +87,8 @@ public class ItemConverter {
                 .introduce(request.getIntroduce())
                 .description(request.getDescription())
                 .projectStatus(request.isProjectStatus())
-                .githubLink(request.getGithubLink())
-                .extraLinks(request.getExtraLinks())
+                .extraLink1(request.getExtraLink1())
+                .extraLink2(request.getExtraLink2())
                 .build();
     }
 

--- a/src/main/java/umc/lightup/item/domain/Item.java
+++ b/src/main/java/umc/lightup/item/domain/Item.java
@@ -28,7 +28,8 @@ public class Item extends BaseEntity {
     @Column(length = 50, nullable = false)
     private String introduce;
 
-    @Column(length = 3000, nullable = false)
+    @Lob
+    @Column(nullable = false)
     private String description;
 
     @Column(name = "project_status", nullable = false)
@@ -40,14 +41,11 @@ public class Item extends BaseEntity {
     @Column(nullable = false)
     private String itemPlanFileUrl;
 
-    @Column(name = "github_link")
-    private String githubLink;
+    @Column(name = "extra_link1")
+    private String extraLink1;
 
-    @Builder.Default
-    @ElementCollection
-    @CollectionTable(name = "item_extra_links", joinColumns = @JoinColumn(name = "item_id"))
-    @Column(name = "extra_link")
-    private List<String> extraLinks = new ArrayList<>();
+    @Column(name = "extra_link2")
+    private String extraLink2;
 
     @Builder.Default
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)

--- a/src/main/java/umc/lightup/item/domain/Item.java
+++ b/src/main/java/umc/lightup/item/domain/Item.java
@@ -5,6 +5,7 @@ import lombok.*;
 import umc.lightup.common.BaseEntity;
 import umc.lightup.member.domain.Member;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -27,26 +28,57 @@ public class Item extends BaseEntity {
     @Column(length = 50, nullable = false)
     private String introduce;
 
-    @Column(length = 80, nullable = false)
+    @Column(length = 3000, nullable = false)
     private String description;
 
-    @Column(name = "project_status", length = 50, nullable = false)
-    private String projectStatus;
+    @Column(name = "project_status", nullable = false)
+    private boolean projectStatus;
 
-    @Column(length = 50, nullable = false)
-    private String collaboration;
-
-    @Column(length = 30, nullable = false)
-    private String address;
-
-    @Column(length = 30, nullable = false)
-    private Boolean office;
-
-    @Column(name = "prefer_mbti", nullable = false, length = 30)
-    private String preferMbti;
-
+    @Column(nullable = false)
     private String itemProfileImageUrl;
 
-    @OneToMany(mappedBy = "item", fetch = FetchType.LAZY)
-    private List<ItemImage> itemImages;
+    @Column(nullable = false)
+    private String itemPlanFileUrl;
+
+    @Column(name = "github_link")
+    private String githubLink;
+
+    @Builder.Default
+    @ElementCollection
+    @CollectionTable(name = "item_extra_links", joinColumns = @JoinColumn(name = "item_id"))
+    @Column(name = "extra_link")
+    private List<String> extraLinks = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
+    private List<ItemRegion> itemRegions = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
+    private List<RecruitPosition> recruitPositions = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
+    private List<ItemImage> itemImages = new ArrayList<>();
+
+    //프로젝트에 프로젝트 프로필 이미지, 기획서를 제외하고 사진을 추가로 업로드 할 수 있게 하려면 itemImages도 필요함
+    public Item uploadItemProfile(String itemProfileImageUrl) {
+        this.itemProfileImageUrl = itemProfileImageUrl;
+        return this;
+    }
+
+    public Item uploadItemPlanFile(String itemPlanFileUrl) {
+        this.itemPlanFileUrl = itemPlanFileUrl;
+        return this;
+    }
+
+    public void addItemRegion(ItemRegion itemRegion) {
+        this.itemRegions.add(itemRegion);
+        itemRegion.assignItem(this);
+    }
+
+    public void addRecruitPosition(RecruitPosition recruitPosition) {
+        this.recruitPositions.add(recruitPosition);
+        recruitPosition.assignItem(this);
+    }
 }

--- a/src/main/java/umc/lightup/item/domain/Item.java
+++ b/src/main/java/umc/lightup/item/domain/Item.java
@@ -45,6 +45,8 @@ public class Item extends BaseEntity {
     @Column(name = "prefer_mbti", nullable = false, length = 30)
     private String preferMbti;
 
+    private String itemProfileImageUrl;
+
     @OneToMany(mappedBy = "item", fetch = FetchType.LAZY)
     private List<ItemImage> itemImages;
 }

--- a/src/main/java/umc/lightup/item/domain/ItemRegion.java
+++ b/src/main/java/umc/lightup/item/domain/ItemRegion.java
@@ -1,0 +1,29 @@
+package umc.lightup.item.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.lightup.common.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemRegion extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Column(nullable = false)
+    private String siDo;
+
+    private String siGunGu;
+
+    public void assignItem(Item item) {
+        this.item = item;
+    }
+}

--- a/src/main/java/umc/lightup/item/domain/RecruitPosition.java
+++ b/src/main/java/umc/lightup/item/domain/RecruitPosition.java
@@ -37,4 +37,8 @@ public class RecruitPosition extends BaseEntity {
 
     @Column(nullable = false)
     private Integer recruitNumber;
+
+    public void assignItem(Item item) {
+        this.item = item;
+    }
 }

--- a/src/main/java/umc/lightup/item/domain/RecruitPosition.java
+++ b/src/main/java/umc/lightup/item/domain/RecruitPosition.java
@@ -1,10 +1,18 @@
 package umc.lightup.item.domain;
 
 import jakarta.persistence.*;
+import lombok.*;
 import umc.lightup.common.BaseEntity;
+import umc.lightup.member.enums.Mbti;
 import umc.lightup.position.domain.Position;
 
+import java.util.List;
+
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecruitPosition extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,4 +25,16 @@ public class RecruitPosition extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "position_id", nullable = false)
     private Position position;
+
+    @Column(length = 3000, nullable = false)
+    private String mainTasks;
+
+    @Column(length = 1000)
+    private String preferentialTreatment;
+
+    @Column(length = 100)
+    private String preferMbti;
+
+    @Column(nullable = false)
+    private Integer recruitNumber;
 }

--- a/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
@@ -17,6 +17,8 @@ public class ItemRequestDTO {
         @NotBlank
         private String projectStatus;
         @NotBlank
+        private String description;
+        @NotBlank
         private String collaboration;
         @NotBlank
         private String address;
@@ -24,7 +26,5 @@ public class ItemRequestDTO {
         private boolean office;
         @NotBlank
         private String preferMbti;
-        @NotBlank
-        private String description;
     }
 }

--- a/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
@@ -22,17 +22,16 @@ public class ItemRequestDTO {
         private String name;
         @NotBlank
         private String introduce;
-        private String githubLink;
-        @Size(max = 2, message = "추가 링크는 2개까지 입력 가능합니다.")
-        private List<String> extraLinks;
+        private String extraLink1;
+        private String extraLink2;
         @NotBlank
         private String description;
-        @NotNull
         private boolean projectStatus;
         @Size(max = 3, message = "협업 지역은 최대 3개까지 선택할 수 있습니다.")
         @Valid
         private List<CollaborationRegionRequestDTO> collaborationRegions;
         @NotEmpty(message = "모집 포지션을 하나 이상 선택해야 합니다.")
+        @Valid
         private List<RecruitPositionRequestDTO> recruitPositions;
     }
 

--- a/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
@@ -1,9 +1,17 @@
 package umc.lightup.item.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import umc.lightup.position.validation.annotation.ExistPosition;
+import umc.lightup.region.validation.annotation.ExistSiDo;
+import umc.lightup.region.validation.annotation.ExistSiGunGu;
+
+import java.util.List;
 
 public class ItemRequestDTO {
 
@@ -14,17 +22,41 @@ public class ItemRequestDTO {
         private String name;
         @NotBlank
         private String introduce;
-        @NotBlank
-        private String projectStatus;
+        private String githubLink;
+        @Size(max = 2, message = "추가 링크는 2개까지 입력 가능합니다.")
+        private List<String> extraLinks;
         @NotBlank
         private String description;
-        @NotBlank
-        private String collaboration;
-        @NotBlank
-        private String address;
         @NotNull
-        private boolean office;
+        private boolean projectStatus;
+        @Size(max = 3, message = "협업 지역은 최대 3개까지 선택할 수 있습니다.")
+        @Valid
+        private List<CollaborationRegionRequestDTO> collaborationRegions;
+        @NotEmpty(message = "모집 포지션을 하나 이상 선택해야 합니다.")
+        private List<RecruitPositionRequestDTO> recruitPositions;
+    }
+
+    @Getter
+    @Setter
+    public static class CollaborationRegionRequestDTO {
         @NotBlank
+        @ExistSiDo
+        private String siDo;
+        @ExistSiGunGu
+        private String siGunGu;
+    }
+
+    @Getter
+    @Setter
+    public static class RecruitPositionRequestDTO {
+        @NotNull
+        @ExistPosition
+        private Long positionId;
+        @NotBlank
+        private String mainTasks;
+        private String preferentialTreatment;
         private String preferMbti;
+        @NotNull
+        private Integer recruitNumber;
     }
 }

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.lightup.member.enums.Gender;
+import umc.lightup.member.enums.Mbti;
 
 import java.util.List;
 
@@ -52,5 +54,45 @@ public class ItemResponseDTO {
     @AllArgsConstructor
     public static class MyItemResultListDTO {
         List<MyItemResultDTO> items;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemInfoDTO {
+        private String introduce;
+        private String itemName;
+        private String itemProfileImageUrl;
+        private String memberName;
+        private boolean gender;
+        private int age;
+        private Mbti mbti;
+        private String email;
+        private String school;
+        private List<ItemRegionResultDTO> regions;
+        private String description;
+        private List<RecruitPositionResultDTO> recruitPositions;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemRegionResultDTO {
+        private String siDo;
+        private String siGunGu;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecruitPositionResultDTO {
+        private String positionName;
+        private Integer recruitNumber;
+        private String mainTasks;
+        private String preferentialTreatment;
+        private String preferMbti;
     }
 }

--- a/src/main/java/umc/lightup/item/repository/ItemImageRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemImageRepository.java
@@ -2,8 +2,12 @@ package umc.lightup.item.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemImage;
+
+import java.util.Optional;
 
 @Repository
 public interface ItemImageRepository extends JpaRepository<ItemImage, Long> {
+    Optional<ItemImage> findByItem(Item item);
 }

--- a/src/main/java/umc/lightup/item/repository/RecruitPositionRepository.java
+++ b/src/main/java/umc/lightup/item/repository/RecruitPositionRepository.java
@@ -1,0 +1,13 @@
+package umc.lightup.item.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.RecruitPosition;
+
+import java.util.List;
+
+@Repository
+public interface RecruitPositionRepository extends JpaRepository<RecruitPosition, Long> {
+    List<RecruitPosition> findByItem(Item item);
+}

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -10,7 +10,7 @@ import umc.lightup.member.domain.Member;
 import java.util.List;
 
 public interface ItemCommandService {
-    Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile file);
+    Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile itemProfileImage, MultipartFile itemPlanFile);
     Item getSingleItem(Long itemId);
 
     List<ItemResponseDTO.ItemResultDTO> getAllItems(Pageable pageable);

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -11,8 +11,13 @@ import java.util.List;
 
 public interface ItemCommandService {
     Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile file);
+    Item getSingleItem(Long itemId);
 
     List<ItemResponseDTO.ItemResultDTO> getAllItems(Pageable pageable);
 
     List<ItemResponseDTO.MyItemResultDTO> getMyItems(Member member);
+
+    List<ItemResponseDTO.ItemRegionResultDTO> getItemRegions(Item item);
+
+    List<ItemResponseDTO.RecruitPositionResultDTO> getItemRecruitPositions(Item item);
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -13,15 +13,16 @@ import umc.lightup.common.repository.UuidRepository;
 import umc.lightup.exception.handler.GeneralHandler;
 import umc.lightup.item.converter.ItemConverter;
 import umc.lightup.item.domain.Item;
-import umc.lightup.item.domain.ItemImage;
+import umc.lightup.item.domain.ItemRegion;
+import umc.lightup.item.domain.RecruitPosition;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
-import umc.lightup.item.repository.ItemImageRepository;
 import umc.lightup.item.repository.ItemRepository;
 import umc.lightup.item.repository.RecruitPositionRepository;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.repository.MemberRegionRepository;
-import umc.lightup.member.repository.MemberRepository;
+import umc.lightup.position.domain.Position;
+import umc.lightup.position.repository.PositionRepository;
 
 import java.util.List;
 import java.util.UUID;
@@ -32,31 +33,64 @@ import java.util.UUID;
 public class ItemCommandServiceImpl implements ItemCommandService {
 
     private final ItemRepository itemRepository;
-    private final MemberRepository memberRepository;
-    private final ItemImageRepository itemImageRepository;
     private final MemberRegionRepository memberRegionRepository;
     private final RecruitPositionRepository recruitPositionRepository;
+    private final PositionRepository positionRepository;
 
     private final AmazonS3Manager s3Manager;
     private final UuidRepository uuidRepository;
 
     @Override
     @Transactional
-    public Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile file) {
+    public Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile itemProfileImage, MultipartFile itemPlanFile) {
         Item item = ItemConverter.toItem(request, member);
 
-        Item saveditem = itemRepository.save(item);
-
-        if (file != null) {
+        if (itemProfileImage != null) {
             String uuid = UUID.randomUUID().toString();
             Uuid savedUuid = uuidRepository.save(Uuid.builder()
                     .uuid(uuid).build());
 
-            String fileUrl = s3Manager.uploadFile(s3Manager.generateItemFileKeyName(savedUuid), file);
-            itemImageRepository.save(ItemConverter.toItemImage(item, fileUrl));
+            String itemProfileImageUrl = s3Manager.uploadFile(s3Manager.generateItemProfileImageKeyName(savedUuid), itemProfileImage);
+            item.uploadItemProfile(itemProfileImageUrl);
         }
 
-        return saveditem;
+        if (itemPlanFile != null) {
+            String uuid = UUID.randomUUID().toString();
+            Uuid savedUuid = uuidRepository.save(Uuid.builder()
+                    .uuid(uuid).build());
+
+            String itemPlanFileUrl = s3Manager.uploadFile(s3Manager.generateItemFileKeyName(savedUuid), itemPlanFile);
+            item.uploadItemPlanFile(itemPlanFileUrl);
+        }
+
+        for (ItemRequestDTO.CollaborationRegionRequestDTO dto : request.getCollaborationRegions()) {
+            ItemRegion itemRegion = ItemRegion.builder()
+                    .item(item)
+                    .siDo(dto.getSiDo())
+                    .siGunGu(dto.getSiGunGu() == null ? "전체" : dto.getSiGunGu())
+                    .build();
+
+            item.addItemRegion(itemRegion);
+        }
+
+        for (ItemRequestDTO.RecruitPositionRequestDTO dto : request.getRecruitPositions()) {
+            Long positionId = dto.getPositionId();
+            Position position = positionRepository.findById(positionId)
+                    .orElseThrow(() -> new GeneralHandler(ErrorStatus.POSITION_NOT_FOUND));
+
+            RecruitPosition recruitPosition = RecruitPosition.builder()
+                    .item(item)
+                    .position(position)
+                    .mainTasks(dto.getMainTasks())
+                    .preferentialTreatment(dto.getPreferentialTreatment())
+                    .preferMbti(dto.getPreferMbti())
+                    .recruitNumber(dto.getRecruitNumber())
+                    .build();
+
+            item.addRecruitPosition(recruitPosition);
+        }
+
+        return itemRepository.save(item);
     }
 
     @Override
@@ -65,10 +99,7 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
         return itemPage.stream()
                 .map(item -> {
-                    String itemImageUrl = item.getItemImages().stream()
-                            .findFirst()
-                            .map(ItemImage::getImageUrl)
-                            .orElse(null);
+                    String itemImageUrl = item.getItemProfileImageUrl();
 
                     return ItemConverter.toItemResultDTO(item, itemImageUrl);
                 }).toList();
@@ -80,11 +111,7 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
         return myItemList.stream()
             .map(item -> {
-                //item에 이미지 저장 방식이나 어떤 이미지를 item의 프로필 이미지로 설정할 것 인지에 따라서 수정해야할 가능성 있음
-                String itemImageUrl = item.getItemImages().stream()
-                        .findFirst()
-                        .map(ItemImage::getImageUrl)
-                        .orElse(null);
+                String itemImageUrl = item.getItemProfileImageUrl();
 
                 return ItemConverter.toMyItemResultDTO(item, itemImageUrl);
             })

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -6,9 +6,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import umc.lightup.api.code.status.ErrorStatus;
 import umc.lightup.aws.s3.AmazonS3Manager;
 import umc.lightup.common.Uuid;
 import umc.lightup.common.repository.UuidRepository;
+import umc.lightup.exception.handler.GeneralHandler;
 import umc.lightup.item.converter.ItemConverter;
 import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemImage;
@@ -16,7 +18,9 @@ import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.item.repository.ItemImageRepository;
 import umc.lightup.item.repository.ItemRepository;
+import umc.lightup.item.repository.RecruitPositionRepository;
 import umc.lightup.member.domain.Member;
+import umc.lightup.member.repository.MemberRegionRepository;
 import umc.lightup.member.repository.MemberRepository;
 
 import java.util.List;
@@ -30,6 +34,8 @@ public class ItemCommandServiceImpl implements ItemCommandService {
     private final ItemRepository itemRepository;
     private final MemberRepository memberRepository;
     private final ItemImageRepository itemImageRepository;
+    private final MemberRegionRepository memberRegionRepository;
+    private final RecruitPositionRepository recruitPositionRepository;
 
     private final AmazonS3Manager s3Manager;
     private final UuidRepository uuidRepository;
@@ -83,5 +89,27 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                 return ItemConverter.toMyItemResultDTO(item, itemImageUrl);
             })
             .toList();
+    }
+
+    @Override
+    public Item getSingleItem(Long itemId) {
+        return itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND));
+    }
+
+    @Override
+    public List<ItemResponseDTO.ItemRegionResultDTO> getItemRegions(Item item) {
+        Member member = item.getMember();
+
+        return memberRegionRepository.findByMember(member).stream()
+                .map(ItemConverter::toItemRegionResultDTO)
+                .toList();
+    }
+
+    @Override
+    public List<ItemResponseDTO.RecruitPositionResultDTO> getItemRecruitPositions(Item item) {
+        return recruitPositionRepository.findByItem(item).stream()
+                .map(ItemConverter::toRecruitPositionResultDTO)
+                .toList();
     }
 }

--- a/src/main/java/umc/lightup/member/domain/MemberRegion.java
+++ b/src/main/java/umc/lightup/member/domain/MemberRegion.java
@@ -1,14 +1,12 @@
 package umc.lightup.member.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import umc.lightup.common.BaseEntity;
 import umc.lightup.region.domain.Region;
 
 @Entity
+@Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
+++ b/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
@@ -43,7 +43,7 @@ public class MemberViewInfo {
                 .skills(skills)
                 .strengths(strengths)
                 .regions(regions.stream()
-                        .map(r->r.getSido()+" "+r.getSigungu())
+                        .map(r->r.getSiDo()+" "+r.getSiGunGu())
                         .toList())
                 .portfolios(portfolios.stream()
                         .map(portfolio -> MemberResponseDTO.PortfolioInfoDTO.builder()

--- a/src/main/java/umc/lightup/member/repository/MemberRegionRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberRegionRepository.java
@@ -2,8 +2,12 @@ package umc.lightup.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberRegion;
+
+import java.util.List;
 
 @Repository
 public interface MemberRegionRepository extends JpaRepository<MemberRegion, Long> {
+    List<MemberRegion> findByMember(Member member);
 }

--- a/src/main/java/umc/lightup/position/service/PositionService.java
+++ b/src/main/java/umc/lightup/position/service/PositionService.java
@@ -19,4 +19,8 @@ public class PositionService {
                 .map(Position::getName)
                 .toList();
     }
+
+    public boolean isPositionExist(Long value) {
+        return positionRepository.existsById(value);
+    }
 }

--- a/src/main/java/umc/lightup/position/validation/annotation/ExistPosition.java
+++ b/src/main/java/umc/lightup/position/validation/annotation/ExistPosition.java
@@ -1,0 +1,18 @@
+package umc.lightup.position.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.lightup.position.validation.validator.PositionExistValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PositionExistValidator.class)
+@Target( {ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistPosition {
+
+    String message() default "해당하는 포지션이 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/lightup/position/validation/validator/PositionExistValidator.java
+++ b/src/main/java/umc/lightup/position/validation/validator/PositionExistValidator.java
@@ -1,0 +1,35 @@
+package umc.lightup.position.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.position.validation.annotation.ExistPosition;
+import umc.lightup.position.service.PositionService;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PositionExistValidator implements ConstraintValidator<ExistPosition, Long> {
+
+    private final PositionService positionService;
+
+    @Override
+    public void initialize(ExistPosition constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isValid = positionService.isPositionExist(value);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.POSITION_NOT_FOUND.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/umc/lightup/region/controller/RegionRestController.java
+++ b/src/main/java/umc/lightup/region/controller/RegionRestController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import umc.lightup.api.ApiResponse;
 import umc.lightup.region.converter.RegionConverter;
-import umc.lightup.region.dto.RegionReponseDTO;
+import umc.lightup.region.dto.RegionResponseDTO;
 import umc.lightup.region.service.RegionService;
 
 import java.util.List;
@@ -22,7 +22,7 @@ public class RegionRestController {
 
     @GetMapping("/sido")
     @Operation(summary = "시/도 단위 지역 조회 API", description = "시/도 단위로 지역을 조회할 수 있는 API 입니다.")
-    public ApiResponse<RegionReponseDTO.SiDoListDTO> getSiDo() {
+    public ApiResponse<RegionResponseDTO.SiDoListDTO> getSiDo() {
         List<String> siDoList = regionService.getSiDoList();
         return ApiResponse.onSuccess(RegionConverter.toSiDoResultDTO(siDoList));
     }
@@ -30,8 +30,8 @@ public class RegionRestController {
     @GetMapping("/sigungu")
     @Operation(summary = "시/군/구 단위 지역 조회 API",
             description = "시/군/구 단위로 지역을 조회할 수 있는 API 입니다. 요청 파라미터로 시/도 값을 받아 해당 시/도 하위의 시/군/구를 조회할 수 있습니다.")
-    public ApiResponse<RegionReponseDTO.SiGunGuListDTO> getSiGunGu(@RequestParam String sido) {
-        List<String> siGunGuList = regionService.getSiGunGuList(sido);
+    public ApiResponse<RegionResponseDTO.SiGunGuListDTO> getSiGunGu(@RequestParam String siDo) {
+        List<String> siGunGuList = regionService.getSiGunGuList(siDo);
         return ApiResponse.onSuccess(RegionConverter.toSiGunGuResultDTO(siGunGuList));
     }
 }

--- a/src/main/java/umc/lightup/region/converter/RegionConverter.java
+++ b/src/main/java/umc/lightup/region/converter/RegionConverter.java
@@ -1,20 +1,20 @@
 package umc.lightup.region.converter;
 
-import umc.lightup.region.dto.RegionReponseDTO;
+import umc.lightup.region.dto.RegionResponseDTO;
 
 import java.util.List;
 
 public class RegionConverter {
 
-    public static RegionReponseDTO.SiDoListDTO toSiDoResultDTO(List<String> sidoList) {
-        return RegionReponseDTO.SiDoListDTO.builder()
-                .sido(sidoList)
+    public static RegionResponseDTO.SiDoListDTO toSiDoResultDTO(List<String> siDoList) {
+        return RegionResponseDTO.SiDoListDTO.builder()
+                .siDo(siDoList)
                 .build();
     }
 
-    public static RegionReponseDTO.SiGunGuListDTO toSiGunGuResultDTO(List<String> sigunguList) {
-        return RegionReponseDTO.SiGunGuListDTO.builder()
-                .sigungu(sigunguList)
+    public static RegionResponseDTO.SiGunGuListDTO toSiGunGuResultDTO(List<String> siGunGuList) {
+        return RegionResponseDTO.SiGunGuListDTO.builder()
+                .siGunGu(siGunGuList)
                 .build();
     }
 }

--- a/src/main/java/umc/lightup/region/domain/Region.java
+++ b/src/main/java/umc/lightup/region/domain/Region.java
@@ -14,9 +14,9 @@ public class Region {
     private Long id;
 
     @Column(nullable = false, length = 20)
-    private String sido;
+    private String siDo;
 
     @Column(nullable = false, length = 30)
-    private String sigungu;
+    private String siGunGu;
 
 }

--- a/src/main/java/umc/lightup/region/dto/RegionResponseDTO.java
+++ b/src/main/java/umc/lightup/region/dto/RegionResponseDTO.java
@@ -7,14 +7,14 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
-public class RegionReponseDTO {
+public class RegionResponseDTO {
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SiDoListDTO {
-        List<String> sido;
+        List<String> siDo;
     }
 
     @Builder
@@ -22,6 +22,6 @@ public class RegionReponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SiGunGuListDTO {
-        List<String> sigungu;
+        List<String> siGunGu;
     }
 }

--- a/src/main/java/umc/lightup/region/repository/RegionRepository.java
+++ b/src/main/java/umc/lightup/region/repository/RegionRepository.java
@@ -10,11 +10,14 @@ import java.util.List;
 
 public interface RegionRepository extends JpaRepository<Region, Long> {
 
-    @Query("SELECT DISTINCT r.sido FROM Region r")
-    List<String> findDistinctSido();
+    @Query("SELECT DISTINCT r.siDo FROM Region r")
+    List<String> findDistinctSiDo();
 
-    List<Region> findBySido(String sido);
+    List<Region> findBySiDo(String siDo);
 
     @Query("select r from MemberRegion mr join mr.region r where mr.member=:member")
     List<Region> findByMember(@Param("member") Member member);
+
+    boolean existsBySiDo(String siDo);
+    boolean existsBySiGunGu(String siGunGu);
 }

--- a/src/main/java/umc/lightup/region/service/RegionService.java
+++ b/src/main/java/umc/lightup/region/service/RegionService.java
@@ -14,14 +14,22 @@ public class RegionService {
     private final RegionRepository regionRepository;
 
     public List<String> getSiDoList() {
-        return regionRepository.findDistinctSido();
+        return regionRepository.findDistinctSiDo();
     }
 
-    public List<String> getSiGunGuList(String sido) {
-        List<Region> regionList = regionRepository.findBySido(sido);
+    public List<String> getSiGunGuList(String siDo) {
+        List<Region> regionList = regionRepository.findBySiDo(siDo);
         return regionList.stream()
-                .map(Region::getSigungu)
+                .map(Region::getSiGunGu)
                 .distinct()
                 .toList();
+    }
+
+    public boolean isSiDoExist(String value) {
+        return regionRepository.existsBySiDo(value);
+    }
+
+    public boolean isSiGunGuExist(String value) {
+        return regionRepository.existsBySiGunGu(value);
     }
 }

--- a/src/main/java/umc/lightup/region/validation/annotation/ExistSiDo.java
+++ b/src/main/java/umc/lightup/region/validation/annotation/ExistSiDo.java
@@ -1,0 +1,18 @@
+package umc.lightup.region.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.lightup.region.validation.validator.SiDoExistValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = SiDoExistValidator.class)
+@Target( {ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistSiDo {
+
+    String message() default "해당하는 시/도가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/lightup/region/validation/annotation/ExistSiGunGu.java
+++ b/src/main/java/umc/lightup/region/validation/annotation/ExistSiGunGu.java
@@ -1,0 +1,18 @@
+package umc.lightup.region.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.lightup.region.validation.validator.SiGunGuExistValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = SiGunGuExistValidator.class)
+@Target( {ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistSiGunGu {
+
+    String message() default "해당하는 시/군/구가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/lightup/region/validation/validator/SiDoExistValidator.java
+++ b/src/main/java/umc/lightup/region/validation/validator/SiDoExistValidator.java
@@ -1,0 +1,34 @@
+package umc.lightup.region.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.region.service.RegionService;
+import umc.lightup.region.validation.annotation.ExistSiDo;
+
+@Component
+@RequiredArgsConstructor
+public class SiDoExistValidator implements ConstraintValidator<ExistSiDo, String> {
+
+    private final RegionService regionService;
+
+    @Override
+    public void initialize(ExistSiDo constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.trim().isEmpty()) return true;
+        boolean isValid = regionService.isSiDoExist(value);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.REGION_NOT_FOUND.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/umc/lightup/region/validation/validator/SiGunGuExistValidator.java
+++ b/src/main/java/umc/lightup/region/validation/validator/SiGunGuExistValidator.java
@@ -1,0 +1,35 @@
+package umc.lightup.region.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.region.service.RegionService;
+import umc.lightup.region.validation.annotation.ExistSiGunGu;
+
+@Component
+@RequiredArgsConstructor
+public class SiGunGuExistValidator implements ConstraintValidator<ExistSiGunGu, String> {
+
+    private final RegionService regionService;
+
+    @Override
+    public void initialize(ExistSiGunGu constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.trim().isEmpty()) return true;
+
+        boolean isValid = regionService.isSiGunGuExist(value);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.REGION_NOT_FOUND.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}


### PR DESCRIPTION
## 💫 PR 제목
- [Item & Region] 프로젝트 생성 기능 디자인에 맞게 구현

---

## 🔧 작업 내용 요약
- 프로젝트 생성시에 추가 링크 (블로그 or 노션 링크 등등), 프로젝트 지역, 모집 포지션까지 선택 가능하도록 변경했습니다.


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- ItemJoinRequestDTO 내부에 협업 지역과 모집 포지션을 또 다른 DTO List로 받아서 처리했는데 이 부분이 저도 작업하면서 좀 어지러웠습니다. 
- 검증까지 하긴 했는데 제대로 된 건지 확실치 않네요.
- 현재 지역 데이터가 si_do, si_gun_gu 형식으로 되어 있어서 request를 받을때 regionId로 받는 것이 불가능하여 String으로 시/도와 시/군/구를 받아와서 검증하는 식으로 처리했습니다.
- 지역 데이터도 변경이 필요할지 필요하다면 어떤 쪽으로 변경하는게 좋을지 아니면 이건 후순위 작업으로 미뤄둘지 고민이 많습니다...
다른 것도 할게 많아서

---

## 🔗 관련 이슈


---

## 📝 기타 참고 사항

