### PR TITLE
[Member] 회원의 회원 좋아요 등록 및 취소 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -23,6 +23,11 @@ public enum ErrorStatus implements BaseErrorCode {
     DUPLICATE_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "MEMBER4005", "이미 존재하는 휴대폰 번호입니다."),
     NO_CREDENTIAL(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER5000", "저장된 패스워드가 없습니다."),
 
+    //MemberLike 관련 에러
+    ALREADY_LIKED(HttpStatus.BAD_REQUEST, "MEMBER4100", "이미 좋아요 한 회원입니다. 좋아요를 취소하려면 Delete Method로 요청을 보내 주세요."),
+    LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4101", "좋아요하지 않은 회원입니다. 좋아요를 하려면 Post Method로 요청을 보내 주세요."),
+    SELF_LIKE(HttpStatus.BAD_REQUEST, "MEMBER4102", "회원 자신에 대한 좋아요 요청입니다."),
+
     //Region 관련 에러
     REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION4000", "해당 지역이 존재하지 않습니다."),
   

--- a/src/main/java/umc/lightup/config/SecurityConfig.java
+++ b/src/main/java/umc/lightup/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers("/api/v1/members/me",
-                                "/api/v1/members/password/change")
+                                "/api/v1/members/password/change",
+                                "/api/v1/members/*/like")
                         .authenticated()
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -144,6 +144,39 @@ public class MemberRestController {
         boolean emailExist = memberCommandService.isEmailExist(email);
         return ApiResponse.onSuccess(new MemberResponseDTO.EmailExistResultDTO(emailExist));
     }
+
+    @PostMapping("/{memberId}/like")
+    @ResponseStatus(HttpStatus.NO_CONTENT) //명시적으로 쓰기 싫었는데 안 쓰니 200 OK가 나가버리네...
+    @Operation(
+            summary = "회원 좋아요 등록 API",
+            description = "회원이 다른 회원에게 좋아요를 등록하는 API입니다.",
+            security = {@SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<Void> addMemberLike(Authentication authentication,
+                                           @PathVariable("memberId") long memberId) {
+        //귀찮았을 뿐 사실 여기에서 존재하는 memberId인지 확인까지 하는 게 맞음, 다만 현재 코드도 Service단에서 확인을 진행해서 동작은 정상적
+        //근데 왜 이메일 확인은 자연스럽게 아무데서도 안 하고 있는 거지?
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+        memberCommandService.addMemberLike(member, memberId);
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+    }
+
+    @DeleteMapping("/{memberId}/like")
+    @ResponseStatus(HttpStatus.NO_CONTENT) //명시적으로 쓰기 싫었는데 안 쓰니 200 OK가 나가버리네...
+    @Operation(
+            summary = "회원 좋아요 등록 취소 API",
+            description = "회원이 다른 회원에게 진행한 좋아요 등록을 취소하는 API입니다.",
+            security = {@SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<Void> removeMemberLike(Authentication authentication,
+                                              @PathVariable("memberId") long memberId) {
+        //귀찮았을 뿐 사실 여기에서 존재하는 memberId인지 확인까지 하는 게 맞음
+        String email = authentication.getName();
+        // Member member = memberCommandService.getMember(email);
+        memberCommandService.removeMemberLike(email, memberId);
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+    }
   
     @PostMapping("/skills")
     @Operation(

--- a/src/main/java/umc/lightup/member/domain/MemberLike.java
+++ b/src/main/java/umc/lightup/member/domain/MemberLike.java
@@ -1,9 +1,16 @@
 package umc.lightup.member.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import umc.lightup.common.BaseEntity;
 
 @Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberLike extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/umc/lightup/member/repository/MemberLikeRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberLikeRepository.java
@@ -1,0 +1,13 @@
+package umc.lightup.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.lightup.member.domain.MemberLike;
+
+@Repository
+public interface MemberLikeRepository extends JpaRepository<MemberLike, Long> {
+    boolean existsByFromMemberIdAndToMemberId(long fromMemberId, long toMemberId); //아니 이게 되는 줄 몰랐었네...
+    int removeByFromMemberIdAndToMemberId(long fromMemberId, long toMemberId); //아니 이게 되는 줄 몰랐었네...
+    boolean existsByFromMemberEmailAndToMemberId(String fromMemberEmail, long toMemberId); //아니 이게 되는 줄 몰랐었네...
+    int removeByFromMemberEmailAndToMemberId(String fromMemberEmail, long toMemberId); //아니 이게 되는 줄 몰랐었네...
+}

--- a/src/main/java/umc/lightup/member/service/MemberCommandService.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandService.java
@@ -12,6 +12,8 @@ public interface MemberCommandService {
     Member putMember(String email, MemberRequestDTO.ChangeDto request);
     String selectSkill(Long skillId,Member member);
     String selectStrength(Long strengthId,Member member);
+    void addMemberLike(Member fromMember, long toMemberId);
+    void removeMemberLike(String fromMemberEmail, long toMemberId);
     boolean isNicknameExist(String nickname);
     boolean isEmailExist(String email);
     boolean isPhoneNumberExist(String phoneNumber);

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -9,12 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.lightup.api.code.status.ErrorStatus;
 import umc.lightup.config.JwtTokenProvider;
 import umc.lightup.exception.handler.GeneralHandler;
-import umc.lightup.member.domain.Credential;
-import umc.lightup.member.domain.Member;
-import umc.lightup.member.domain.MemberSkill;
-import umc.lightup.member.domain.MemberStrength;
-import umc.lightup.member.domain.MemberPosition;
-import umc.lightup.member.domain.Portfolio;
+import umc.lightup.member.domain.*;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
 import umc.lightup.member.dto.MemberViewInfo;
@@ -36,8 +31,6 @@ import java.util.Collections;
 import umc.lightup.member.repository.*;
 import umc.lightup.region.domain.Region;
 import umc.lightup.region.repository.RegionRepository;
-import umc.lightup.skill.repository.SkillRepository;
-import umc.lightup.strength.repository.StrengthRepository;
 
 import java.util.List;
 
@@ -55,6 +48,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final StrengthRepository strengthRepository;
     private final RegionRepository regionRepository;
     private final PortfolioRepository portfolioRepository;
+    private final MemberLikeRepository memberLikeRepository;
   
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
@@ -196,6 +190,29 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         memberStrengthRepository.save(memberStrength);
 
         return foundStrength.getName();
+    }
+
+    @Override
+    @Transactional
+    public void addMemberLike(Member fromMember, long toMemberId) {
+        if (fromMember.getId() == toMemberId)
+            throw new GeneralHandler(ErrorStatus.SELF_LIKE);
+        Member toMember = memberRepository.findById(toMemberId) //아 괜히 검색쿼리 더 날리고 싶지 않은데
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        if (memberLikeRepository.existsByFromMemberIdAndToMemberId(fromMember.getId(), toMemberId))
+            throw new GeneralHandler(ErrorStatus.ALREADY_LIKED);
+        memberLikeRepository.save(MemberLike.builder()
+                .fromMember(fromMember)
+                .toMember(toMember)
+                .build());
+    }
+
+    @Override
+    @Transactional
+    public void removeMemberLike(String fromMemberEmail, long toMemberId) {
+        if (memberLikeRepository.removeByFromMemberEmailAndToMemberId(fromMemberEmail, toMemberId) == 0)
+            //데이터를 지우면서 지운 row의 수가 0은 아닌지 확인(1이어야 함)
+            throw new GeneralHandler(ErrorStatus.LIKE_NOT_FOUND);
     }
 
     @Override

--- a/src/test/java/umc/lightup/members/MemberTest.java
+++ b/src/test/java/umc/lightup/members/MemberTest.java
@@ -61,6 +61,8 @@ public class MemberTest {
     @Autowired
     StrengthRepository strengthRepository;
     @Autowired
+    MemberLikeRepository memberLikeRepository;
+    @Autowired
     MemberCommandService memberCommandService;
     @Autowired
     MemberRestController memberRestController;
@@ -381,6 +383,94 @@ public class MemberTest {
                 () -> assertNull(result.getPhoneNumber()),
                 () -> assertNull(result.getProfileImageUrl())
         );
+
+        //When
+        mockMvc.perform(post("/api/v1/members/2/like")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        //Then
+        assertAll("member like register with single member with just adding",
+                () -> assertTrue(memberLikeRepository.existsByFromMemberIdAndToMemberId(3L, 2L)),
+                () -> assertFalse(memberLikeRepository.existsByFromMemberIdAndToMemberId(3L, 1L)));
+
+        //중복 좋아요 에러 테스트
+        //When
+        String errorContent1 = mockMvc.perform(post("/api/v1/members/2/like")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<Void> error1Response =
+                jacksonObjectMapper.readValue(errorContent1,
+                        new TypeReference<ApiResponse<Void>>(){});
+
+        //Then
+        assertAll("Duplicated Member like register",
+                () -> assertEquals(ErrorStatus.ALREADY_LIKED.getCode(), error1Response.getCode()),
+                () -> assertEquals(ErrorStatus.ALREADY_LIKED.getMessage(), error1Response.getMessage())
+        );
+
+        //중복 좋아요 에러 테스트
+        //When
+        String errorContent2 = mockMvc.perform(delete("/api/v1/members/1/like")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<Void> error2Response =
+                jacksonObjectMapper.readValue(errorContent2,
+                        new TypeReference<ApiResponse<Void>>(){});
+
+        //Then
+        assertAll("Duplicated Member like register",
+                () -> assertEquals(ErrorStatus.LIKE_NOT_FOUND.getCode(), error2Response.getCode()),
+                () -> assertEquals(ErrorStatus.LIKE_NOT_FOUND.getMessage(), error2Response.getMessage())
+        );
+
+        //When
+        mockMvc.perform(delete("/api/v1/members/2/like")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+        mockMvc.perform(post("/api/v1/members/1/like")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isNoContent());
+
+        //Then
+        assertAll("member like register with single member after change",
+                () -> assertFalse(memberLikeRepository.existsByFromMemberIdAndToMemberId(3L, 2L)),
+                () -> assertTrue(memberLikeRepository.existsByFromMemberIdAndToMemberId(3L, 1L)));
+
+        //확실한 비교를 위해 다른 Member로도 로그인 해서 확인
+        String loginResult2 = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone2@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse2 =
+                jacksonObjectMapper.readValue(loginResult2,
+                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>(){});
+        assertEquals(2L, loginResponse2.getResult().getMemberId());
+        String accessToken2 = loginResponse2.getResult().getAccessToken();
+
+        //When
+        mockMvc.perform(post("/api/v1/members/3/like")
+                        .header("Authorization", "Bearer " + accessToken2))
+                .andExpect(status().isNoContent());
+        mockMvc.perform(post("/api/v1/members/1/like")
+                        .header("Authorization", "Bearer " + accessToken2))
+                .andExpect(status().isNoContent());
+        //Then
+        assertAll("member like register with multiple members",
+                () -> assertFalse(memberLikeRepository.existsByFromMemberIdAndToMemberId(3L, 2L)),
+                () -> assertTrue(memberLikeRepository.existsByFromMemberIdAndToMemberId(3L, 1L)),
+                () -> assertTrue(memberLikeRepository.existsByFromMemberIdAndToMemberId(2L, 3L)),
+                () -> assertTrue(memberLikeRepository.existsByFromMemberIdAndToMemberId(2L, 1L)),
+                () -> assertFalse(memberLikeRepository.existsByFromMemberIdAndToMemberId(1L, 2L)),
+                () -> assertFalse(memberLikeRepository.existsByFromMemberIdAndToMemberId(1L, 3L))
+        );
+
     }
 
     @Test
@@ -1146,5 +1236,115 @@ public class MemberTest {
         mockMvc.perform(post("/api/v1/members/email/exist")
                         .param("email", "jdnosfajdn"))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("자기 자신 좋아요 에러 테스트")
+    void memberSelfLikeErrorTest() throws Exception {
+        //Given
+        String loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse =
+                jacksonObjectMapper.readValue(loginResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>(){});
+
+        assertEquals(1L, loginResponse.getResult().getMemberId());
+        String accessToken = loginResponse.getResult().getAccessToken();
+
+
+        //When
+        String content = mockMvc.perform(post("/api/v1/members/1/like")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<Void> response1 =
+                jacksonObjectMapper.readValue(content,
+                        new TypeReference<ApiResponse<Void>>(){});
+
+        //Then
+        assertAll("Member Self Like result",
+                () -> assertEquals(ErrorStatus.SELF_LIKE.getCode(), response1.getCode()),
+                () -> assertEquals(ErrorStatus.SELF_LIKE.getMessage(), response1.getMessage())
+        );
+
+
+        //When
+        content = mockMvc.perform(delete("/api/v1/members/1/like")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<Void> response2 =
+                jacksonObjectMapper.readValue(content,
+                        new TypeReference<ApiResponse<Void>>(){});
+
+        //Then
+        assertAll("Member Self Like remove result",
+                () -> assertEquals(ErrorStatus.LIKE_NOT_FOUND.getCode(), response2.getCode()),
+                () -> assertEquals(ErrorStatus.LIKE_NOT_FOUND.getMessage(), response2.getMessage())
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 멤버의 좋아요 에러 테스트")
+    void memberLikeToNonExistErrorTest() throws Exception {
+        //Given
+        String loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone2@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse =
+                jacksonObjectMapper.readValue(loginResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>(){});
+
+        assertEquals(2L, loginResponse.getResult().getMemberId());
+        String accessToken = loginResponse.getResult().getAccessToken();
+
+        //When
+        String content = mockMvc.perform(post("/api/v1/members/" + Long.MAX_VALUE + "/like")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<Void> response1 =
+                jacksonObjectMapper.readValue(content,
+                        new TypeReference<ApiResponse<Void>>(){});
+
+        //Then
+        assertAll("Member Like to not existing member result",
+                () -> assertEquals(ErrorStatus.MEMBER_NOT_FOUND.getCode(), response1.getCode()),
+                () -> assertEquals(ErrorStatus.MEMBER_NOT_FOUND.getMessage(), response1.getMessage())
+        );
+
+        //When
+        content = mockMvc.perform(delete("/api/v1/members/" + Long.MAX_VALUE + "/like")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<Void> response2 =
+                jacksonObjectMapper.readValue(content,
+                        new TypeReference<ApiResponse<Void>>(){});
+
+        //Then
+        assertAll("Member Like removeto not existing member result",
+                () -> assertEquals(ErrorStatus.LIKE_NOT_FOUND.getCode(), response2.getCode()),
+                () -> assertEquals(ErrorStatus.LIKE_NOT_FOUND.getMessage(), response2.getMessage())
+        );
+    }
+
+    @Test
+    @DisplayName("로그인 없이 좋아요 시 에러 테스트")
+    void memberLikeWithoutLoginErrorTest() throws Exception {
+        //When
+        mockMvc.perform(post("/api/v1/members/1/like"))
+                .andExpect(status().is4xxClientError());
     }
 }


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 회원의 회원 좋아요 등록 및 취소 기능 구현

---

## 🔧 작업 내용 요약
- 특정 멤버가 다른 특정 멤버의 좋아요를 표시하거나 표시를 취소할 수 있는 기능

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- Controller에서 Id값의 검증을 진행하지 않는 게 적절한지
- Service단의 로직이 적절한지
- Repository단의 함수 형태가 적절한지(현재 상태로도 정상 동작 하더라고요)
- Test 로직에서 전반적인 테스트 부분에 테스트 코드를 같이 넣었는데 적절한지(다만 이건 아직 테스트 코드 쓰지 못하고 계신다는 점을 생각하면 확인이 어려우실 것 같긴 합니다)

---

## 🔗 관련 이슈
- closes #35

---

## 📝 기타 참고 사항
- 제가 작성한 Email 발송기능과 충돌나겠네요...
- Github가 아니라 Intellij로 PR 써보는 건 처음인데, 오타나 오류 발생한다면 이 때문일 겁니다.