### PR TITLE
[Skill & Strength] 유저가 선택한 포지션 기준으로 스킬, 강점 목록 조회

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -43,7 +43,13 @@ public enum ErrorStatus implements BaseErrorCode {
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM4000", "프로젝트가 존재하지 않습니다."),
 
     //ItemImage 관련 에러
-    ITEM_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM_IMAGE4000", "아이템 이미지가 존재하지 않습니다.")
+    ITEM_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM_IMAGE4000", "아이템 이미지가 존재하지 않습니다."),
+
+    //MemberSkill 관련 에러
+    MEMBER_SKILL_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_SKILL4000", "유저의 스킬이 존재하지 않습니다."),
+
+    //MemberStrength 관련 에러
+    MEMBER_STRENGTH_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_STRENGTH4000", "유저의 강점이 존재하지 않습니다.")
     ;
 
 

--- a/src/main/java/umc/lightup/member/domain/MemberSkill.java
+++ b/src/main/java/umc/lightup/member/domain/MemberSkill.java
@@ -1,14 +1,12 @@
 package umc.lightup.member.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import umc.lightup.common.BaseEntity;
 import umc.lightup.skill.domain.Skill;
 
 @Entity
+@Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/umc/lightup/member/domain/MemberStrength.java
+++ b/src/main/java/umc/lightup/member/domain/MemberStrength.java
@@ -1,15 +1,12 @@
 package umc.lightup.member.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import umc.lightup.common.BaseEntity;
-import umc.lightup.skill.domain.Skill;
 import umc.lightup.strength.domain.Strength;
 
 @Entity
+@Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
@@ -6,8 +6,12 @@ import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberSkill;
 import umc.lightup.skill.domain.Skill;
 
+import java.util.List;
+
+
 @Repository
 public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
+    List<MemberSkill> findByMember(Member member);
     boolean existsByMemberAndSkill(Member member, Skill skill);
 }
 

--- a/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
@@ -1,6 +1,8 @@
 package umc.lightup.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberSkill;
@@ -11,7 +13,8 @@ import java.util.List;
 
 @Repository
 public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
-    List<MemberSkill> findByMember(Member member);
+    @Query("select s.name from MemberSkill ms join ms.skill s where ms.member = :member")
+    List<String> findSkillNameByMember(@Param("member") Member member);
     boolean existsByMemberAndSkill(Member member, Skill skill);
 }
 

--- a/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
@@ -6,8 +6,11 @@ import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberStrength;
 import umc.lightup.strength.domain.Strength;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberStrengthRepository extends JpaRepository<MemberStrength, Long> {
+    Optional<MemberStrength> findByMember(Member member);
     boolean existsByMemberAndStrength(Member member, Strength skill);
 }
 

--- a/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
@@ -1,16 +1,19 @@
 package umc.lightup.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberStrength;
 import umc.lightup.strength.domain.Strength;
 
-import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface MemberStrengthRepository extends JpaRepository<MemberStrength, Long> {
-    Optional<MemberStrength> findByMember(Member member);
+    @Query("select s.name from MemberStrength ms join ms.strength s where s.name = :member")
+    List<String> findStrengthNameByMember(@Param("member") Member member);
     boolean existsByMemberAndStrength(Member member, Strength skill);
 }
 

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -135,14 +135,14 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         // 한 번에 반환하기 위해 DTO 반환을 사용했는데 좋은 설계 방식인지는 한번 고민할 필요가 있음
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
-        List<String> skills = skillRepository.findNameByMember(member);
-        List<String> strengths = strengthRepository.findNameByMember(member);
+//        List<String> skills = skillRepository.findNameByMember(member);
+//        List<String> strengths = strengthRepository.findNameByMember(member);
         List<Region> regions = regionRepository.findByMember(member);
         List<Portfolio> portfolios = portfolioRepository.findByMember(member);
         return MemberViewInfo.builder()
                 .member(member)
-                .skills(skills)
-                .strengths(strengths)
+//                .skills(skills)
+//                .strengths(strengths)
                 .regions(regions)
                 .portfolios(portfolios)
                 .emailOpen(false)

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -137,12 +137,18 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
 //        List<String> skills = skillRepository.findNameByMember(member);
 //        List<String> strengths = strengthRepository.findNameByMember(member);
+        List<String> skills = memberSkillRepository.findByMember(member).stream()
+                .map(memberSkill -> memberSkill.getSkill().getName())
+                .toList();
+        List<String> strengths = memberStrengthRepository.findByMember(member).stream()
+                .map(memberStrength -> memberStrength.getStrength().getName())
+                .toList();
         List<Region> regions = regionRepository.findByMember(member);
         List<Portfolio> portfolios = portfolioRepository.findByMember(member);
         return MemberViewInfo.builder()
                 .member(member)
-//                .skills(skills)
-//                .strengths(strengths)
+                .skills(skills)
+                .strengths(strengths)
                 .regions(regions)
                 .portfolios(portfolios)
                 .emailOpen(false)

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -135,14 +135,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         // 한 번에 반환하기 위해 DTO 반환을 사용했는데 좋은 설계 방식인지는 한번 고민할 필요가 있음
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
-//        List<String> skills = skillRepository.findNameByMember(member);
-//        List<String> strengths = strengthRepository.findNameByMember(member);
-        List<String> skills = memberSkillRepository.findByMember(member).stream()
-                .map(memberSkill -> memberSkill.getSkill().getName())
-                .toList();
-        List<String> strengths = memberStrengthRepository.findByMember(member).stream()
-                .map(memberStrength -> memberStrength.getStrength().getName())
-                .toList();
+        List<String> skills = memberSkillRepository.findSkillNameByMember(member);
+        List<String> strengths = memberStrengthRepository.findStrengthNameByMember(member);
         List<Region> regions = regionRepository.findByMember(member);
         List<Portfolio> portfolios = portfolioRepository.findByMember(member);
         return MemberViewInfo.builder()

--- a/src/main/java/umc/lightup/skill/controller/SkillRestController.java
+++ b/src/main/java/umc/lightup/skill/controller/SkillRestController.java
@@ -2,13 +2,10 @@ package umc.lightup.skill.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import umc.lightup.api.ApiResponse;
-import umc.lightup.member.domain.Member;
 import umc.lightup.member.service.MemberCommandService;
 import umc.lightup.skill.converter.SkillConverter;
-import umc.lightup.skill.dto.SkillRequestDTO;
 import umc.lightup.skill.dto.SkillResponseDTO;
 import umc.lightup.skill.service.SkillService;
 
@@ -25,14 +22,17 @@ public class SkillRestController {
     @GetMapping
     @Operation(
             summary = "유저의 스킬 조회 API",
-            description = "유저가 스킬을 선택하기 전에 드롭다운으로 스킬을 조회하는 API입니다."
+            description = "유저가 드롭다운으로 스킬을 조회하는 API입니다."
     )
-    public ApiResponse<SkillResponseDTO.skillListDTO> getSkills() {
-        List<String> skillsList = skillService.getSkillsList();
+    public ApiResponse<SkillResponseDTO.skillListDTO> getSkills(@RequestParam String positionName) {
+        List<String> skillsList = skillService.getSkillsList(positionName);
         return ApiResponse.onSuccess(SkillConverter.toSkillListDTO(skillsList));
     }
 
-    @PostMapping
+
+
+    //커스텀 스킬 생성 기능 삭제
+/*    @PostMapping
     @Operation(
             summary = "유저의 커스텀 스킬 생성 API",
             description = "유저가 직접 스킬을 생성하고 선택하는 API입니다. 유저가 생성한 스킬은 생성과 동시에 선택됩니다."
@@ -43,5 +43,5 @@ public class SkillRestController {
         String skillName = skillService.createSkill(request, member);
 
         return ApiResponse.onSuccess(SkillConverter.toCreatedSkillResultDTO(skillName, member));
-    }
+    }*/
 }

--- a/src/main/java/umc/lightup/skill/converter/SkillConverter.java
+++ b/src/main/java/umc/lightup/skill/converter/SkillConverter.java
@@ -1,8 +1,5 @@
 package umc.lightup.skill.converter;
 
-import umc.lightup.member.domain.Member;
-import umc.lightup.skill.domain.Skill;
-import umc.lightup.skill.dto.SkillRequestDTO;
 import umc.lightup.skill.dto.SkillResponseDTO;
 
 import java.util.List;
@@ -15,7 +12,8 @@ public class SkillConverter {
                 .build();
     }
 
-    public static SkillResponseDTO.createdSkillResultDTO toCreatedSkillResultDTO(String skillName, Member member) {
+    //커스텀 스킬 기능 삭제
+/*    public static SkillResponseDTO.createdSkillResultDTO toCreatedSkillResultDTO(String skillName, Member member) {
         return SkillResponseDTO.createdSkillResultDTO.builder()
                 .createdSkill(skillName)
                 .memberId(member.getId())
@@ -26,5 +24,5 @@ public class SkillConverter {
         String skillName = request.getSkillName();
 
         return Skill.createSkill(skillName, true, member);
-    }
+    }*/
 }

--- a/src/main/java/umc/lightup/skill/domain/Skill.java
+++ b/src/main/java/umc/lightup/skill/domain/Skill.java
@@ -3,15 +3,14 @@ package umc.lightup.skill.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
-import umc.lightup.common.BaseEntity;
-import umc.lightup.member.domain.Member;
+import umc.lightup.skill.enums.SkillType;
 
 @Getter
 @Entity
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class Skill extends BaseEntity {
+public class Skill {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -19,7 +18,12 @@ public class Skill extends BaseEntity {
     @Column(length = 30, nullable = false, unique = false)
     private String name;
 
-    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    private SkillType skillType;
+
+    //커스텀 스킬 생성 기능 삭제
+/*    @Column(nullable = false)
     private boolean isCustom;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -31,5 +35,5 @@ public class Skill extends BaseEntity {
         skill.isCustom = isCustom;
         skill.owner = owner;
         return skill;
-    }
+    }*/
 }

--- a/src/main/java/umc/lightup/skill/dto/SkillRequestDTO.java
+++ b/src/main/java/umc/lightup/skill/dto/SkillRequestDTO.java
@@ -6,10 +6,11 @@ import lombok.Setter;
 
 public class SkillRequestDTO {
 
-    @Getter
+    //커스텀 스킬 기능 삭제
+/*    @Getter
     @Setter
     public static class CreateSkillDTO {
         @NotBlank
         String skillName;
-    }
+    }*/
 }

--- a/src/main/java/umc/lightup/skill/dto/SkillResponseDTO.java
+++ b/src/main/java/umc/lightup/skill/dto/SkillResponseDTO.java
@@ -17,13 +17,14 @@ public class SkillResponseDTO {
         List<String> skills;
     }
 
-    @Builder
+    //커스텀 스킬 기능 삭제
+/*    @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class createdSkillResultDTO {
         String createdSkill;
         Long memberId;
-    }
+    }*/
 
 }

--- a/src/main/java/umc/lightup/skill/enums/SkillType.java
+++ b/src/main/java/umc/lightup/skill/enums/SkillType.java
@@ -1,0 +1,5 @@
+package umc.lightup.skill.enums;
+
+public enum SkillType {
+    FRONTEND, BACKEND, DESIGN, PLAN, MARKETING, COMMON
+}

--- a/src/main/java/umc/lightup/skill/repository/SkillRepository.java
+++ b/src/main/java/umc/lightup/skill/repository/SkillRepository.java
@@ -15,7 +15,7 @@ public interface SkillRepository extends JpaRepository<Skill, Long> {
     @Query("select s from Skill s order by case " +
             "s.skillType " +
             "when :skillType then 1 " +
-            "else 2" +
+            "else 2 " +
             "end")
     List<Skill> findAllOrderedBySkillType(@Param("skillType") SkillType skillType);
 

--- a/src/main/java/umc/lightup/skill/repository/SkillRepository.java
+++ b/src/main/java/umc/lightup/skill/repository/SkillRepository.java
@@ -4,17 +4,27 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import umc.lightup.member.domain.Member;
 import umc.lightup.skill.domain.Skill;
+import umc.lightup.skill.enums.SkillType;
 
 import java.util.List;
 
 @Repository
 public interface SkillRepository extends JpaRepository<Skill, Long> {
-    @Query("select s from Skill s where s.isCustom = false")
+
+    @Query("select s from Skill s order by case " +
+            "s.skillType " +
+            "when :skillType then 1 " +
+            "else 2" +
+            "end")
+    List<Skill> findAllOrderedBySkillType(@Param("skillType") SkillType skillType);
+
+    //커스텀 스킬 기능 삭제
+/*    @Query("select s from Skill s where s.isCustom = false")
     List<Skill> findBasicSkills();
     @Query("select count(*) from Skill where name = :name and isCustom = false")
     Long countByNameAndIsCustomFalse (@Param("name") String name);
     @Query("select s.name from MemberSkill ms join ms.skill s where ms.member=:member")
     List<String> findNameByMember(@Param("member") Member member);
+ */
 }

--- a/src/main/java/umc/lightup/skill/service/SkillService.java
+++ b/src/main/java/umc/lightup/skill/service/SkillService.java
@@ -3,14 +3,9 @@ package umc.lightup.skill.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import umc.lightup.api.code.status.ErrorStatus;
-import umc.lightup.exception.handler.GeneralHandler;
-import umc.lightup.member.domain.Member;
-import umc.lightup.member.domain.MemberSkill;
 import umc.lightup.member.repository.MemberSkillRepository;
-import umc.lightup.skill.converter.SkillConverter;
 import umc.lightup.skill.domain.Skill;
-import umc.lightup.skill.dto.SkillRequestDTO;
+import umc.lightup.skill.enums.SkillType;
 import umc.lightup.skill.repository.SkillRepository;
 
 import java.util.List;
@@ -23,14 +18,28 @@ public class SkillService {
     private final SkillRepository skillRepository;
     private final MemberSkillRepository memberSkillRepository;
 
-    public List<String> getSkillsList() {
-        List<Skill> skills = skillRepository.findBasicSkills();
+    public List<String> getSkillsList(String positionName) {
+        SkillType skillType = mapPositionToSkillType(positionName);
+        List<Skill> skills = skillRepository.findAllOrderedBySkillType(skillType);
+
         return skills.stream()
                 .map(Skill::getName)
                 .toList();
     }
 
-    @Transactional
+    private SkillType mapPositionToSkillType(String positionName) {
+        return switch (positionName) {
+            case "프론트엔드" -> SkillType.FRONTEND;
+            case "백엔드" -> SkillType.BACKEND;
+            case "디자인" -> SkillType.DESIGN;
+            case "기획" -> SkillType.PLAN;
+            case "마케팅" -> SkillType.MARKETING;
+            default -> SkillType.COMMON;
+        };
+    }
+
+    //커스텀 스킬 기능 삭제
+/*    @Transactional
     public String createSkill(SkillRequestDTO.CreateSkillDTO request, Member member) {
         Skill newSkill = SkillConverter.toSkill(request, member);
 
@@ -44,5 +53,5 @@ public class SkillService {
         MemberSkill memberSkill = MemberSkill.createMemberSkill(member, newSkill);
         memberSkillRepository.save(memberSkill);
         return newSkill.getName();
-    }
+    }*/
 }

--- a/src/main/java/umc/lightup/strength/controller/StrengthRestController.java
+++ b/src/main/java/umc/lightup/strength/controller/StrengthRestController.java
@@ -2,13 +2,9 @@ package umc.lightup.strength.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import umc.lightup.api.ApiResponse;
-import umc.lightup.member.domain.Member;
-import umc.lightup.member.service.MemberCommandService;
 import umc.lightup.strength.converter.StrengthConverter;
-import umc.lightup.strength.dto.StrengthRequestDTO;
 import umc.lightup.strength.dto.StrengthResponseDTO;
 import umc.lightup.strength.service.StrengthService;
 
@@ -20,19 +16,19 @@ import java.util.List;
 public class StrengthRestController {
 
     private final StrengthService strengthService;
-    private final MemberCommandService memberCommandService;
 
     @GetMapping
     @Operation(
             summary = "유저의 강점 조회 API",
             description = "유저가 강점을 선택하기 전에 드롭다운으로 강점들을 조회하는 API입니다."
     )
-    public ApiResponse<StrengthResponseDTO.strengthListDTO> getStrengths() {
-        List<String> strengthsList = strengthService.getStrengthsList();
+    public ApiResponse<StrengthResponseDTO.strengthListDTO> getStrengths(@RequestParam String positionName) {
+        List<String> strengthsList = strengthService.getStrengthsList(positionName);
         return ApiResponse.onSuccess(StrengthConverter.toStrengthListDTO(strengthsList));
     }
 
-    @PostMapping
+    //커스텀 강점 생성 기능 삭제
+/*    @PostMapping
     @Operation(
             summary = "유저의 커스텀 강점 생성 API",
             description = "유저가 직접 강점을 생성하고 선택하는 API입니다. 유저가 생성한 강점은 생성과 동시에 선택됩니다."
@@ -43,5 +39,5 @@ public class StrengthRestController {
         String strengthName = strengthService.createStrength(request, member);
 
         return ApiResponse.onSuccess(StrengthConverter.toCreatedStrengthResultDTO(strengthName, member));
-    }
+    }*/
 }

--- a/src/main/java/umc/lightup/strength/converter/StrengthConverter.java
+++ b/src/main/java/umc/lightup/strength/converter/StrengthConverter.java
@@ -1,8 +1,5 @@
 package umc.lightup.strength.converter;
 
-import umc.lightup.member.domain.Member;
-import umc.lightup.strength.domain.Strength;
-import umc.lightup.strength.dto.StrengthRequestDTO;
 import umc.lightup.strength.dto.StrengthResponseDTO;
 
 import java.util.List;
@@ -15,7 +12,8 @@ public class StrengthConverter {
                 .build();
     }
 
-    public static StrengthResponseDTO.createdStrengthResultDTO toCreatedStrengthResultDTO(String strengthName, Member member) {
+    //커스텀 강점 생성 기능 삭제
+/*    public static StrengthResponseDTO.createdStrengthResultDTO toCreatedStrengthResultDTO(String strengthName, Member member) {
         return StrengthResponseDTO.createdStrengthResultDTO.builder()
                 .createdStrength(strengthName)
                 .memberId(member.getId())
@@ -26,5 +24,5 @@ public class StrengthConverter {
         String strengthName = request.getStrengthName();
 
         return Strength.createStrength(strengthName, true, member);
-    }
+    }*/
 }

--- a/src/main/java/umc/lightup/strength/domain/Strength.java
+++ b/src/main/java/umc/lightup/strength/domain/Strength.java
@@ -3,15 +3,14 @@ package umc.lightup.strength.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
-import umc.lightup.common.BaseEntity;
-import umc.lightup.member.domain.Member;
+import umc.lightup.strength.enums.StrengthType;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class Strength extends BaseEntity {
+public class Strength {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -19,7 +18,12 @@ public class Strength extends BaseEntity {
     @Column(length = 30, nullable = false, unique = false)
     private String name;
 
-    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    @Column(length = 30, nullable = false)
+    private StrengthType strengthType;
+
+    //커스텀 강점 생성 기능 삭제
+/*    @Column(nullable = false)
     private boolean isCustom;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -31,5 +35,5 @@ public class Strength extends BaseEntity {
         strength.isCustom = isCustom;
         strength.owner = owner;
         return strength;
-    }
+    }*/
 }

--- a/src/main/java/umc/lightup/strength/dto/StrengthResponseDTO.java
+++ b/src/main/java/umc/lightup/strength/dto/StrengthResponseDTO.java
@@ -17,13 +17,14 @@ public class StrengthResponseDTO {
         List<String> strengths;
     }
 
-    @Builder
+    //커스텀 강점 생성 기능 삭제
+/*    @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class createdStrengthResultDTO {
         String createdStrength;
         Long memberId;
-    }
+    }*/
 
 }

--- a/src/main/java/umc/lightup/strength/enums/StrengthType.java
+++ b/src/main/java/umc/lightup/strength/enums/StrengthType.java
@@ -1,0 +1,5 @@
+package umc.lightup.strength.enums;
+
+public enum StrengthType {
+    FRONTEND, BACKEND, DESIGN, PLAN, MARKETING, COMMON
+}

--- a/src/main/java/umc/lightup/strength/repository/StrengthRepository.java
+++ b/src/main/java/umc/lightup/strength/repository/StrengthRepository.java
@@ -14,8 +14,8 @@ public interface StrengthRepository extends JpaRepository<Strength, Long> {
     @Query("select s from Strength s order by case " +
             "s.strengthType " +
             "when :skillType then 1 " +
-            "when umc.lightup.strength.enums.StrengthType.COMMON then 2" +
-            "else 3" +
+            "when umc.lightup.strength.enums.StrengthType.COMMON then 2 " +
+            "else 3 " +
             "end")
     List<Strength> findAllOrderedByStrengthType(@Param("skillType") StrengthType strengthType);
     //커스텀 강점 생성 기능 삭제

--- a/src/main/java/umc/lightup/strength/repository/StrengthRepository.java
+++ b/src/main/java/umc/lightup/strength/repository/StrengthRepository.java
@@ -4,17 +4,25 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import umc.lightup.member.domain.Member;
 import umc.lightup.strength.domain.Strength;
+import umc.lightup.strength.enums.StrengthType;
 
 import java.util.List;
 
 @Repository
 public interface StrengthRepository extends JpaRepository<Strength, Long> {
-    @Query("select s from Strength s where s.isCustom = false")
+    @Query("select s from Strength s order by case " +
+            "s.strengthType " +
+            "when :skillType then 1 " +
+            "when umc.lightup.strength.enums.StrengthType.COMMON then 2" +
+            "else 3" +
+            "end")
+    List<Strength> findAllOrderedByStrengthType(@Param("skillType") StrengthType strengthType);
+    //커스텀 강점 생성 기능 삭제
+/*    @Query("select s from Strength s where s.isCustom = false")
     List<Strength> findBasicStrengths();
     @Query("select count(*) from Strength where name = :name and isCustom = false")
     Long countByNameAndIsCustomFalse (@Param("name") String name);
     @Query("select s.name from MemberStrength ms join ms.strength s where ms.member=:member")
-    List<String> findNameByMember(@Param("member") Member member);
+    List<String> findNameByMember(@Param("member") Member member);*/
 }

--- a/src/main/java/umc/lightup/strength/service/StrengthService.java
+++ b/src/main/java/umc/lightup/strength/service/StrengthService.java
@@ -3,14 +3,9 @@ package umc.lightup.strength.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import umc.lightup.api.code.status.ErrorStatus;
-import umc.lightup.exception.handler.GeneralHandler;
-import umc.lightup.member.domain.Member;
-import umc.lightup.member.domain.MemberStrength;
 import umc.lightup.member.repository.MemberStrengthRepository;
-import umc.lightup.strength.converter.StrengthConverter;
 import umc.lightup.strength.domain.Strength;
-import umc.lightup.strength.dto.StrengthRequestDTO;
+import umc.lightup.strength.enums.StrengthType;
 import umc.lightup.strength.repository.StrengthRepository;
 
 import java.util.List;
@@ -23,14 +18,27 @@ public class StrengthService {
     private final StrengthRepository strengthRepository;
     private final MemberStrengthRepository memberStrengthRepository;
 
-    public List<String> getStrengthsList() {
-        List<Strength> strengths = strengthRepository.findBasicStrengths();
+    public List<String> getStrengthsList(String positionName) {
+        StrengthType strengthType = mapPositionToStrengthType(positionName);
+        List<Strength> strengths = strengthRepository.findAllOrderedByStrengthType(strengthType);
         return strengths.stream()
                 .map(Strength::getName)
                 .toList();
     }
 
-    @Transactional
+    private StrengthType mapPositionToStrengthType(String positionName) {
+        return switch (positionName) {
+            case "프론트엔드" -> StrengthType.FRONTEND;
+            case "백엔드" -> StrengthType.BACKEND;
+            case "디자인" -> StrengthType.DESIGN;
+            case "기획" -> StrengthType.PLAN;
+            case "마케팅" -> StrengthType.MARKETING;
+            default -> StrengthType.COMMON;
+        };
+    }
+
+    //커스텀 강점 생성 기능 삭제
+/*    @Transactional
     public String createStrength(StrengthRequestDTO.CreateStrengthDTO request, Member member) {
         Strength newStrength = StrengthConverter.toStrength(request, member);
 
@@ -44,5 +52,5 @@ public class StrengthService {
         MemberStrength memberStrength = MemberStrength.createMemberStrength(member, newStrength);
         memberStrengthRepository.save(memberStrength);
         return newStrength.getName();
-    }
+    }*/
 }


### PR DESCRIPTION
## 💫 PR 제목
- [Skill & Strength] 유저가 선택한 포지션 기준으로 스킬, 강점 목록 조회

---

## 🔧 작업 내용 요약
- 유저가 프로필 수정 페이지에서 자신의 파트( 프론트, 백, 기획 등등) 를 선택한 뒤에 스킬과 강점을 선택할 때 선택한 파트의 스킬, 강점을 우선적으로 드롭다운에 노출합니다.
- 커스텀 스킬, 커스텀 강점 생성 기능은 일단 삭제했습니다.
- 이에 따라 Skill, Strength 엔티티 필드들도 수정되었습니다.
- 디자인이 계속 달라져서 엔티티 수정이 잦네요... 


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- Skill과 Strength가 원래 Member랑 매핑이 되어있었는데 커스텀 기능이 사라지면서 매핑할 필요가 없어져 Skill, Strength 엔티티의 필드를 각각 id, name, enum 타입만 남겨두었습니다. 일단 저희 서비스에서 자체적으로 제공하는 데이터이며 변경될 일이 별로 없을 것 같아서 이런식으로 관리하긴 했는데 적절한지 봐주세요.
---

## 🔗 관련 이슈
- closes #30 

---

## 📝 기타 참고 사항
- 스킬, 강점은 각각 3개씩 선택할 수 있는데 이에 따라 Member 도메인 쪽에서 구현해둔 스킬, 강점 선택 api를 3개씩 받을 수 있도록 수정해야 할 것 같습니다.
