### PR TITLE
[Member] 유저의 선호 지역 선택 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -18,6 +18,8 @@ import umc.lightup.member.dto.MemberResponseDTO;
 import umc.lightup.member.service.CredentialQueryService;
 import umc.lightup.member.service.MemberCommandService;
 
+import java.util.List;
+
 import static umc.lightup.member.dto.MemberResponseDTO.memberPositionDeleteResultDTOBuilder;
 import static umc.lightup.member.dto.MemberResponseDTO.memberPositionResultDTOBuilder;
 
@@ -214,5 +216,16 @@ public class MemberRestController {
 
         String strengthName = memberCommandService.selectStrength(strengthId, member);
         return ApiResponse.onSuccess(MemberConverter.toSelectStrengthResultDTO(strengthName, member));
+    }
+
+
+    @PostMapping("/regions")
+    @Operation(summary = "유저 선호 지역 선택 API", description = "유저가 선호 지역을 선택하는 API입니다.")
+    public ApiResponse<MemberResponseDTO.selectRegionResultsDTO> selectRegions(Authentication authentication, @RequestBody @Valid MemberRequestDTO.MemberRegionListRequestDTO request) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+
+        List<MemberResponseDTO.singleRegionResultDTO> resultDTOList = memberCommandService.selectRegions(member, request);
+        return ApiResponse.onSuccess(MemberConverter.toSelectRegionResultsDTO(resultDTOList));
     }
 }

--- a/src/main/java/umc/lightup/member/converter/MemberConverter.java
+++ b/src/main/java/umc/lightup/member/converter/MemberConverter.java
@@ -1,7 +1,10 @@
 package umc.lightup.member.converter;
 
 import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.MemberRegion;
 import umc.lightup.member.dto.MemberResponseDTO;
+
+import java.util.List;
 
 public class MemberConverter {
 
@@ -16,6 +19,19 @@ public class MemberConverter {
         return MemberResponseDTO.selectStrengthResultDTO.builder()
                 .strengthName(strengthName)
                 .memberName(member.getName())
+                .build();
+    }
+
+    public static MemberResponseDTO.selectRegionResultsDTO toSelectRegionResultsDTO(List<MemberResponseDTO.singleRegionResultDTO> regionList) {
+        return MemberResponseDTO.selectRegionResultsDTO.builder()
+                .regions(regionList)
+                .build();
+    }
+
+    public static MemberResponseDTO.singleRegionResultDTO toSingleRegionResultDTO (MemberRegion memberRegion) {
+        return MemberResponseDTO.singleRegionResultDTO.builder()
+                .siDo(memberRegion.getSiDo())
+                .siGunGu(memberRegion.getSiGunGu())
                 .build();
     }
 }

--- a/src/main/java/umc/lightup/member/domain/Member.java
+++ b/src/main/java/umc/lightup/member/domain/Member.java
@@ -13,6 +13,7 @@ import umc.lightup.member.enums.Role;
 import umc.lightup.member.service.CredentialQueryService;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -59,6 +60,15 @@ public class Member extends BaseEntity implements UserDetails {
     private String career;
 
     private String profileImageUrl; // 추가, S3 필요
+
+    @Builder.Default
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberRegion> memberRegions = new ArrayList<>();
+
+    public void addMemberRegion(MemberRegion memberRegion) {
+        this.memberRegions.add(memberRegion);
+        memberRegion.assignMember(this);
+    }
 
 //    @OneToMany(mappedBy = "member", orphanRemoval = true)
 //    private List<Credential> credentials;

--- a/src/main/java/umc/lightup/member/domain/MemberRegion.java
+++ b/src/main/java/umc/lightup/member/domain/MemberRegion.java
@@ -19,7 +19,10 @@ public class MemberRegion extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "region_id", nullable = false)
-    private Region region;
+    @Column(nullable = false)
+    private String siDo;
+
+    private String siGunGu;
+
+    public void assignMember(Member member) { this.member = member; }
 }

--- a/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
@@ -1,5 +1,6 @@
 package umc.lightup.member.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -11,9 +12,12 @@ import umc.lightup.member.enums.Role;
 import umc.lightup.member.validation.annotation.UniqueEmail;
 import umc.lightup.member.validation.annotation.UniqueNickname;
 import umc.lightup.member.validation.annotation.ValidRole;
+import umc.lightup.region.validation.annotation.ExistSiDo;
+import umc.lightup.region.validation.annotation.ExistSiGunGu;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 public class MemberRequestDTO {
 
@@ -144,5 +148,23 @@ public class MemberRequestDTO {
         @NotNull
         private Long strengthId;
      
+    }
+
+    @Getter
+    @Setter
+    public static class MemberRegionListRequestDTO {
+        @Size(max = 3, message = "지역은 최대 3개까지 선택할 수 있습니다.")
+        @Valid
+        private List<MemberRegionRequestDTO> memberRegions;
+    }
+
+    @Getter
+    @Setter
+    public static class MemberRegionRequestDTO {
+        @NotBlank
+        @ExistSiDo
+        private String siDo;
+        @ExistSiGunGu
+        private String siGunGu;
     }
 }

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -64,7 +64,7 @@ public class MemberResponseDTO {
         private String school;
         private List<String> skills;
         private List<String> strengths;
-        private List<String> regions;
+        private List<singleRegionResultDTO> regions;
         private List<PortfolioInfoDTO> portfolios;
         private String email;
         private String phoneNumber;
@@ -123,6 +123,24 @@ public class MemberResponseDTO {
     public static class selectStrengthResultDTO {
         String strengthName;
         String memberName;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class selectRegionResultsDTO {
+        private List<singleRegionResultDTO> regions;
+    }
+
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class singleRegionResultDTO {
+        String siDo;
+        String siGunGu;
     }
 
     public static LoginResultDTO.LoginResultDTOBuilder loginResultDTOBuilder() {

--- a/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
+++ b/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
@@ -1,7 +1,9 @@
 package umc.lightup.member.dto;
 
 import lombok.*;
+import umc.lightup.member.converter.MemberConverter;
 import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.MemberRegion;
 import umc.lightup.member.domain.Portfolio;
 import umc.lightup.region.domain.Region;
 
@@ -22,7 +24,7 @@ public class MemberViewInfo {
     private Member member;
     private List<String> skills;
     private List<String> strengths;
-    private List<Region> regions;
+    private List<MemberRegion> regions;
     private List<Portfolio> portfolios;
     private boolean emailOpen = false;
     private boolean phoneOpen = false;
@@ -42,8 +44,11 @@ public class MemberViewInfo {
 
                 .skills(skills)
                 .strengths(strengths)
-                .regions(regions.stream()
+                /*.regions(regions.stream()
                         .map(r->r.getSiDo()+" "+r.getSiGunGu())
+                        .toList())*/
+                .regions(regions.stream()
+                        .map(MemberConverter::toSingleRegionResultDTO)
                         .toList())
                 .portfolios(portfolios.stream()
                         .map(portfolio -> MemberResponseDTO.PortfolioInfoDTO.builder()

--- a/src/main/java/umc/lightup/member/service/MemberCommandService.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandService.java
@@ -4,6 +4,8 @@ import umc.lightup.member.domain.Member;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
 
+import java.util.List;
+
 public interface MemberCommandService {
     Member joinMember(MemberRequestDTO.JoinDto request);
     MemberResponseDTO.LoginResultDTO loginMember(MemberRequestDTO.PasswordLoginRequestDTO request);
@@ -12,6 +14,7 @@ public interface MemberCommandService {
     Member putMember(String email, MemberRequestDTO.ChangeDto request);
     String selectSkill(Long skillId,Member member);
     String selectStrength(Long strengthId,Member member);
+    List<MemberResponseDTO.singleRegionResultDTO> selectRegions(Member member, MemberRequestDTO.MemberRegionListRequestDTO request);
     void addMemberLike(Member fromMember, long toMemberId);
     void removeMemberLike(String fromMemberEmail, long toMemberId);
     boolean isNicknameExist(String nickname);

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.lightup.api.code.status.ErrorStatus;
 import umc.lightup.config.JwtTokenProvider;
 import umc.lightup.exception.handler.GeneralHandler;
+import umc.lightup.member.converter.MemberConverter;
 import umc.lightup.member.domain.*;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
@@ -26,6 +27,7 @@ import umc.lightup.strength.repository.StrengthRepository;
 import umc.lightup.position.domain.Position;
 import umc.lightup.position.repository.PositionRepository;
 
+import java.util.ArrayList;
 import java.util.Collections;
 
 import umc.lightup.member.repository.*;
@@ -43,6 +45,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final MemberPositionRepository memberPositionRepository;
     private final MemberSkillRepository memberSkillRepository;
     private final MemberStrengthRepository memberStrengthRepository;
+    private final MemberRegionRepository memberRegionRepository;
     private final PositionRepository positionRepository;
     private final SkillRepository skillRepository;
     private final StrengthRepository strengthRepository;
@@ -131,7 +134,9 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
         List<String> skills = memberSkillRepository.findSkillNameByMember(member);
         List<String> strengths = memberStrengthRepository.findStrengthNameByMember(member);
-        List<Region> regions = regionRepository.findByMember(member);
+//        List<Region> regions = regionRepository.findByMember(member);
+        List<MemberRegion> regions = memberRegionRepository.findByMember(member);
+
         List<Portfolio> portfolios = portfolioRepository.findByMember(member);
         return MemberViewInfo.builder()
                 .member(member)
@@ -190,6 +195,23 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         memberStrengthRepository.save(memberStrength);
 
         return foundStrength.getName();
+    }
+
+    @Override
+    @Transactional
+    public List<MemberResponseDTO.singleRegionResultDTO> selectRegions(Member member, MemberRequestDTO.MemberRegionListRequestDTO request) {
+        List<MemberResponseDTO.singleRegionResultDTO> resultDTOList = new ArrayList<>();
+        for (MemberRequestDTO.MemberRegionRequestDTO dto : request.getMemberRegions()) {
+            MemberRegion memberRegion = MemberRegion.builder()
+                    .member(member)
+                    .siDo(dto.getSiDo())
+                    .siGunGu(dto.getSiGunGu() == null ? "전체" : dto.getSiGunGu())
+                    .build();
+
+            member.addMemberRegion(memberRegion);
+            resultDTOList.add(MemberConverter.toSingleRegionResultDTO(memberRegion));
+        }
+        return resultDTOList;
     }
 
     @Override

--- a/src/main/java/umc/lightup/region/repository/RegionRepository.java
+++ b/src/main/java/umc/lightup/region/repository/RegionRepository.java
@@ -15,8 +15,8 @@ public interface RegionRepository extends JpaRepository<Region, Long> {
 
     List<Region> findBySiDo(String siDo);
 
-    @Query("select r from MemberRegion mr join mr.region r where mr.member=:member")
-    List<Region> findByMember(@Param("member") Member member);
+/*    @Query("select r from MemberRegion mr join mr.region r where mr.member=:member")
+    List<Region> findByMember(@Param("member") Member member);*/
 
     boolean existsBySiDo(String siDo);
     boolean existsBySiGunGu(String siGunGu);


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 유저의 선호 지역 선택 기능 구현
---

## 🔧 작업 내용 요약
- 유저가 자신의 선호 지역을 선택할 수 있는 기능을 구현했습니다.
- 선호 지역은 최대 3개까지 설정할 수 있으며 시/군/구 를 선택하지 않으면 기본값은 "전체"로 설정됩니다.
- 기존 MemberRegion 엔티티는 region 엔티티와 매핑되어 있어 시/군/구 값도 필수로 입력받아야 했습니다. 따라서 MemberRegion 엔티티와 region 엔티티와의 매핑을 없앴습니다. 대신 MemberRegion 엔티티에 String 으로 각각 siDo, siGunGu 필드를 넣고 siDo 값만 nullable = false로 설정해서 사용자가 시/군/구를 필수로 선택하지 않아도 사용 가능하도록 했습니다.
- MemberRegion 엔티티가 변경됨에 따라 이전에 현승님이 구현해두셨던 MemberViewInfo 와 충돌이 나서 현재 구현된 방식과 맞도록 수정해두었습니다!


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 현재 구현한 방식이 적절한지

---

## 🔗 관련 이슈
- closes #49 

---

## 📝 기타 참고 사항
- 
