### PR TITLE
[Item] 프로젝트 생성시 대표 주제 설정 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -61,6 +61,9 @@ public enum ErrorStatus implements BaseErrorCode {
     //ItemImage 관련 에러
     ITEM_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEM_IMAGE4000", "아이템 이미지가 존재하지 않습니다."),
 
+    //ItemCategory 관련 에러
+    ITEM_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEMCATEGORY4000", "해당 아이템 카테고리가 존재하지 않습니다."),
+
     //MemberSkill 관련 에러
     MEMBER_SKILL_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_SKILL4000", "유저의 스킬이 존재하지 않습니다."),
 

--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -52,6 +52,9 @@ public enum ErrorStatus implements BaseErrorCode {
     ITEM_ALREADY_LIKED(HttpStatus.BAD_REQUEST, "ITEMLIKE4001", "이미 좋아요를 누른 프로젝트입니다."),
     ITEM_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEMLIKE4002", "좋아요가 존재하지 않습니다."),
 
+    //ItemApply 관련 에러
+    DUPLICATE_ITEM_APPLY(HttpStatus.BAD_REQUEST, "ITEMAPPLY4000", "이미 지원한 프로젝트입니다."),
+
     //ItemViewHistory 관련 에러
     ITEM_VIEW_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEMVIEWHISTORY4000", "프로젝트 조회 내역이 존재하지 않습니다."),
 

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -18,6 +18,7 @@ import umc.lightup.api.ApiResponse;
 import umc.lightup.api.code.status.SuccessStatus;
 import umc.lightup.item.converter.ItemConverter;
 import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.ItemApply;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.item.service.ItemCommandService;
@@ -95,5 +96,14 @@ public class ItemRestController {
         String email = authentication.getName();
         itemCommandService.removeItemLike(email, itemId);
         return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+    }
+
+    @PostMapping("/{itemId}/apply")
+    @Operation(summary = "프로젝트 지원 API", description = "유저가 프로젝트에 지원 요청을 보내는 API 입니다.")
+    public ApiResponse<ItemResponseDTO.ItemApplyResultDTO> applyItem(Authentication authentication, @PathVariable("itemId") long itemId) {
+        Member member = memberCommandService.getMember(authentication.getName());
+        Item item = itemCommandService.getSingleItem(itemId);
+        ItemApply itemApply = itemCommandService.applyItem(member, item);
+        return ApiResponse.onSuccess(ItemConverter.toItemApplyResultDTO(itemApply));
     }
 }

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -1,6 +1,7 @@
 package umc.lightup.item.converter;
 
 import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.ItemApply;
 import umc.lightup.item.domain.ItemImage;
 import umc.lightup.item.domain.RecruitPosition;
 import umc.lightup.item.dto.ItemRequestDTO;
@@ -89,6 +90,13 @@ public class ItemConverter {
                 .projectStatus(request.isProjectStatus())
                 .extraLink1(request.getExtraLink1())
                 .extraLink2(request.getExtraLink2())
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemApplyResultDTO toItemApplyResultDTO (ItemApply itemApply) {
+        return ItemResponseDTO.ItemApplyResultDTO.builder()
+                .appliedAt(itemApply.getAppliedAt())
+                .message(itemApply.getItem().getName() + "에 지원했어요")
                 .build();
     }
 

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -1,9 +1,6 @@
 package umc.lightup.item.converter;
 
-import umc.lightup.item.domain.Item;
-import umc.lightup.item.domain.ItemApply;
-import umc.lightup.item.domain.ItemImage;
-import umc.lightup.item.domain.RecruitPosition;
+import umc.lightup.item.domain.*;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.member.domain.Member;

--- a/src/main/java/umc/lightup/item/domain/Item.java
+++ b/src/main/java/umc/lightup/item/domain/Item.java
@@ -32,6 +32,10 @@ public class Item extends BaseEntity {
     @Column(nullable = false)
     private String description;
 
+    @Builder.Default
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
+    private List<ItemCategory> itemCategories = new ArrayList<>();
+
     @Column(name = "project_status", nullable = false)
     private boolean projectStatus;
 
@@ -68,6 +72,11 @@ public class Item extends BaseEntity {
     public Item uploadItemPlanFile(String itemPlanFileUrl) {
         this.itemPlanFileUrl = itemPlanFileUrl;
         return this;
+    }
+
+    public void addItemCategory(ItemCategory itemCategory) {
+        this.itemCategories.add(itemCategory);
+        itemCategory.assignItem(this);
     }
 
     public void addItemRegion(ItemRegion itemRegion) {

--- a/src/main/java/umc/lightup/item/domain/ItemApply.java
+++ b/src/main/java/umc/lightup/item/domain/ItemApply.java
@@ -1,0 +1,38 @@
+package umc.lightup.item.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import umc.lightup.item.enums.ItemApplyStatus;
+import umc.lightup.member.domain.Member;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemApply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Enumerated(EnumType.STRING)
+    private ItemApplyStatus status; // 지원 상태: 대기, 수락, 거절
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime appliedAt;
+
+}
+

--- a/src/main/java/umc/lightup/item/domain/ItemCategory.java
+++ b/src/main/java/umc/lightup/item/domain/ItemCategory.java
@@ -1,0 +1,26 @@
+package umc.lightup.item.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.lightup.common.BaseEntity;
+import umc.lightup.item.enums.CategoryType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemCategory extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Item item;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CategoryType categoryType;
+
+    public void assignItem(Item item) { this.item = item; }
+}

--- a/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
@@ -26,6 +26,9 @@ public class ItemRequestDTO {
         private String extraLink2;
         @NotBlank
         private String description;
+        @Size(max = 3, message = "프로젝트 카테고리는 최대 3개까지 선택할 수 있습니다.")
+        @Valid
+        private List<ItemCategoryRequestDTO> itemCategories;
         private boolean projectStatus;
         @Size(max = 3, message = "협업 지역은 최대 3개까지 선택할 수 있습니다.")
         @Valid
@@ -33,6 +36,13 @@ public class ItemRequestDTO {
         @NotEmpty(message = "모집 포지션을 하나 이상 선택해야 합니다.")
         @Valid
         private List<RecruitPositionRequestDTO> recruitPositions;
+    }
+
+    @Getter
+    @Setter
+    public static class ItemCategoryRequestDTO {
+        @NotBlank
+        private String itemCategory;
     }
 
     @Getter

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import umc.lightup.member.enums.Gender;
 import umc.lightup.member.enums.Mbti;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class ItemResponseDTO {
@@ -94,5 +95,14 @@ public class ItemResponseDTO {
         private String mainTasks;
         private String preferentialTreatment;
         private String preferMbti;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemApplyResultDTO {
+        private LocalDateTime appliedAt;
+        private String message;
     }
 }

--- a/src/main/java/umc/lightup/item/enums/CategoryType.java
+++ b/src/main/java/umc/lightup/item/enums/CategoryType.java
@@ -1,0 +1,45 @@
+package umc.lightup.item.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.exception.handler.GeneralHandler;
+import umc.lightup.item.domain.ItemCategory;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum CategoryType {
+    PLATFORM("플랫폼"),
+    LIFESTYLE("라이프스타일"),
+    FINANCE("금융"),
+    COMMUNITY("커뮤니티"),
+    MEDIA("미디어"),
+    EDUCATION("교육"),
+    PRODUCTIVITY("생산성"),
+    BLOCKCHAIN("블록체인"),
+    NOCODE("노코드"),
+    AI("인공지능"),
+    DATA_ANALYSIS("데이터 분석"),
+    DESIGN("디자인"),
+    MARKETING("마케팅"),
+    GAME("게임"),
+    ECOMMERCE("이커머스"),
+    HEALTH_CARE("헬스 케어"),
+    BIO("바이오"),
+    META_BUS("메타버스"),
+    SALES("세일즈"),
+    SECURITY("보안"),
+    ESG("ESG"),
+    ROBOTICS("로보틱스");
+
+    private final String displayName;
+
+    public static CategoryType toCategoryType(String displayName) {
+        return Arrays.stream(values())
+                .filter(c -> c.displayName.equals(displayName))
+                .findAny()
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_CATEGORY_NOT_FOUND));
+    }
+}

--- a/src/main/java/umc/lightup/item/enums/ItemApplyStatus.java
+++ b/src/main/java/umc/lightup/item/enums/ItemApplyStatus.java
@@ -1,0 +1,5 @@
+package umc.lightup.item.enums;
+
+public enum ItemApplyStatus {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/umc/lightup/item/repository/ItemApplyRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemApplyRepository.java
@@ -1,0 +1,10 @@
+package umc.lightup.item.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.ItemApply;
+import umc.lightup.member.domain.Member;
+
+public interface ItemApplyRepository extends JpaRepository<ItemApply, Long> {
+    boolean existsByMemberAndItem(Member member, Item item);
+}

--- a/src/main/java/umc/lightup/item/repository/ItemCategoryRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemCategoryRepository.java
@@ -1,0 +1,9 @@
+package umc.lightup.item.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.lightup.item.domain.ItemCategory;
+
+@Repository
+public interface ItemCategoryRepository extends JpaRepository<ItemCategory, Long> {
+}

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -3,6 +3,7 @@ package umc.lightup.item.service;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.item.domain.Item;
+import umc.lightup.item.domain.ItemApply;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.member.domain.Member;
@@ -12,6 +13,7 @@ import java.util.List;
 public interface ItemCommandService {
     Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile itemProfileImage, MultipartFile itemPlanFile);
     Item getSingleItem(Long itemId);
+    ItemApply applyItem(Member member, Item item);
     void addItemLike(Member member, long itemId);
     void removeItemLike(String email, long itemId);
     void updateItemHistory(Member member, Item item);

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -15,10 +15,8 @@ import umc.lightup.item.converter.ItemConverter;
 import umc.lightup.item.domain.*;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
-import umc.lightup.item.repository.ItemLikeRepository;
-import umc.lightup.item.repository.ItemRepository;
-import umc.lightup.item.repository.ItemViewHistoryRepository;
-import umc.lightup.item.repository.RecruitPositionRepository;
+import umc.lightup.item.enums.ItemApplyStatus;
+import umc.lightup.item.repository.*;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.repository.MemberRegionRepository;
 import umc.lightup.position.domain.Position;
@@ -40,6 +38,7 @@ public class ItemCommandServiceImpl implements ItemCommandService {
     private final PositionRepository positionRepository;
     private final ItemLikeRepository itemLikeRepository;
     private final ItemViewHistoryRepository itemViewHistoryRepository;
+    private final ItemApplyRepository itemApplyRepository;
 
     private final AmazonS3Manager s3Manager;
     private final UuidRepository uuidRepository;
@@ -187,5 +186,20 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                     .viewedAt(LocalDateTime.now())
                     .build());
         }
+    }
+
+    @Override
+    @Transactional
+    public ItemApply applyItem(Member member, Item item) {
+        if (itemApplyRepository.existsByMemberAndItem(member, item)) {
+            throw new GeneralHandler(ErrorStatus.DUPLICATE_ITEM_APPLY);
+        }
+
+        return itemApplyRepository.save(ItemApply.builder()
+                .member(member)
+                .item(item)
+                .status(ItemApplyStatus.PENDING)
+                .appliedAt(LocalDateTime.now())
+                .build());
     }
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -15,6 +15,7 @@ import umc.lightup.item.converter.ItemConverter;
 import umc.lightup.item.domain.*;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
+import umc.lightup.item.enums.CategoryType;
 import umc.lightup.item.enums.ItemApplyStatus;
 import umc.lightup.item.repository.*;
 import umc.lightup.member.domain.Member;
@@ -64,6 +65,16 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
             String itemPlanFileUrl = s3Manager.uploadFile(s3Manager.generateItemFileKeyName(savedUuid), itemPlanFile);
             item.uploadItemPlanFile(itemPlanFileUrl);
+        }
+
+        for (ItemRequestDTO.ItemCategoryRequestDTO dto : request.getItemCategories()) {
+            CategoryType categoryType = CategoryType.toCategoryType(dto.getItemCategory());
+            ItemCategory itemCategory = ItemCategory.builder()
+                    .item(item)
+                    .categoryType(categoryType)
+                    .build();
+
+            item.addItemCategory(itemCategory);
         }
 
         for (ItemRequestDTO.CollaborationRegionRequestDTO dto : request.getCollaborationRegions()) {


### PR DESCRIPTION
## 💫 PR 제목
- [Item] 프로젝트 생성시 대표 주제 설정 기능 구현

---

## 🔧 작업 내용 요약
- 프로젝트 생성시 대표 주제를 3개까지 설정할 수 있도록 구현했습니다.
- 대표 주제는 저희 서비스 자체적으로 제공하며 enum 값으로 관리하고 있습니다.


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 사용자에게 대표 주제 요청을 받을 때는 String으로 받고 이를 Service에서 사용할 때는 enum 함수로 enum값으로 변경하여 사용했는데 이 방식이 적절한지

---

## 🔗 관련 이슈
-

---

## 📝 기타 참고 사항
- 
