### PR TITLE
[Member] 회원가입 form 수정

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseErrorCode {
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER4003", "이미 존재하는 닉네임입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4004", "이미 존재하는 이메일입니다."),
     DUPLICATE_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "MEMBER4005", "이미 존재하는 휴대폰 번호입니다."),
+    INVALID_ROLE(HttpStatus.BAD_REQUEST, "MEMBER4006", "올바른 Role이 아닙니다. LEADER, TEAMMATE 중 하나를 선택해 주세요."),
     NO_CREDENTIAL(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER5000", "저장된 패스워드가 없습니다."),
 
     //Region 관련 에러

--- a/src/main/java/umc/lightup/member/domain/Member.java
+++ b/src/main/java/umc/lightup/member/domain/Member.java
@@ -26,19 +26,16 @@ public class Member extends BaseEntity implements UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 20)
+    @Column(nullable = false, length = 20)
     private String name;
 
     @Column(unique = true, length = 20)
     private String nickname; // 추가
 
-    @Column(nullable = false)
     private Boolean gender; // 수정
 
-    @Column(nullable = false)
     private Integer age;
 
-    @Column(nullable = false)
     private LocalDate birth;
 
     @Enumerated(EnumType.STRING)
@@ -55,7 +52,7 @@ public class Member extends BaseEntity implements UserDetails {
     @Column(length = 30)
     private String school;
 
-    @Column(unique = true, nullable = false, length = 20)
+    @Column(unique = true, length = 20)
     private String phoneNumber;
 
     @Column(length = 80)

--- a/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
@@ -10,7 +10,7 @@ import umc.lightup.member.enums.Mbti;
 import umc.lightup.member.enums.Role;
 import umc.lightup.member.validation.annotation.UniqueEmail;
 import umc.lightup.member.validation.annotation.UniqueNickname;
-import umc.lightup.member.validation.annotation.UniquePhoneNumber;
+import umc.lightup.member.validation.annotation.ValidRole;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -27,24 +27,10 @@ public class MemberRequestDTO {
         private String name;
         @UniqueNickname
         private String nickname;
-        @NotNull
-        private Boolean gender;
-        @NotNull
-        @Past
-        private LocalDate birth;
-        @NotNull
-        private Role role;
-        @NotNull
-        private Mbti mbti;
         @NotEmpty
         @Email
         @UniqueEmail
         private String email;
-        private String school;
-        @NotEmpty
-        @UniquePhoneNumber
-        @Pattern(regexp = "0[1-8]\\d{0,1}-\\d{3,4}-\\d{4,5}")
-        private String phoneNumber;
         @NotEmpty
         private String password;
 
@@ -52,14 +38,8 @@ public class MemberRequestDTO {
             return Member.builder()
                     .name(this.name)
                     .nickname(this.nickname)
-                    .gender(this.gender)
-                    .birth(this.birth)
-                    .role(this.role)
-                    .mbti(this.mbti)
+                    .role(Role.PROVISION)
                     .email(this.email)
-                    .school(this.school)
-                    .phoneNumber(this.phoneNumber)
-                    .age((int) this.birth.until(LocalDate.now(), ChronoUnit.YEARS))
                     .build();
         }
 
@@ -88,6 +68,7 @@ public class MemberRequestDTO {
         @Past
         private LocalDate birth;
         @NotNull
+        @ValidRole
         private Role role;
         @NotNull
         private Mbti mbti;

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -36,8 +36,8 @@ public class MemberResponseDTO {
         private long id;
         private String name;
         private String nickname;
-        private int age;
-        private boolean gender;
+        private Integer age;
+        private Boolean gender;
         private LocalDate birth;
         private Role role;
         private Mbti mbti;
@@ -55,8 +55,8 @@ public class MemberResponseDTO {
     public static class MemberInfoDTO {
         private String name;
         private String nickname;
-        private int age;
-        private boolean gender;
+        private Integer age;
+        private Boolean gender;
         private LocalDate birth;
         private Role role;
         private Mbti mbti;

--- a/src/main/java/umc/lightup/member/enums/Role.java
+++ b/src/main/java/umc/lightup/member/enums/Role.java
@@ -2,6 +2,7 @@ package umc.lightup.member.enums;
 
 public enum Role {
     ADMIN, //관리자
+    PROVISION, //준회원(아직 회원정보가 없음)
     LEADER, // 팀원을 구하는 유저
     TEAMMATE // 팀을 구하는 유저
 }

--- a/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Repository
 public interface MemberStrengthRepository extends JpaRepository<MemberStrength, Long> {
-    @Query("select s.name from MemberStrength ms join ms.strength s where s.name = :member")
+    @Query("select s.name from MemberStrength ms join ms.strength s where ms.member = :member")
     List<String> findStrengthNameByMember(@Param("member") Member member);
     boolean existsByMemberAndStrength(Member member, Strength skill);
 }

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -155,10 +155,10 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     @Transactional
     public Member putMember(String email, MemberRequestDTO.ChangeDto request) {
         Member member = getMember(email);
-        if (!member.getEmail().equals(request.getEmail()) &&
+        if (!request.getEmail().equals(member.getEmail()) &&
                 isEmailExist(request.getEmail()))
             throw new GeneralHandler(ErrorStatus.DUPLICATE_EMAIL);
-        if (!member.getPhoneNumber().equals(request.getPhoneNumber()) &&
+        if (!request.getPhoneNumber().equals(member.getPhoneNumber()) &&
                 isPhoneNumberExist(request.getPhoneNumber()))
             throw new GeneralHandler(ErrorStatus.DUPLICATE_PHONE_NUMBER);
         if (member.getNickname() != null &&

--- a/src/main/java/umc/lightup/member/validation/annotation/ValidRole.java
+++ b/src/main/java/umc/lightup/member/validation/annotation/ValidRole.java
@@ -1,0 +1,17 @@
+package umc.lightup.member.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.lightup.member.validation.validator.RoleValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = RoleValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidRole {
+    String message() default "올바른 Role이 아닙니다. LEADER, TEAMMATE 중 하나를 선택해 주세요.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/lightup/member/validation/validator/RoleValidator.java
+++ b/src/main/java/umc/lightup/member/validation/validator/RoleValidator.java
@@ -1,0 +1,26 @@
+package umc.lightup.member.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.member.enums.Role;
+import umc.lightup.member.validation.annotation.ValidRole;
+
+public class RoleValidator implements ConstraintValidator<ValidRole, Role> {
+    @Override
+    public void initialize(ValidRole constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Role value, ConstraintValidatorContext context) {
+        boolean isValid = value == null || value.equals(Role.LEADER) || value.equals(Role.TEAMMATE);
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.INVALID_ROLE.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/test/java/umc/lightup/members/MemberTest.java
+++ b/src/test/java/umc/lightup/members/MemberTest.java
@@ -28,8 +28,10 @@ import umc.lightup.member.service.MemberCommandService;
 import umc.lightup.region.domain.Region;
 import umc.lightup.region.repository.RegionRepository;
 import umc.lightup.skill.domain.Skill;
+import umc.lightup.skill.enums.SkillType;
 import umc.lightup.skill.repository.SkillRepository;
 import umc.lightup.strength.domain.Strength;
+import umc.lightup.strength.enums.StrengthType;
 import umc.lightup.strength.repository.StrengthRepository;
 
 import java.time.LocalDate;
@@ -90,61 +92,81 @@ public class MemberTest {
         Member member1 = memberCommandService.joinMember(MemberRequestDTO.JoinDto.builder()
                 .name("기본값1")
                 .nickname("닉네임1")
-                .gender(true)
-                .birth(LocalDate.of(1980, Month.AUGUST, 1))
-                .role(Role.LEADER)
-                .mbti(Mbti.ENFJ)
                 .email("someone@example.com")
-                .phoneNumber("010-5555-6666")
                 .password("password")
                 .build());
         assertSame(1L, member1.getId());
 
+        member1 = memberCommandService.putMember("someone@example.com",
+                MemberRequestDTO.ChangeDto.builder()
+                        .name("기본값1")
+                        .nickname("닉네임1")
+                        .gender(true)
+                        .birth(LocalDate.of(1980, Month.AUGUST, 1))
+                        .role(Role.LEADER)
+                        .mbti(Mbti.ENFJ)
+                        .email("someone@example.com")
+                        .phoneNumber("010-5555-6666")
+                        .build());
+
         Member member2 = memberCommandService.joinMember(MemberRequestDTO.JoinDto.builder()
                 .name("기본값2")
                 .nickname("닉네임2")
-                .gender(false)
-                .birth(LocalDate.of(2000, Month.JANUARY, 1))
-                .role(Role.TEAMMATE)
-                .mbti(Mbti.ISTP)
                 .email("someone2@example.com")
-                .phoneNumber("010-2222-2222")
                 .password("password")
                 .build());
         assertSame(2L, member2.getId());
 
+        member2 = memberCommandService.putMember("someone2@example.com",
+                MemberRequestDTO.ChangeDto.builder()
+                        .name("기본값2")
+                        .nickname("닉네임2")
+                        .gender(false)
+                        .birth(LocalDate.of(2000, Month.JANUARY, 1))
+                        .role(Role.TEAMMATE)
+                        .mbti(Mbti.ISTP)
+                        .email("someone2@example.com")
+                        .phoneNumber("010-2222-2222")
+                        .build());
+
         Skill skill1 = Skill.builder()
                 .name("스킬1")
+                .skillType(SkillType.BACKEND)
                 .build();
         skillRepository.save(skill1);
         assertSame(1L, skill1.getId());
 
         Skill skill2 = Skill.builder()
                 .name("스킬2")
+                .skillType(SkillType.FRONTEND)
                 .build();
         skillRepository.save(skill2);
         assertSame(2L, skill2.getId());
 
         Skill skill3 = Skill.builder()
                 .name("스킬3")
+                .skillType(SkillType.DESIGN)
                 .build();
         skillRepository.save(skill3);
         assertSame(3L, skill3.getId());
 
         Strength strength1 = Strength.builder()
                 .name("강점1")
+                .strengthType(StrengthType.PLAN)
                 .build();
         strengthRepository.save(strength1);
         assertSame(1L, strength1.getId());
 
         Strength strength2 = Strength.builder()
                 .name("강점2")
+                .strengthType(StrengthType.MARKETING)
                 .build();
         strengthRepository.save(strength2);
         assertSame(2L, strength2.getId());
 
         Strength strength3 = Strength.builder()
                 .name("강점3")
+                .strengthType(StrengthType.COMMON)
                 .build();
         strengthRepository.save(strength3);
         assertSame(3L, strength3.getId());
@@ -196,12 +218,7 @@ public class MemberTest {
         MemberRequestDTO.JoinDto joinDto = MemberRequestDTO.JoinDto.builder()
                 .name("이름2")
                 .nickname("닉네임2")
-                .gender(true)
-                .birth(LocalDate.of(2006, Month.DECEMBER, 31))
-                .role(Role.LEADER)
-                .mbti(Mbti.INTJ)
                 .email("someone5@example.com")
-                .phoneNumber("02-000-5555")
                 .password("password")
                 .build();
 
@@ -225,7 +242,7 @@ public class MemberTest {
 
 
     /**
-     * 휴대전화 형식 외 회원가입 테스트에서 응답을 받기 위한 임시 클래스
+     * 휴대전화 형식 외 회원수정 테스트에서 응답을 받기 위한 임시 클래스
      */
     static class PhoneCheck {
         private String phoneNumber;
@@ -240,26 +257,43 @@ public class MemberTest {
     }
 
     @Test
-    @DisplayName("휴대전화 형식 외 회원가입 테스트")
-    void joinPhonePatternTest() throws Exception {
-
+    @DisplayName("휴대전화 형식 외 회원수정 테스트")
+    void putPhonePatternTest() throws Exception {
         //Given
-        MemberRequestDTO.JoinDto joinDto = MemberRequestDTO.JoinDto.builder()
+        //귀찮아서 이렇게 했지만 원래는 member 새로 만드는 것부터 하는 게 좋긴 함
+        String loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone2@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse =
+                jacksonObjectMapper.readValue(loginResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>() {
+                        });
+
+        assertEquals(2L, loginResponse.getResult().getMemberId());
+
+        String accessToken = loginResponse.getResult().getAccessToken();
+
+        MemberRequestDTO.ChangeDto changeDto = MemberRequestDTO.ChangeDto.builder()
                 .name("이름2")
                 .nickname("닉네임4")
                 .gender(true)
                 .birth(LocalDate.of(2006, Month.DECEMBER, 31))
                 .role(Role.LEADER)
                 .mbti(Mbti.INTJ)
-                .email("someone5@example.com")
+                .email("someone2@example.com")
                 .phoneNumber("jewnhfdwnshed")
-                .password("password")
                 .build();
 
         //When
-        String content = mockMvc.perform(post("/api/v1/members/join")
+        String content = mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(jacksonObjectMapper.writeValueAsString(joinDto)))
+                        .content(jacksonObjectMapper.writeValueAsString(changeDto)))
 
                 //Then
                 .andExpect(status().isBadRequest())
@@ -273,8 +307,92 @@ public class MemberTest {
         assertNotNull(response.getResult().getPhoneNumber());
     }
 
+
     /**
-     * 4개 테스트 때려박았는데, 원래 이게 좋은 방식은 아닌 걸로 알고 있음
+     * 지정된 Role 이외 회원수정 테스트에서 응답을 받기 위한 임시 클래스
+     */
+    static class RoleCheck {
+        private String role;
+
+        public String getRole() {
+            return role;
+        }
+
+        public void setRole(String role) {
+            this.role = role;
+        }
+    }
+
+    @Test
+    @DisplayName("지정된 Role 이외 회원수정 테스트")
+    void putRoleValidationTest() throws Exception {
+        //Given
+        //귀찮아서 이렇게 했지만 원래는 member 새로 만드는 것부터 하는 게 좋긴 함
+        String loginResult = mockMvc.perform(post("/api/v1/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(MemberRequestDTO.PasswordLoginRequestDTO.builder()
+                                .email("someone2@example.com")
+                                .password("password")
+                                .build())))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.LoginResultDTO> loginResponse =
+                jacksonObjectMapper.readValue(loginResult,
+                        new TypeReference<ApiResponse<MemberResponseDTO.LoginResultDTO>>() {
+                        });
+
+        assertEquals(2L, loginResponse.getResult().getMemberId());
+
+        String accessToken = loginResponse.getResult().getAccessToken();
+
+        MemberRequestDTO.ChangeDto changeDto = MemberRequestDTO.ChangeDto.builder()
+                .name("이름2")
+                .nickname("닉네임4")
+                .gender(true)
+                .birth(LocalDate.of(2006, Month.DECEMBER, 31))
+                .role(Role.ADMIN)
+                .mbti(Mbti.INTJ)
+                .email("someone2@example.com")
+                .phoneNumber("010-2222-2222")
+                .build();
+
+        //When
+        String content = mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(changeDto)))
+
+                //Then
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        System.out.println(content);
+
+        ApiResponse<RoleCheck> response =
+                jacksonObjectMapper.readValue(content,
+                        new TypeReference<ApiResponse<RoleCheck>>(){});
+        assertNotNull(response.getResult().getRole());
+
+        //Given
+        changeDto.setRole(Role.PROVISION);
+
+        //When
+        content = mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(changeDto)))
+
+                //Then
+                .andExpect(status().isBadRequest())
+                .andReturn().getResponse().getContentAsString();
+        System.out.println(content);
+
+        response = jacksonObjectMapper.readValue(content,
+                        new TypeReference<ApiResponse<RoleCheck>>(){});
+        assertNotNull(response.getResult().getRole());
+    }
+
+    /**
+     * 6개 테스트 때려박았는데, 원래 이게 좋은 방식은 아닌 걸로 알고 있음
      */
     @Test
     @DisplayName("전체적인 API 테스트")
@@ -294,12 +412,7 @@ public class MemberTest {
         MemberRequestDTO.JoinDto joinDto = MemberRequestDTO.JoinDto.builder()
                 .name(name3)
                 .nickname(nickname3)
-                .gender(gender3)
-                .birth(birth3)
-                .role(role3)
-                .mbti(mbti3)
                 .email(email3)
-                .phoneNumber(phoneNumber3)
                 .password(password3)
                 .build();
 
@@ -355,20 +468,62 @@ public class MemberTest {
 
         //Then
         int age3 = (int) birth3.until(before, ChronoUnit.YEARS);
-        assertAll("MyInfo check",
+        assertAll("MyInfo check before first change",
                 () -> assertEquals(3L, myInfoResponse.getResult().getId()),
                 () -> assertEquals(name3, myInfoResponse.getResult().getName()),
                 () -> assertEquals(nickname3, myInfoResponse.getResult().getNickname()),
-                () -> assertEquals(gender3, myInfoResponse.getResult().isGender()),
-                () -> assertEquals(age3, myInfoResponse.getResult().getAge()),
-                () -> assertEquals(birth3, myInfoResponse.getResult().getBirth()),
-                () -> assertEquals(role3, myInfoResponse.getResult().getRole()),
-                () -> assertEquals(mbti3, myInfoResponse.getResult().getMbti()),
+                () -> assertEquals(null, myInfoResponse.getResult().getGender()),
+                () -> assertEquals(null, myInfoResponse.getResult().getAge()),
+                () -> assertEquals(null, myInfoResponse.getResult().getBirth()),
+                () -> assertEquals(Role.PROVISION, myInfoResponse.getResult().getRole()),
+                () -> assertEquals(null, myInfoResponse.getResult().getMbti()),
                 () -> assertEquals(email3, myInfoResponse.getResult().getEmail()),
-                () -> assertEquals(phoneNumber3, myInfoResponse.getResult().getPhoneNumber()),
+                () -> assertEquals(null, myInfoResponse.getResult().getPhoneNumber()),
                 () -> assertNull(myInfoResponse.getResult().getSchool()),
                 () -> assertNull(myInfoResponse.getResult().getCareer()),
                 () -> assertNull(myInfoResponse.getResult().getProfileImageUrl())
+        );
+
+        //Given
+        MemberRequestDTO.ChangeDto changeDto = MemberRequestDTO.ChangeDto.builder()
+                .name(name3)
+                .nickname(nickname3)
+                .gender(gender3)
+                .birth(birth3)
+                .role(role3)
+                .mbti(mbti3)
+                .email(email3)
+                .phoneNumber(phoneNumber3)
+                .build();
+
+        //When
+        String putContent = mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(changeDto)))
+
+                //Then
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        ApiResponse<MemberResponseDTO.MyInfoDTO> putResponse =
+                jacksonObjectMapper.readValue(putContent,
+                        new TypeReference<ApiResponse<MemberResponseDTO.MyInfoDTO>>(){});
+
+        //Then
+        assertAll("MyInfo check after first change",
+                () -> assertEquals(3L, putResponse.getResult().getId()),
+                () -> assertEquals(name3, putResponse.getResult().getName()),
+                () -> assertEquals(nickname3, putResponse.getResult().getNickname()),
+                () -> assertEquals(gender3, putResponse.getResult().getGender()),
+                () -> assertEquals(age3, putResponse.getResult().getAge()),
+                () -> assertEquals(birth3, putResponse.getResult().getBirth()),
+                () -> assertEquals(role3, putResponse.getResult().getRole()),
+                () -> assertEquals(mbti3, putResponse.getResult().getMbti()),
+                () -> assertEquals(email3, putResponse.getResult().getEmail()),
+                () -> assertEquals(phoneNumber3, putResponse.getResult().getPhoneNumber()),
+                () -> assertNull(putResponse.getResult().getSchool()),
+                () -> assertNull(putResponse.getResult().getCareer()),
+                () -> assertNull(putResponse.getResult().getProfileImageUrl())
         );
 
         //When
@@ -386,7 +541,7 @@ public class MemberTest {
                 () -> assertEquals(name3, result.getName()),
                 () -> assertEquals(nickname3, result.getNickname()),
                 () -> assertEquals(age3, result.getAge()),
-                () -> assertEquals(gender3, result.isGender()),
+                () -> assertEquals(gender3, result.getGender()),
                 () -> assertEquals(role3, result.getRole()),
                 () -> assertEquals(mbti3, result.getMbti()),
                 () -> assertNull(result.getCareer()),
@@ -450,7 +605,7 @@ public class MemberTest {
                 () -> assertEquals(member.getName(), result.getName()),
                 () -> assertEquals(member.getNickname(), result.getNickname()),
                 () -> assertEquals(member.getAge(), result.getAge()),
-                () -> assertEquals(member.getGender(), result.isGender()),
+                () -> assertEquals(member.getGender(), result.getGender()),
                 () -> assertEquals(member.getRole(), result.getRole()),
                 () -> assertEquals(member.getMbti(), result.getMbti()),
                 () -> assertEquals(member.getCareer(), result.getCareer()),
@@ -543,7 +698,7 @@ public class MemberTest {
                 () -> assertEquals(member.getName(), result.getName()),
                 () -> assertEquals(member.getNickname(), result.getNickname()),
                 () -> assertEquals(member.getAge(), result.getAge()),
-                () -> assertEquals(member.getGender(), result.isGender()),
+                () -> assertEquals(member.getGender(), result.getGender()),
                 () -> assertEquals(member.getRole(), result.getRole()),
                 () -> assertEquals(member.getMbti(), result.getMbti()),
                 () -> assertEquals(member.getCareer(), result.getCareer()),
@@ -626,12 +781,7 @@ public class MemberTest {
         MemberRequestDTO.JoinDto joinDto = MemberRequestDTO.JoinDto.builder()
                 .name(name4)
                 .nickname(nickname4)
-                .gender(gender4)
-                .birth(birth4)
-                .role(role4)
-                .mbti(mbti4)
                 .email(email4)
-                .phoneNumber(phoneNumber4)
                 .password(password4)
                 .build();
 
@@ -687,20 +837,20 @@ public class MemberTest {
                 () -> assertEquals(4L, myInfoResponseResult.getId()),
                 () -> assertEquals(name4, myInfoResponseResult.getName()),
                 () -> assertEquals(nickname4, myInfoResponseResult.getNickname()),
-                () -> assertEquals(gender4, myInfoResponseResult.isGender()),
-                () -> assertEquals(age4, myInfoResponseResult.getAge()),
-                () -> assertEquals(birth4, myInfoResponseResult.getBirth()),
-                () -> assertEquals(role4, myInfoResponseResult.getRole()),
-                () -> assertEquals(mbti4, myInfoResponseResult.getMbti()),
+                () -> assertEquals(null, myInfoResponseResult.getGender()),
+                () -> assertEquals(null, myInfoResponseResult.getAge()),
+                () -> assertEquals(null, myInfoResponseResult.getBirth()),
+                () -> assertEquals(Role.PROVISION, myInfoResponseResult.getRole()),
+                () -> assertEquals(null, myInfoResponseResult.getMbti()),
                 () -> assertEquals(email4, myInfoResponseResult.getEmail()),
-                () -> assertEquals(phoneNumber4, myInfoResponseResult.getPhoneNumber()),
+                () -> assertEquals(null, myInfoResponseResult.getPhoneNumber()),
                 () -> assertNull(myInfoResponseResult.getSchool()),
                 () -> assertNull(myInfoResponseResult.getCareer()),
                 () -> assertNull(myInfoResponseResult.getProfileImageUrl())
         );
 
         //When
-        //변경사항 없음
+        //초기 설정
         MemberRequestDTO.ChangeDto change1 = MemberRequestDTO.ChangeDto.builder()
                 .name(name4)
                 .nickname(nickname4)
@@ -731,7 +881,7 @@ public class MemberTest {
                 () -> assertEquals(4L, change1ResponseResult.getId()),
                 () -> assertEquals(name4, change1ResponseResult.getName()),
                 () -> assertEquals(nickname4, change1ResponseResult.getNickname()),
-                () -> assertEquals(gender4, change1ResponseResult.isGender()),
+                () -> assertEquals(gender4, change1ResponseResult.getGender()),
                 () -> assertEquals(age4, change1ResponseResult.getAge()),
                 () -> assertEquals(birth4, change1ResponseResult.getBirth()),
                 () -> assertEquals(role4, change1ResponseResult.getRole()),
@@ -741,6 +891,37 @@ public class MemberTest {
                 () -> assertNull(change1ResponseResult.getSchool()),
                 () -> assertNull(change1ResponseResult.getCareer()),
                 () -> assertNull(change1ResponseResult.getProfileImageUrl())
+        );
+
+        change1Result = mockMvc.perform(put("/api/v1/members/me")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jacksonObjectMapper.writeValueAsString(change1))
+                )
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        change1Response =
+                jacksonObjectMapper.readValue(change1Result,
+                        new TypeReference<ApiResponse<MemberResponseDTO.MyInfoDTO>>() {
+                        });
+
+        //Then
+        //변경사항 없음
+        MemberResponseDTO.MyInfoDTO change1_1ResponseResult = change1Response.getResult();
+        assertAll("MyInfo check without change",
+                () -> assertEquals(4L, change1_1ResponseResult.getId()),
+                () -> assertEquals(name4, change1_1ResponseResult.getName()),
+                () -> assertEquals(nickname4, change1_1ResponseResult.getNickname()),
+                () -> assertEquals(gender4, change1_1ResponseResult.getGender()),
+                () -> assertEquals(age4, change1_1ResponseResult.getAge()),
+                () -> assertEquals(birth4, change1_1ResponseResult.getBirth()),
+                () -> assertEquals(role4, change1_1ResponseResult.getRole()),
+                () -> assertEquals(mbti4, change1_1ResponseResult.getMbti()),
+                () -> assertEquals(email4, change1_1ResponseResult.getEmail()),
+                () -> assertEquals(phoneNumber4, change1_1ResponseResult.getPhoneNumber()),
+                () -> assertNull(change1_1ResponseResult.getSchool()),
+                () -> assertNull(change1_1ResponseResult.getCareer()),
+                () -> assertNull(change1_1ResponseResult.getProfileImageUrl())
         );
 
 
@@ -778,7 +959,7 @@ public class MemberTest {
                 () -> assertEquals(4L, change2ResponseResult.getId()),
                 () -> assertEquals("name4", change2ResponseResult.getName()),
                 () -> assertEquals(nickname4, change2ResponseResult.getNickname()),
-                () -> assertEquals(false, change2ResponseResult.isGender()),
+                () -> assertEquals(false, change2ResponseResult.getGender()),
                 () -> assertEquals(changedAge, change2ResponseResult.getAge()),
                 () -> assertEquals(changedBirth, change2ResponseResult.getBirth()),
                 () -> assertEquals(Role.TEAMMATE, change2ResponseResult.getRole()),
@@ -822,7 +1003,7 @@ public class MemberTest {
                 () -> assertEquals(4L, change3ResponseResult.getId()),
                 () -> assertEquals(name4, change3ResponseResult.getName()),
                 () -> assertNull(change3ResponseResult.getNickname()),
-                () -> assertEquals(gender4, change3ResponseResult.isGender()),
+                () -> assertEquals(gender4, change3ResponseResult.getGender()),
                 () -> assertEquals(age4, change3ResponseResult.getAge()),
                 () -> assertEquals(birth4, change3ResponseResult.getBirth()),
                 () -> assertEquals(role4, change3ResponseResult.getRole()),
@@ -879,7 +1060,7 @@ public class MemberTest {
         MemberRequestDTO.ChangeDto change1 = MemberRequestDTO.ChangeDto.builder()
                 .name(myInfoResponseResult.getName())
                 .nickname("닉네임1")
-                .gender(myInfoResponseResult.isGender())
+                .gender(myInfoResponseResult.getGender())
                 .birth(myInfoResponseResult.getBirth())
                 .role(myInfoResponseResult.getRole())
                 .mbti(myInfoResponseResult.getMbti())
@@ -911,7 +1092,7 @@ public class MemberTest {
         MemberRequestDTO.ChangeDto change2 = MemberRequestDTO.ChangeDto.builder()
                 .name(myInfoResponseResult.getName())
                 .nickname(myInfoResponseResult.getNickname())
-                .gender(myInfoResponseResult.isGender())
+                .gender(myInfoResponseResult.getGender())
                 .birth(myInfoResponseResult.getBirth())
                 .role(myInfoResponseResult.getRole())
                 .mbti(myInfoResponseResult.getMbti())
@@ -943,7 +1124,7 @@ public class MemberTest {
         MemberRequestDTO.ChangeDto change3 = MemberRequestDTO.ChangeDto.builder()
                 .name(myInfoResponseResult.getName())
                 .nickname(myInfoResponseResult.getNickname())
-                .gender(myInfoResponseResult.isGender())
+                .gender(myInfoResponseResult.getGender())
                 .birth(myInfoResponseResult.getBirth())
                 .role(myInfoResponseResult.getRole())
                 .mbti(myInfoResponseResult.getMbti())


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 회원가입 form 수정

---

## 🔧 작업 내용 요약
- 비밀번호를 통한 회원가입 시 이름, 닉네임, 이메일, 비밀번호만을 이용해 회원가입하도록 설정
- 나머지 데이터는 회원정보수정에서 수정 후 서비스 이용 가능

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 현재 닉네임이 nullable인데 적절한지

---

## 🔗 관련 이슈
- 프론트엔드에서 급히 수정해 달라 했기에 Issue 없이 진행

---

## 📝 기타 참고 사항
- DB schema를 변경해야 정상 동작함(notnull 필드 대부분을 nullable로 변경함)
- 아직 프로젝트 신청이 구현되지 않아 서비스 제한은 걸지 않음
- 테스트 코드는 아직 수정하지 않음(원래는 test code를 수정하고 올리는 게 맞으나 프론트에서 급히 수정해 달라 했기 때문)
