### PR TITLE
[Member] 이메일 발송 및 비밀번호 초기화 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf' // 이메일 템플릿 설정용
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -43,7 +43,10 @@ public enum ErrorStatus implements BaseErrorCode {
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM4000", "프로젝트가 존재하지 않습니다."),
 
     //ItemImage 관련 에러
-    ITEM_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM_IMAGE4000", "아이템 이미지가 존재하지 않습니다.")
+    ITEM_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM_IMAGE4000", "아이템 이미지가 존재하지 않습니다."),
+
+    //Email 관련 에러
+    EMAIL_SEND_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "EMAIL5003", "이메일 전송에 실패했습니다.")
     ;
 
 

--- a/src/main/java/umc/lightup/config/EmailService.java
+++ b/src/main/java/umc/lightup/config/EmailService.java
@@ -2,7 +2,6 @@ package umc.lightup.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.mail.Message;
-import jakarta.mail.MessagingException;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +39,7 @@ public class EmailService {
             message.addRecipient(Message.RecipientType.TO, new InternetAddress(to));
             message.setText(content, "utf-8", "html");
             javaMailSender.send(message);
-        } catch (MessagingException e) {
+        } catch (Exception e) {
             throw new GeneralHandler(ErrorStatus.EMAIL_SEND_FAIL);
         }
     }

--- a/src/main/java/umc/lightup/config/EmailService.java
+++ b/src/main/java/umc/lightup/config/EmailService.java
@@ -1,0 +1,72 @@
+package umc.lightup.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.exception.handler.GeneralHandler;
+
+import java.util.Locale;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+    private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * HTML(MIME)의 형태로 이메일을 전송함
+     * @param to 수신 주소(보낼 주소)
+     * @param title 이메일의 제목
+     * @param content 이메일의 내용(HTML 형식)
+     * @throws GeneralHandler 이메일 전송 실패 시
+     */
+    @Async
+    public void sendEmailMime(String to, String title, String content) {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        try {
+            message.setSubject(title);
+            message.addRecipient(Message.RecipientType.TO, new InternetAddress(to));
+            message.setText(content, "utf-8", "html");
+            javaMailSender.send(message);
+        } catch (MessagingException e) {
+            throw new GeneralHandler(ErrorStatus.EMAIL_SEND_FAIL);
+        }
+    }
+
+    /**
+     * HTML(MIME)의 형태로 이메일을 전송함
+     * @param to 수신 주소(보낼 주소)
+     * @param title 이메일의 제목
+     * @param templateName 템플릿 파일 이름
+     * @param variables 템플릿 값 설정
+     * @throws GeneralHandler 이메일 전송 실패 시
+     */
+    @SuppressWarnings("unchecked")
+    @Async
+    public void sendEmailTemplate(String to, String title, String templateName, Object variables) {
+        Context context = new Context(Locale.KOREA, objectMapper.convertValue(variables, Map.class));
+        String html = templateEngine.process(templateName, context);
+        try {
+            MimeMessage mail = javaMailSender.createMimeMessage();
+            MimeMessageHelper message = new MimeMessageHelper(mail, true, "utf-8");
+            message.setSubject(title);
+            message.setTo(to);
+            message.setText(html, true);
+            javaMailSender.send(mail);
+        } catch (Exception e) {
+            throw new GeneralHandler(ErrorStatus.EMAIL_SEND_FAIL);
+        }
+    }
+}

--- a/src/main/java/umc/lightup/config/SecurityConfig.java
+++ b/src/main/java/umc/lightup/config/SecurityConfig.java
@@ -12,6 +12,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import java.security.SecureRandom;
+
 @EnableWebSecurity
 @Configuration
 @RequiredArgsConstructor
@@ -40,5 +42,10 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecureRandom secureRandom() {
+        return new SecureRandom();
     }
 }

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -11,7 +11,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import umc.lightup.api.ApiResponse;
 import umc.lightup.api.code.status.SuccessStatus;
-import umc.lightup.member.domain.Credential;
 import umc.lightup.member.converter.MemberConverter;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.dto.MemberRequestDTO;
@@ -131,6 +130,17 @@ public class MemberRestController {
         credentialQueryService.updatePasswordByEmail(email, request);
         return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
         //null 반환이 과연 옳은가? 물론 이 null 안 쓰려면 응답 통일 형식부터 갈아엎어야 하는 대공사가 필요하긴 함
+    }
+
+    @PostMapping("/password/initialize")
+    @ResponseStatus(HttpStatus.NO_CONTENT) //명시적으로 쓰기 싫었는데 안 쓰니 200 OK가 나가버리네...
+    @Operation(
+            summary = "비밀번호 초기화 API",
+            description = "비밀번호를 변경하는 API입니다. 사용자가 비밀번호를 잊었을 때 사용합니다."
+    )
+    public ApiResponse<Void> passwordInitialize(@RequestParam @NotBlank @Email String email) {
+        credentialQueryService.initializePasswordByEmail(email);
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
     }
 
     @PostMapping("/email/exist")

--- a/src/main/java/umc/lightup/member/dto/EmailRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/EmailRequestDTO.java
@@ -1,0 +1,18 @@
+package umc.lightup.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class EmailRequestDTO {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    // 템플릿 이름: password-reset
+    public static class PasswordInitializeDTO {
+        String userName;
+        String tempPassword;
+    }
+}

--- a/src/main/java/umc/lightup/member/service/CredentialQueryService.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryService.java
@@ -1,10 +1,10 @@
 package umc.lightup.member.service;
 
-import org.springframework.transaction.annotation.Transactional;
 import umc.lightup.member.domain.Credential;
 import umc.lightup.member.dto.MemberRequestDTO;
 
 public interface CredentialQueryService {
     Credential findByEmail(String email);
     Credential updatePasswordByEmail(String email, MemberRequestDTO.PasswordChangeRequestDTO request);
+    void initializePasswordByEmail(String email);
 }

--- a/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
@@ -5,12 +5,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.config.EmailService;
 import umc.lightup.exception.handler.GeneralHandler;
 import umc.lightup.member.domain.Credential;
+import umc.lightup.member.dto.EmailRequestDTO;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.enums.CredentialType;
 import umc.lightup.member.repository.CredentialRepository;
 
+import java.security.SecureRandom;
 import java.util.Optional;
 
 @Service
@@ -18,7 +21,9 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class CredentialQueryServiceImpl implements CredentialQueryService {
     private final CredentialRepository credentialRepository;
+    private final EmailService emailService;
     private final PasswordEncoder passwordEncoder;
+    private final SecureRandom secureRandom;
 
     @Override
     public Credential findByEmail(String email) {
@@ -41,5 +46,41 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
         target.setCredential(passwordEncoder.encode(request.getNewPassword()));
         credentialRepository.save(target);
         return target;
+    }
+
+
+    private static final String PASSWORD_CHARACTERS =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*-_=+;,.<>?";
+    private static final int PASSWORD_INITIALIZE_LENGTH = 16;
+
+    /**
+     * 이메일을 받아 사용자의 비밀번호를 초기화한 후 메일을 발송함
+     * @param email 사용자의 이메일
+     */
+    @Override
+    @Transactional
+    public void initializePasswordByEmail(String email) {
+        Credential target = credentialRepository.findByCredentialTypeAndEmail(CredentialType.PASSWORD, email)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 무작위 생성
+        StringBuilder newPassword = new StringBuilder(PASSWORD_INITIALIZE_LENGTH);
+        for (int i = 0; i < PASSWORD_INITIALIZE_LENGTH; i++)
+            newPassword.append(PASSWORD_CHARACTERS.charAt(secureRandom.nextInt(PASSWORD_CHARACTERS.length())));
+        String newPasswordString = newPassword.toString();
+
+        // 메일 전송
+        EmailRequestDTO.PasswordInitializeDTO initializeDTO = EmailRequestDTO.PasswordInitializeDTO.builder()
+                .userName(target.getMember().getName())
+                .tempPassword(newPasswordString)
+                .build();
+        emailService.sendEmailTemplate(target.getMember().getEmail(),
+                "[Lightup] 비밀번호 재설정 안내",
+                "password-reset",
+                initializeDTO);
+
+        // 비밀번호 재설정
+        target.setCredential(passwordEncoder.encode(newPasswordString));
+        credentialRepository.save(target);
     }
 }

--- a/src/main/resources/templates/password-reset.html
+++ b/src/main/resources/templates/password-reset.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>비밀번호 초기화 안내</title>
+</head>
+<body>
+<h2 th:text="${userName} + '님, 비밀번호가 초기화되었습니다.'">고객님, 비밀번호가 초기화되었습니다.</h2>
+<p>임시 비밀번호: <b th:text="${tempPassword}">password</b></p>
+<p>임시 비밀번호로 로그인 이후 비밀번호를 변경해 주세요.</p>
+<p>감사합니다.</p>
+</body>
+</html>

--- a/src/test/java/umc/lightup/members/MemberTest.java
+++ b/src/test/java/umc/lightup/members/MemberTest.java
@@ -135,22 +135,22 @@ public class MemberTest {
         //Region에 Builder 넣기 싫은데...
 
         Region region1 = Region.builder()
-                .sido("시도1")
-                .sigungu("시군구1")
+                .siDo("시도1")
+                .siGunGu("시군구1")
                 .build();
         regionRepository.save(region1);
         assertSame(1L, region1.getId());
 
         Region region2 = Region.builder()
-                .sido("시도2")
-                .sigungu("시군구2")
+                .siDo("시도2")
+                .siGunGu("시군구2")
                 .build();
         regionRepository.save(region2);
         assertSame(2L, region2.getId());
 
         Region region3 = Region.builder()
-                .sido("시도3")
-                .sigungu("시군구3")
+                .siDo("시도3")
+                .siGunGu("시군구3")
                 .build();
         regionRepository.save(region3);
         assertSame(3L, region3.getId());
@@ -452,7 +452,7 @@ public class MemberTest {
         assertIterableEquals(
                 regionSet.stream().map(regionId -> {
                     Region region = regionRepository.findById(regionId).get();
-                    return region.getSido() + " " + region.getSigungu();
+                    return region.getSiDo() + " " + region.getSiGunGu();
                 }).toList(),
                 result.getRegions(),
                 "region information"); //순서도 같도록 의도한 것
@@ -545,7 +545,7 @@ public class MemberTest {
         assertIterableEquals(
                 regionSet.stream().map(regionId -> {
                     Region region = regionRepository.findById(regionId).get();
-                    return region.getSido() + " " + region.getSigungu();
+                    return region.getSiDo() + " " + region.getSiGunGu();
                 }).toList(),
                 result.getRegions(),
                 "region information"); //순서도 같도록 의도한 것

--- a/src/test/java/umc/lightup/members/MemberTest.java
+++ b/src/test/java/umc/lightup/members/MemberTest.java
@@ -3,6 +3,10 @@ package umc.lightup.members;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,8 +15,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import umc.lightup.api.ApiResponse;
 import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.config.EmailService;
 import umc.lightup.member.controller.MemberRestController;
 import umc.lightup.member.domain.*;
+import umc.lightup.member.dto.EmailRequestDTO;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
 import umc.lightup.member.enums.Mbti;
@@ -33,6 +39,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -40,6 +48,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 @AutoConfigureMockMvc
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("All") //Optional.get 경고 보기 싫어... 이렇게 쓰니 MockBean 경고도 지워지네?
 public class MemberTest {
     @Autowired
     private MockMvc mockMvc;
@@ -66,6 +76,14 @@ public class MemberTest {
     MemberRestController memberRestController;
     @Autowired
     private ObjectMapper jacksonObjectMapper;
+
+    //경고뜨는데 GPT가 그냥 쓰라네요...
+    //import에서의 경고도 지우기 위해 import 안 쓰느라 형태가 이상해졌습니다
+    @org.springframework.boot.test.mock.mockito.MockBean
+    private EmailService emailService;
+
+    @Captor
+    private ArgumentCaptor<EmailRequestDTO.PasswordInitializeDTO> dtoCaptor;
 
     @BeforeAll
     void setup() {
@@ -1047,6 +1065,87 @@ public class MemberTest {
     }
 
     @Test
+    @DisplayName("비밀번호 초기화 및 원상복귀 테스트")
+    void passwordInitializeTest() throws Exception {
+        //Given은 BeforeAll 이용
+        //When
+        mockMvc.perform(post("/api/v1/members/password/initialize")
+                        .param("email", "someone2@example.com")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED))
+                .andExpect(status().isNoContent());
+
+
+        //Then
+        verify(emailService).sendEmailTemplate(
+                eq("someone2@example.com"),
+                eq("[Lightup] 비밀번호 재설정 안내"),
+                eq("password-reset"),
+                dtoCaptor.capture()
+        );
+
+        EmailRequestDTO.PasswordInitializeDTO sentDto = dtoCaptor.getValue();
+        assertEquals("기본값2", sentDto.getUserName());
+        String tempPassword = sentDto.getTempPassword();
+
+        mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone2@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().is4xxClientError());
+
+        String loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone2@example.com")
+                                .password(tempPassword)
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse = jacksonObjectMapper.readValue(loginResult,
+                new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>(){});
+
+        assertEquals(2L, loginResponse.getResult().getMemberId());
+        //Token 다시 받아오기
+        String accessToken = loginResponse.getResult().getAccessToken();
+
+        //다시 돌려놓아야 다른 테스트에서 문제가 발생하지 않음
+
+        //When
+        MemberRequestDTO.PasswordChangeRequestDTO change2 =
+                MemberRequestDTO.PasswordChangeRequestDTO.builder()
+                        .prevPassword(tempPassword)
+                        .newPassword("password")
+                        .build();
+
+        String content = mockMvc.perform(post("/api/v1/members/password/change")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(change2)))
+                .andExpect(status().isNoContent())
+                .andReturn().getResponse().getContentAsString();
+
+        //Then
+        System.out.println("content = " + content);
+        mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone2@example.com")
+                                .password(tempPassword)
+                                .build())))
+                .andExpect(status().is4xxClientError());
+
+        mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone2@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     @DisplayName("비밀번호 변경 실패 테스트(비밀번호 불일치)")
     void passwordChangeFailTest() throws Exception {
         //귀찮아서 이렇게 했지만 원래는 member 새로 만드는 것부터 하는 게 좋긴 함
@@ -1089,6 +1188,25 @@ public class MemberTest {
         assertAll("Password change with wrong old password",
                 () -> assertEquals(ErrorStatus.INVALID_PASSWORD.getCode(), change1Response.getCode()),
                 () -> assertEquals(ErrorStatus.INVALID_PASSWORD.getMessage(), change1Response.getMessage())
+        );
+    }
+
+    @Test
+    @DisplayName("비밀번호 초기화 실패 테스트(이메일 없음)")
+    void passwordInitializeFailTest() throws Exception {
+        String content1 = mockMvc.perform(post("/api/v1/members/password/initialize")
+                        .param("email", "noone@example.com")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<Void> change1Response =
+                jacksonObjectMapper.readValue(content1,
+                        new TypeReference<ApiResponse<Void>>(){});
+
+        //Then
+        assertAll("Password initialize with wrong email",
+                () -> assertEquals(ErrorStatus.MEMBER_NOT_FOUND.getCode(), change1Response.getCode()),
+                () -> assertEquals(ErrorStatus.MEMBER_NOT_FOUND.getMessage(), change1Response.getMessage())
         );
     }
 


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 이메일 발송 및 비밀번호 초기화 기능 구현

---

## 🔧 작업 내용 요약
- 사용자가 비밀번호를 잊었을 때 비밀번호를 초기화하는 기능 구현
- 이메일을 미리 지정한 템플릿을 이용해 발송하는 기능 구현

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 메일 발송 방식(특히 DTO를 사용하는 부분)이 적절한지
- 템플릿 엔진(thymeleaf)를 적절하게 사용했는지
- 메일 발송 기능에 대해서는 아직 테스트 코드를 작성하지 않았는데 괜찮을지(이 테스트 코드 부분은 여건이 된다면 merge 전 작성될 수 있음)

---

## 🔗 관련 이슈
- closes #32 

---

## 📝 기타 참고 사항
- 이메일 SMTP 설정을 진행해야 메일 발송 기능을 구현할 수 있습니다. SMTP 설정을 진행하고 설정값을 application.yml에 넣어 주세요.
- 이메일 SMTP 설정 방법은 이 내용의 앞부분을 참고해 주세요: https://jasonoh22.tistory.com/174
- 이메일 SMTP를 설정하시면 송신 메일 주소는 설정한 이메일이 됩니다.
- 주의할 점으로 SMTP 설정이 이루어지면 이메일과 비밀번호를 이용해 계정에 로그인이 가능합니다. 지금까지 받았고 보냈던 이메일 기록을 전부 보는 것은 물론 이 이메일 주소로 메일을 보낼 수 있게 되니, 각자 설정하시고 유출되지 않게 주의해 주세요.
- 템플릿은 나중에 프론트엔드나 디자인 파트 팀원의 도움을 받아 수정해야 하지 않을까 싶습니다. 근데 Thymeleaf 처음 보시죠? 코드나 html 보고 이해 안 되면 이해 안 하셔도 큰 상관은 없지 않을까 싶습니다.