### PR TITLE
[Item] 프로젝트 지원 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -52,6 +52,9 @@ public enum ErrorStatus implements BaseErrorCode {
     ITEM_ALREADY_LIKED(HttpStatus.BAD_REQUEST, "ITEMLIKE4001", "이미 좋아요를 누른 프로젝트입니다."),
     ITEM_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEMLIKE4002", "좋아요가 존재하지 않습니다."),
 
+    //ItemViewHistory 관련 에러
+    ITEM_VIEW_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEMVIEWHISTORY4000", "프로젝트 조회 내역이 존재하지 않습니다."),
+
     //ItemImage 관련 에러
     ITEM_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM_IMAGE4000", "아이템 이미지가 존재하지 않습니다."),
 

--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -52,6 +52,9 @@ public enum ErrorStatus implements BaseErrorCode {
     ITEM_ALREADY_LIKED(HttpStatus.BAD_REQUEST, "ITEMLIKE4001", "이미 좋아요를 누른 프로젝트입니다."),
     ITEM_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEMLIKE4002", "좋아요가 존재하지 않습니다."),
 
+    //ItemApply 관련 에러
+    DUPLICATE_ITEM_APPLY(HttpStatus.BAD_REQUEST, "ITEMAPPLY4000", "이미 지원한 프로젝트입니다."),
+
     //ItemViewHistory 관련 에러
     ITEM_VIEW_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEMVIEWHISTORY4000", "프로젝트 조회 내역이 존재하지 않습니다."),
 

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -69,10 +69,12 @@ public class ItemRestController {
 
     @GetMapping("/{itemId}")
     @Operation(summary = "특정 프로젝트 상세 조회 API", description = "특정 프로젝트를 상세 조회하는 API 입니다.")
-    public ApiResponse<ItemResponseDTO.ItemInfoDTO> getItemInfo(@PathVariable("itemId") @Min(1) Long itemId) {
+    public ApiResponse<ItemResponseDTO.ItemInfoDTO> getItemInfo(Authentication authentication, @PathVariable("itemId") @Min(1) Long itemId) {
+        Member member = memberCommandService.getMember(authentication.getName());
         Item findItem = itemCommandService.getSingleItem(itemId);
         List<ItemResponseDTO.ItemRegionResultDTO> itemRegions = itemCommandService.getItemRegions(findItem);
         List<ItemResponseDTO.RecruitPositionResultDTO> itemRecruitPositions = itemCommandService.getItemRecruitPositions(findItem);
+        itemCommandService.updateItemHistory(member, findItem);
         return ApiResponse.onSuccess(ItemConverter.toItemInfoDTO(findItem, itemRegions, itemRecruitPositions));
     }
 

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -18,6 +18,7 @@ import umc.lightup.api.ApiResponse;
 import umc.lightup.api.code.status.SuccessStatus;
 import umc.lightup.item.converter.ItemConverter;
 import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.ItemApply;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.item.service.ItemCommandService;
@@ -95,5 +96,14 @@ public class ItemRestController {
         String email = authentication.getName();
         itemCommandService.removeItemLike(email, itemId);
         return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+    }
+
+    @PostMapping("/{itemId}/apply")
+    @Operation(summary = "프로젝트 지원 API", description = "유저가 프로젝트에 지원 요청을 보내는 API 입니다.")
+    public ApiResponse<ItemResponseDTO.ItemApplyResultDTO> applyItem(Authentication authentication, @PathVariable("itemId") long itemId) {
+        Member member = memberCommandService.getMember(authentication.getName());
+        Item item = itemCommandService.getSingleItem(itemId);
+        ItemApply itemApply = itemCommandService.applyItem(member, item);
+        return ApiResponse.onSuccess(ItemConverter.toItemApplyResultDTO(itemApply));
     }
 }

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -1,6 +1,7 @@
 package umc.lightup.item.converter;
 
 import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.ItemApply;
 import umc.lightup.item.domain.ItemImage;
 import umc.lightup.item.domain.RecruitPosition;
 import umc.lightup.item.dto.ItemRequestDTO;
@@ -89,6 +90,13 @@ public class ItemConverter {
                 .projectStatus(request.isProjectStatus())
                 .extraLink1(request.getExtraLink1())
                 .extraLink2(request.getExtraLink2())
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemApplyResultDTO toItemApplyResultDTO (ItemApply itemApply) {
+        return ItemResponseDTO.ItemApplyResultDTO.builder()
+                .appliedAt(itemApply.getAppliedAt())
+                .message(itemApply.getItem().getName() + "에 지원했어요")
                 .build();
     }
 

--- a/src/main/java/umc/lightup/item/domain/ItemApply.java
+++ b/src/main/java/umc/lightup/item/domain/ItemApply.java
@@ -1,0 +1,38 @@
+package umc.lightup.item.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import umc.lightup.item.enums.ItemApplyStatus;
+import umc.lightup.member.domain.Member;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemApply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Enumerated(EnumType.STRING)
+    private ItemApplyStatus status; // 지원 상태: 대기, 수락, 거절
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime appliedAt;
+
+}
+

--- a/src/main/java/umc/lightup/item/domain/ItemViewHistory.java
+++ b/src/main/java/umc/lightup/item/domain/ItemViewHistory.java
@@ -1,12 +1,17 @@
 package umc.lightup.item.domain;
 
 import jakarta.persistence.*;
+import lombok.*;
 import org.springframework.data.annotation.LastModifiedDate;
 import umc.lightup.member.domain.Member;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class ItemViewHistory { //extends 없음
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,4 +28,8 @@ public class ItemViewHistory { //extends 없음
     @LastModifiedDate
     @Column(nullable = false)
     private LocalDateTime viewedAt;
+
+    public void updateViewedAt() {
+        this.viewedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import umc.lightup.member.enums.Gender;
 import umc.lightup.member.enums.Mbti;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class ItemResponseDTO {
@@ -94,5 +95,14 @@ public class ItemResponseDTO {
         private String mainTasks;
         private String preferentialTreatment;
         private String preferMbti;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemApplyResultDTO {
+        private LocalDateTime appliedAt;
+        private String message;
     }
 }

--- a/src/main/java/umc/lightup/item/enums/ItemApplyStatus.java
+++ b/src/main/java/umc/lightup/item/enums/ItemApplyStatus.java
@@ -1,0 +1,5 @@
+package umc.lightup.item.enums;
+
+public enum ItemApplyStatus {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/umc/lightup/item/repository/ItemApplyRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemApplyRepository.java
@@ -1,0 +1,10 @@
+package umc.lightup.item.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.ItemApply;
+import umc.lightup.member.domain.Member;
+
+public interface ItemApplyRepository extends JpaRepository<ItemApply, Long> {
+    boolean existsByMemberAndItem(Member member, Item item);
+}

--- a/src/main/java/umc/lightup/item/repository/ItemViewHistoryRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemViewHistoryRepository.java
@@ -1,0 +1,12 @@
+package umc.lightup.item.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.ItemViewHistory;
+import umc.lightup.member.domain.Member;
+
+import java.util.Optional;
+
+public interface ItemViewHistoryRepository extends JpaRepository<ItemViewHistory, Long> {
+    Optional<ItemViewHistory> findByMemberAndItem(Member memberId, Item itemId);
+}

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -3,6 +3,7 @@ package umc.lightup.item.service;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.ItemApply;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.member.domain.Member;
@@ -12,6 +13,7 @@ import java.util.List;
 public interface ItemCommandService {
     Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile itemProfileImage, MultipartFile itemPlanFile);
     Item getSingleItem(Long itemId);
+    ItemApply applyItem(Member member, Item item);
     void addItemLike(Member member, long itemId);
     void removeItemLike(String email, long itemId);
     void updateItemHistory(Member member, Item item);

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -14,6 +14,7 @@ public interface ItemCommandService {
     Item getSingleItem(Long itemId);
     void addItemLike(Member member, long itemId);
     void removeItemLike(String email, long itemId);
+    void updateItemHistory(Member member, Item item);
 
     List<ItemResponseDTO.ItemResultDTO> getAllItems(Pageable pageable);
 

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -15,10 +15,8 @@ import umc.lightup.item.converter.ItemConverter;
 import umc.lightup.item.domain.*;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
-import umc.lightup.item.repository.ItemLikeRepository;
-import umc.lightup.item.repository.ItemRepository;
-import umc.lightup.item.repository.ItemViewHistoryRepository;
-import umc.lightup.item.repository.RecruitPositionRepository;
+import umc.lightup.item.enums.ItemApplyStatus;
+import umc.lightup.item.repository.*;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.repository.MemberRegionRepository;
 import umc.lightup.position.domain.Position;
@@ -40,6 +38,7 @@ public class ItemCommandServiceImpl implements ItemCommandService {
     private final PositionRepository positionRepository;
     private final ItemLikeRepository itemLikeRepository;
     private final ItemViewHistoryRepository itemViewHistoryRepository;
+    private final ItemApplyRepository itemApplyRepository;
 
     private final AmazonS3Manager s3Manager;
     private final UuidRepository uuidRepository;
@@ -187,5 +186,20 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                     .viewedAt(LocalDateTime.now())
                     .build());
         }
+    }
+
+    @Override
+    @Transactional
+    public ItemApply applyItem(Member member, Item item) {
+        if (itemApplyRepository.existsByMemberAndItem(member, item)) {
+            throw new GeneralHandler(ErrorStatus.DUPLICATE_ITEM_APPLY);
+        }
+
+        return itemApplyRepository.save(ItemApply.builder()
+                .member(member)
+                .item(item)
+                .status(ItemApplyStatus.PENDING)
+                .appliedAt(LocalDateTime.now())
+                .build());
     }
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -12,21 +12,21 @@ import umc.lightup.common.Uuid;
 import umc.lightup.common.repository.UuidRepository;
 import umc.lightup.exception.handler.GeneralHandler;
 import umc.lightup.item.converter.ItemConverter;
-import umc.lightup.item.domain.Item;
-import umc.lightup.item.domain.ItemLike;
-import umc.lightup.item.domain.ItemRegion;
-import umc.lightup.item.domain.RecruitPosition;
+import umc.lightup.item.domain.*;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.item.repository.ItemLikeRepository;
 import umc.lightup.item.repository.ItemRepository;
+import umc.lightup.item.repository.ItemViewHistoryRepository;
 import umc.lightup.item.repository.RecruitPositionRepository;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.repository.MemberRegionRepository;
 import umc.lightup.position.domain.Position;
 import umc.lightup.position.repository.PositionRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -39,6 +39,7 @@ public class ItemCommandServiceImpl implements ItemCommandService {
     private final RecruitPositionRepository recruitPositionRepository;
     private final PositionRepository positionRepository;
     private final ItemLikeRepository itemLikeRepository;
+    private final ItemViewHistoryRepository itemViewHistoryRepository;
 
     private final AmazonS3Manager s3Manager;
     private final UuidRepository uuidRepository;
@@ -168,6 +169,23 @@ public class ItemCommandServiceImpl implements ItemCommandService {
     public void removeItemLike(String email, long itemId) {
         if (itemLikeRepository.removeByMemberEmailAndItemId(email, itemId) == 0) {
             throw new GeneralHandler(ErrorStatus.ITEM_LIKE_NOT_FOUND);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void updateItemHistory(Member member, Item item) {
+        Optional<ItemViewHistory> optionalHistory = itemViewHistoryRepository.findByMemberAndItem(member, item);
+
+        if (optionalHistory.isPresent()) {
+            ItemViewHistory itemViewHistory = optionalHistory.get();
+            itemViewHistory.updateViewedAt();
+        } else {
+            itemViewHistoryRepository.save(ItemViewHistory.builder()
+                    .member(member)
+                    .item(item)
+                    .viewedAt(LocalDateTime.now())
+                    .build());
         }
     }
 }


### PR DESCRIPTION
## 💫 PR 제목
- [Item] 프로젝트 지원 기능 구현
---

## 🔧 작업 내용 요약
- 유저가 프로젝트에 지원하기 버튼을 누르면 프로젝트 지원 요청을 보내고 DB에 요청 내역이 저장됩니다.

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 유저가 다른 유저에게 제안을 보내는 API 는 아직 구현이 안 되었는데 프로젝트에 유저가 지원하는 API 방식이 적절한지 (ItemApply 엔티티를 추가하여 구현함)
- ItemApply 엔티티 설계가 적절한지
- 중복 지원 검증만 넣어놨는데 추가로 고려해야할 사항이 있을지

---

## 🔗 관련 이슈
- closes #46 

---

## 📝 기타 참고 사항
