### PR TITLE
[Member] 소셜로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@ plugins {
 	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
+ext {
+	springCloudVersion = "2025.0.0"
+}
 
 group = 'umc'
 version = '0.0.1-SNAPSHOT'
@@ -30,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf' // 이메일 템플릿 설정용
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
@@ -45,6 +49,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion"
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/lightup/LightupApplication.java
+++ b/src/main/java/umc/lightup/LightupApplication.java
@@ -2,10 +2,12 @@ package umc.lightup;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
 public class LightupApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -24,6 +24,15 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_ROLE(HttpStatus.BAD_REQUEST, "MEMBER4006", "올바른 Role이 아닙니다. LEADER, TEAMMATE 중 하나를 선택해 주세요."),
     NO_CREDENTIAL(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER5000", "저장된 패스워드가 없습니다."),
 
+    // Credential 관련 에러
+    CREDENTIAL_NOT_FOUND(HttpStatus.BAD_REQUEST, "CREDENTIAL4000", "해당 형태의 로그인 정보를 찾을 수 없습니다."),
+    ALREADY_SIGNED_IN_EMAIL(HttpStatus.BAD_REQUEST, "CREDENTIAL4001", "이미 동일한 이메일로 가입된 회원이 있습니다."),
+    CREDENTIAL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "CREDENTIAL4002", "이미 해당 방법으로 소셜로그인이 연결되어 있습니다."),
+    CREDENTIAL_ALREADY_USED(HttpStatus.BAD_REQUEST, "CREDENTIAL4003", "이미 다른 계정에 소셜로그인이 연결되어 있습니다."),
+    ONLY_CREDENTIAL_REMAIN(HttpStatus.BAD_REQUEST, "CREDENTIAL4004", "현재 유일한 로그인 방법이 하나밖에 없습니다. 로그인 방법을 지우면 로그인이 불가합니다."),
+    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "CREDENTIAL4005", "auth code가 올바르지 않습니다."),
+    AUTH_NOT_GRANTED(HttpStatus.BAD_REQUEST, "CREDENTIAL4006", "소셜로그인의 권한이 부족합니다. 필요한 모든 권한 제공에 동의했는지 확인해 주세요."),
+
     //MemberLike 관련 에러
     ALREADY_LIKED(HttpStatus.BAD_REQUEST, "MEMBER4100", "이미 좋아요 한 회원입니다. 좋아요를 취소하려면 Delete Method로 요청을 보내 주세요."),
     LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4101", "좋아요하지 않은 회원입니다. 좋아요를 하려면 Post Method로 요청을 보내 주세요."),

--- a/src/main/java/umc/lightup/config/SecurityConfig.java
+++ b/src/main/java/umc/lightup/config/SecurityConfig.java
@@ -36,6 +36,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers("/api/v1/members/me",
                                 "/api/v1/members/password/change",
+                                "/api/v1/members/login/path",
+                                "/api/v1/members/login/path/**",
                                 "/api/v1/members/*/like")
                         .authenticated()
                         .anyRequest().permitAll()

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -10,11 +10,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import umc.lightup.api.ApiResponse;
+import umc.lightup.api.code.status.ErrorStatus;
 import umc.lightup.api.code.status.SuccessStatus;
+import umc.lightup.exception.handler.GeneralHandler;
 import umc.lightup.member.converter.MemberConverter;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
+import umc.lightup.member.enums.CredentialType;
 import umc.lightup.member.service.CredentialQueryService;
 import umc.lightup.member.service.MemberCommandService;
 
@@ -44,6 +47,81 @@ public class MemberRestController {
     public ApiResponse<MemberResponseDTO.LoginResultDTO> login
             (@RequestBody @Valid MemberRequestDTO.PasswordLoginRequestDTO request) {
         return ApiResponse.onSuccess(memberCommandService.loginMember(request));
+    }
+
+    @PostMapping("/join/{oauth}")
+    @Operation(summary = "유저 소셜로그인을 통한 회원가입 API",description = "유저가 소셜로그인으로 회원가입하는 API입니다.")
+    public ApiResponse<MemberResponseDTO.JoinResultDTO> joinByOAuth(
+            @PathVariable("oauth") CredentialType oauth,
+            @RequestParam @NotBlank String authCode) {
+        Member member = switch (oauth) {
+            case GOOGLE -> memberCommandService.joinMemberByGoogle(authCode);
+            case KAKAO -> memberCommandService.joinMemberByKakao(authCode);
+            case PASSWORD -> throw new GeneralHandler(ErrorStatus._BAD_REQUEST);
+        };
+        return ApiResponse.onSuccess(MemberResponseDTO.joinResultDTOBuilder()
+                .memberId(member.getId())
+                .createdAt(member.getCreatedAt())
+                .build());
+    }
+
+    @PostMapping("/login/{oauth}")
+    @Operation(summary = "유저 소셜로그인 API",description = "유저가 소셜로그인하는 API입니다.")
+    public ApiResponse<MemberResponseDTO.LoginResultDTO> loginByOAuth
+            (@PathVariable("oauth") CredentialType oauth,
+             @RequestParam @NotBlank String authCode) {
+        MemberResponseDTO.LoginResultDTO loginResult = switch (oauth) {
+            case GOOGLE -> memberCommandService.loginMemberByGoogle(authCode);
+            case KAKAO -> memberCommandService.loginMemberByKakao(authCode);
+            case PASSWORD -> throw new GeneralHandler(ErrorStatus._BAD_REQUEST);
+        };
+        return ApiResponse.onSuccess(loginResult);
+    }
+
+    @PostMapping("login/path/{oauth}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "유저 소셜로그인 방법 추가 API",
+            description = "유저가 로그인 방법을 추가하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<Void> addLogin
+            (Authentication authentication,
+             @PathVariable("oauth") CredentialType oauth,
+             @RequestParam @NotBlank String authCode) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+        switch (oauth) {
+            case GOOGLE -> memberCommandService.addGoogleLogin(member, authCode);
+            case KAKAO -> memberCommandService.addKakaoLogin(member, authCode);
+            case PASSWORD -> memberCommandService.addPasswordLogin(member, authCode);
+        };
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+    }
+
+    @GetMapping("login/path")
+    @Operation(summary = "유저 소셜로그인 방법 확인 API",
+            description = "유저가 로그인 방법을 확인하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.CredentialInfoResultDTO> checkLogin
+            (Authentication authentication) {
+        String email = authentication.getName();
+        return ApiResponse.onSuccess(credentialQueryService.getMemberCredentials(email));
+    }
+
+    @DeleteMapping("login/path/{oauth}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "유저 소셜로그인 방법 삭제 API",
+            description = "유저가 로그인 방법을 삭제하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<Void> removeLogin
+            (Authentication authentication,
+             @PathVariable("oauth") CredentialType oauth) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+        memberCommandService.removeCredential(member, oauth);
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
     }
 
     @GetMapping("/me")

--- a/src/main/java/umc/lightup/member/converter/MemberConverter.java
+++ b/src/main/java/umc/lightup/member/converter/MemberConverter.java
@@ -1,7 +1,10 @@
 package umc.lightup.member.converter;
 
+import umc.lightup.member.domain.Credential;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.dto.MemberResponseDTO;
+
+import java.util.List;
 
 public class MemberConverter {
 
@@ -16,6 +19,18 @@ public class MemberConverter {
         return MemberResponseDTO.selectStrengthResultDTO.builder()
                 .strengthName(strengthName)
                 .memberName(member.getName())
+                .build();
+    }
+
+    public static MemberResponseDTO.CredentialInfoResultDTO toSelectCredentialInfoResultDTO(List<Credential> credentials) {
+        return MemberResponseDTO.CredentialInfoResultDTO.builder()
+                .credentials(credentials.stream()
+                        .map(c->MemberResponseDTO.CredentialInfoDTO.builder()
+                                .credentialType(c.getCredentialType())
+                                .createdAt(c.getCreatedAt())
+                                .updatedAt(c.getUpdatedAt())
+                                .build())
+                        .toList())
                 .build();
     }
 }

--- a/src/main/java/umc/lightup/member/domain/Member.java
+++ b/src/main/java/umc/lightup/member/domain/Member.java
@@ -26,7 +26,7 @@ public class Member extends BaseEntity implements UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 20)
+    @Column(length = 20) //소셜로그인 회원가입 시 안 들어올 수 있음
     private String name;
 
     @Column(unique = true, length = 20)

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -2,6 +2,7 @@ package umc.lightup.member.dto;
 
 import lombok.*;
 import umc.lightup.member.domain.Member;
+import umc.lightup.member.enums.CredentialType;
 import umc.lightup.member.enums.Mbti;
 import umc.lightup.member.enums.Role;
 
@@ -70,7 +71,25 @@ public class MemberResponseDTO {
         private String phoneNumber;
         private String profileImageUrl;
     }
-    
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CredentialInfoResultDTO {
+        private List<CredentialInfoDTO> credentials;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CredentialInfoDTO {
+        private CredentialType credentialType;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+
     @Getter
     @Builder
     @NoArgsConstructor

--- a/src/main/java/umc/lightup/member/dto/OAuth2RequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/OAuth2RequestDTO.java
@@ -1,0 +1,32 @@
+package umc.lightup.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class OAuth2RequestDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GoogleOAuth2RequestDTO {
+        String code;
+        String client_id;
+        String client_secret;
+        String redirect_uri;
+        String grant_type;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class KakaoOAuth2RequestDTO {
+        String grant_type;
+        String client_id;
+        String redirect_uri;
+        String code;
+        String client_secret;
+    }
+}

--- a/src/main/java/umc/lightup/member/dto/OAuth2ResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/OAuth2ResponseDTO.java
@@ -1,0 +1,67 @@
+package umc.lightup.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class OAuth2ResponseDTO {
+    @Getter
+    @Setter
+    public static class GoogleOAuth2ResponseDTO {
+        String access_token;
+//        String refresh_token;
+        int expires_in;
+        String scope;
+        String token_type;
+        String id_token;
+//        String id_token_hint;
+//        String refresh_token_hint;
+//        String scope_hint;
+//        String token_hint;
+    }
+
+    @Getter
+    @Setter
+    public static class GoogleUserinfoResponseDTO {
+        String sub;
+        String id;
+        String email;
+        String verified_email;
+        String name;
+        String given_name;
+        String family_name;
+        String picture;
+        String locale;
+    }
+
+    @Getter
+    @Setter
+    public static class KakaoUserinfoResponseDTO {
+        long id;
+        KakaoAccount kakao_account;
+
+        @Getter
+        @Setter
+        public static class KakaoAccount {
+            String email;
+            Profile profile;
+        }
+
+        @Getter
+        @Setter
+        public static class Profile {
+            String nickname;
+            String profile_image_url;
+        }
+
+        public String getEmail() {
+            return kakao_account.getEmail();
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class KakaoOAuth2ResponseDTO {
+        private String access_token;
+        // ...
+    }
+}

--- a/src/main/java/umc/lightup/member/openfeign/GoogleApiClient.java
+++ b/src/main/java/umc/lightup/member/openfeign/GoogleApiClient.java
@@ -1,0 +1,17 @@
+package umc.lightup.member.openfeign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import umc.lightup.member.dto.OAuth2ResponseDTO;
+
+@FeignClient(name = "googleApiClient", url = "https://www.googleapis.com")
+public interface GoogleApiClient {
+    @GetMapping(value = "/userinfo/v2/me",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<OAuth2ResponseDTO.GoogleUserinfoResponseDTO> getUserinfo
+            (@RequestHeader("Authorization") String authHeader);
+}

--- a/src/main/java/umc/lightup/member/openfeign/GoogleOAuth2Client.java
+++ b/src/main/java/umc/lightup/member/openfeign/GoogleOAuth2Client.java
@@ -1,0 +1,17 @@
+package umc.lightup.member.openfeign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import umc.lightup.member.dto.OAuth2RequestDTO;
+import umc.lightup.member.dto.OAuth2ResponseDTO;
+
+@FeignClient(name = "googleOAuth2Client", url = "https://oauth2.googleapis.com")
+public interface GoogleOAuth2Client {
+    @PostMapping(value = "/token",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    ResponseEntity<OAuth2ResponseDTO.GoogleOAuth2ResponseDTO> requestAccessToken
+            (@RequestBody OAuth2RequestDTO.GoogleOAuth2RequestDTO body);
+}

--- a/src/main/java/umc/lightup/member/openfeign/KakaoApiClient.java
+++ b/src/main/java/umc/lightup/member/openfeign/KakaoApiClient.java
@@ -1,0 +1,14 @@
+package umc.lightup.member.openfeign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import umc.lightup.member.dto.OAuth2ResponseDTO;
+
+@FeignClient(name = "kakaoApiClient", url = "https://kapi.kakao.com")
+public interface KakaoApiClient {
+    @GetMapping("/v2/user/me")
+    ResponseEntity<OAuth2ResponseDTO.KakaoUserinfoResponseDTO> getUserInfo
+            (@RequestHeader("Authorization") String authorization);
+}

--- a/src/main/java/umc/lightup/member/openfeign/KakaoOAuth2Client.java
+++ b/src/main/java/umc/lightup/member/openfeign/KakaoOAuth2Client.java
@@ -1,0 +1,17 @@
+package umc.lightup.member.openfeign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import umc.lightup.member.dto.OAuth2RequestDTO;
+import umc.lightup.member.dto.OAuth2ResponseDTO;
+
+@FeignClient(name = "kakaoOAuth2Client", url = "https://kauth.kakao.com")
+public interface KakaoOAuth2Client {
+    @PostMapping(value = "/oauth/token",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+    ResponseEntity<OAuth2ResponseDTO.KakaoOAuth2ResponseDTO> getToken
+            (@RequestBody OAuth2RequestDTO.KakaoOAuth2RequestDTO body);
+}

--- a/src/main/java/umc/lightup/member/repository/CredentialRepository.java
+++ b/src/main/java/umc/lightup/member/repository/CredentialRepository.java
@@ -1,16 +1,26 @@
 package umc.lightup.member.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import umc.lightup.member.domain.Credential;
+import umc.lightup.member.domain.Member;
 import umc.lightup.member.enums.CredentialType;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface CredentialRepository extends JpaRepository<Credential, Long> {
     @Query("select c from Credential c join fetch c.member m where c.credentialType=:credentialType and m.email=:email")
     Optional<Credential> findByCredentialTypeAndEmail(@Param("credentialType") CredentialType credentialType, @Param("email") String email);
+    @EntityGraph(attributePaths = {"member"})
+    Optional<Credential> findByCredentialTypeAndCredential(CredentialType credentialType, String credential);
+    boolean existsByCredentialTypeAndCredential(CredentialType credentialType, String credential);
+    boolean existsByCredentialTypeAndMember(CredentialType credentialType, Member member);
+    long countByMember(Member member);
+    long removeByCredentialTypeAndMember(CredentialType credentialType, Member member);
+    List<Credential> findAllByMemberEmail(String memberEmail);
 }

--- a/src/main/java/umc/lightup/member/service/CredentialQueryService.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryService.java
@@ -1,10 +1,17 @@
 package umc.lightup.member.service;
 
 import umc.lightup.member.domain.Credential;
+import umc.lightup.member.domain.Member;
 import umc.lightup.member.dto.MemberRequestDTO;
+import umc.lightup.member.dto.MemberResponseDTO;
+import umc.lightup.member.dto.OAuth2ResponseDTO;
 
 public interface CredentialQueryService {
     Credential findByEmail(String email);
     Credential updatePasswordByEmail(String email, MemberRequestDTO.PasswordChangeRequestDTO request);
     void initializePasswordByEmail(String email);
+    MemberResponseDTO.CredentialInfoResultDTO getMemberCredentials(String email);
+    OAuth2ResponseDTO.GoogleUserinfoResponseDTO getGoogleUserinfo(String authCode);
+    OAuth2ResponseDTO.KakaoUserinfoResponseDTO getKakaoUserinfo(String authCode);
+    MemberResponseDTO.LoginResultDTO getLoginResultDTO(Member member);
 }

--- a/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
@@ -1,19 +1,32 @@
 package umc.lightup.member.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.lightup.api.code.status.ErrorStatus;
 import umc.lightup.config.EmailService;
+import umc.lightup.config.JwtProperties;
+import umc.lightup.config.JwtTokenProvider;
 import umc.lightup.exception.handler.GeneralHandler;
+import umc.lightup.member.converter.MemberConverter;
 import umc.lightup.member.domain.Credential;
-import umc.lightup.member.dto.EmailRequestDTO;
-import umc.lightup.member.dto.MemberRequestDTO;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.dto.*;
 import umc.lightup.member.enums.CredentialType;
+import umc.lightup.member.openfeign.GoogleApiClient;
+import umc.lightup.member.openfeign.GoogleOAuth2Client;
+import umc.lightup.member.openfeign.KakaoApiClient;
+import umc.lightup.member.openfeign.KakaoOAuth2Client;
 import umc.lightup.member.repository.CredentialRepository;
 
 import java.security.SecureRandom;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -24,6 +37,26 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
     private final EmailService emailService;
     private final PasswordEncoder passwordEncoder;
     private final SecureRandom secureRandom;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private final GoogleOAuth2Client googleOAuth2Client;
+    private final GoogleApiClient googleApiClient;
+    private final KakaoOAuth2Client kakaoOAuth2Client;
+    private final KakaoApiClient kakaoApiClient;
+
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String googleClientId;
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String googleClientSecret;
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String googleRedirectUri;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String kakaoClientSecret;
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
 
     @Override
     public Credential findByEmail(String email) {
@@ -39,7 +72,7 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
     @Transactional
     public Credential updatePasswordByEmail(String email, MemberRequestDTO.PasswordChangeRequestDTO request) {
         Credential target = credentialRepository.findByCredentialTypeAndEmail(CredentialType.PASSWORD, email)
-                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.CREDENTIAL_NOT_FOUND));
         if (!passwordEncoder.matches(request.getPrevPassword(), target.getCredential())) {
             throw new GeneralHandler(ErrorStatus.INVALID_PASSWORD);
         }
@@ -61,7 +94,7 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
     @Transactional
     public void initializePasswordByEmail(String email) {
         Credential target = credentialRepository.findByCredentialTypeAndEmail(CredentialType.PASSWORD, email)
-                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.CREDENTIAL_NOT_FOUND));
 
         // 무작위 생성
         StringBuilder newPassword = new StringBuilder(PASSWORD_INITIALIZE_LENGTH);
@@ -82,5 +115,76 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
         // 비밀번호 재설정
         target.setCredential(passwordEncoder.encode(newPasswordString));
         credentialRepository.save(target);
+    }
+
+    @Override
+    public MemberResponseDTO.CredentialInfoResultDTO getMemberCredentials(String email) {
+        List<Credential> credentials = credentialRepository.findAllByMemberEmail(email);
+        return MemberConverter.toSelectCredentialInfoResultDTO(credentials);
+    }
+
+    @Override
+    public OAuth2ResponseDTO.GoogleUserinfoResponseDTO getGoogleUserinfo(String authCode) {
+        OAuth2RequestDTO.GoogleOAuth2RequestDTO oauth2Request =
+                OAuth2RequestDTO.GoogleOAuth2RequestDTO.builder()
+                        .code(authCode)
+                        .client_id(googleClientId)
+                        .client_secret(googleClientSecret)
+                        .redirect_uri(googleRedirectUri)
+                        .grant_type("authorization_code")
+                        .build();
+        ResponseEntity<OAuth2ResponseDTO.GoogleOAuth2ResponseDTO> oauth2Response =
+                googleOAuth2Client.requestAccessToken(oauth2Request);
+        if (!oauth2Response.getStatusCode().is2xxSuccessful() ||
+                oauth2Response.getBody() == null ||
+                oauth2Response.getBody().getAccess_token() == null)
+            throw new GeneralHandler(ErrorStatus.INVALID_AUTH_CODE);
+        ResponseEntity<OAuth2ResponseDTO.GoogleUserinfoResponseDTO> userinfo =
+                googleApiClient.getUserinfo(JwtProperties.TOKEN_PREFIX + oauth2Response.getBody().getAccess_token());
+        if (!userinfo.getStatusCode().is2xxSuccessful() ||
+                userinfo.getBody() == null ||
+                userinfo.getBody().getEmail() == null)
+            throw new GeneralHandler(ErrorStatus.AUTH_NOT_GRANTED);
+        return userinfo.getBody();
+    }
+
+    @Override
+    public OAuth2ResponseDTO.KakaoUserinfoResponseDTO getKakaoUserinfo(String authCode) {
+        OAuth2RequestDTO.KakaoOAuth2RequestDTO oauth2Request =
+                OAuth2RequestDTO.KakaoOAuth2RequestDTO.builder()
+                        .code(authCode)
+                        .client_id(kakaoClientId)
+                        .client_secret(kakaoClientSecret)
+                        .redirect_uri(kakaoRedirectUri)
+                        .grant_type("authorization_code")
+                        .build();
+        ResponseEntity<OAuth2ResponseDTO.KakaoOAuth2ResponseDTO> oauth2Response =
+                kakaoOAuth2Client.getToken(oauth2Request);
+        if (!oauth2Response.getStatusCode().is2xxSuccessful() ||
+                oauth2Response.getBody() == null ||
+                oauth2Response.getBody().getAccess_token() == null)
+            throw new GeneralHandler(ErrorStatus.INVALID_AUTH_CODE);
+        ResponseEntity<OAuth2ResponseDTO.KakaoUserinfoResponseDTO> userinfo =
+                kakaoApiClient.getUserInfo(JwtProperties.TOKEN_PREFIX + oauth2Response.getBody().getAccess_token());
+        if (!userinfo.getStatusCode().is2xxSuccessful() ||
+                userinfo.getBody() == null ||
+                userinfo.getBody().getEmail() == null)
+            throw new GeneralHandler(ErrorStatus.AUTH_NOT_GRANTED);
+        return userinfo.getBody();
+    }
+
+    @Override
+    public MemberResponseDTO.LoginResultDTO getLoginResultDTO(Member member) {
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                member.getEmail(), null,
+                Collections.singleton(() -> member.getRole().name())
+        );
+
+        String accessToken = jwtTokenProvider.generateToken(authentication);
+
+        return MemberResponseDTO.loginResultDTOBuilder()
+                .memberId(member.getId())
+                .accessToken(accessToken)
+                .build();
     }
 }

--- a/src/main/java/umc/lightup/member/service/MemberCommandService.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandService.java
@@ -3,10 +3,19 @@ package umc.lightup.member.service;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
+import umc.lightup.member.enums.CredentialType;
 
 public interface MemberCommandService {
     Member joinMember(MemberRequestDTO.JoinDto request);
     MemberResponseDTO.LoginResultDTO loginMember(MemberRequestDTO.PasswordLoginRequestDTO request);
+    MemberResponseDTO.LoginResultDTO loginMemberByGoogle(String authCode);
+    MemberResponseDTO.LoginResultDTO loginMemberByKakao(String authCode);
+    Member joinMemberByGoogle(String authCode);
+    Member joinMemberByKakao(String authCode);
+    Member addGoogleLogin(Member member, String authCode);
+    Member addKakaoLogin(Member member, String authCode);
+    Member addPasswordLogin(Member member, String password);
+    void removeCredential(Member member, CredentialType credentialType);
     Member getMember(String email);
     MemberResponseDTO.MemberInfoDTO getMember(long id, String viewerEmail);
     Member putMember(String email, MemberRequestDTO.ChangeDto request);

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -1,19 +1,15 @@
 package umc.lightup.member.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import umc.lightup.api.code.status.ErrorStatus;
-import umc.lightup.config.JwtTokenProvider;
 import umc.lightup.exception.handler.GeneralHandler;
 import umc.lightup.member.domain.*;
-import umc.lightup.member.dto.MemberRequestDTO;
-import umc.lightup.member.dto.MemberResponseDTO;
-import umc.lightup.member.dto.MemberViewInfo;
+import umc.lightup.member.dto.*;
 import umc.lightup.member.enums.CredentialType;
+import umc.lightup.member.enums.Role;
 import umc.lightup.member.repository.CredentialRepository;
 import umc.lightup.member.repository.MemberPositionRepository;
 import umc.lightup.member.repository.MemberRepository;
@@ -25,8 +21,6 @@ import umc.lightup.strength.domain.Strength;
 import umc.lightup.strength.repository.StrengthRepository;
 import umc.lightup.position.domain.Position;
 import umc.lightup.position.repository.PositionRepository;
-
-import java.util.Collections;
 
 import umc.lightup.member.repository.*;
 import umc.lightup.region.domain.Region;
@@ -49,9 +43,9 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final RegionRepository regionRepository;
     private final PortfolioRepository portfolioRepository;
     private final MemberLikeRepository memberLikeRepository;
-  
+
     private final PasswordEncoder passwordEncoder;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final CredentialQueryService credentialQueryService;
 
 
     @Override
@@ -68,25 +62,143 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     public MemberResponseDTO.LoginResultDTO loginMember(MemberRequestDTO.PasswordLoginRequestDTO request) {
         Credential credential = credentialRepository
                 .findByCredentialTypeAndEmail(CredentialType.PASSWORD, request.getEmail())
-                .orElseThrow(()-> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
-
-        Member member = credential.getMember(); //주객전도가 되긴 했으나 한 번의 쿼리로 데이터를 가져오기 위한 가장 편한 방법임
+                .orElseThrow(()-> new GeneralHandler(ErrorStatus.CREDENTIAL_NOT_FOUND));
 
         if(!passwordEncoder.matches(request.getPassword(), credential.getCredential())) {
             throw new GeneralHandler(ErrorStatus.INVALID_PASSWORD);
         }
 
-        Authentication authentication = new UsernamePasswordAuthenticationToken(
-                member.getEmail(), null,
-                Collections.singleton(() -> member.getRole().name())
-        );
+        //주객전도가 되긴 했으나 한 번의 쿼리로 데이터를 가져오기 위한 가장 편한 방법임
+        return credentialQueryService.getLoginResultDTO(credential.getMember());
+    }
 
-        String accessToken = jwtTokenProvider.generateToken(authentication);
+    @Override
+    public MemberResponseDTO.LoginResultDTO loginMemberByGoogle(String authCode) {
+        OAuth2ResponseDTO.GoogleUserinfoResponseDTO userinfo = credentialQueryService.getGoogleUserinfo(authCode);
 
-        return MemberResponseDTO.loginResultDTOBuilder()
-                .memberId(member.getId())
-                .accessToken(accessToken)
+        Credential credential = credentialRepository
+                .findByCredentialTypeAndCredential(CredentialType.GOOGLE, userinfo.getSub())
+                .orElseThrow(()-> new GeneralHandler(ErrorStatus.CREDENTIAL_NOT_FOUND));
+
+        return credentialQueryService.getLoginResultDTO(credential.getMember());
+    }
+
+    @Override
+    public MemberResponseDTO.LoginResultDTO loginMemberByKakao(String authCode) {
+        OAuth2ResponseDTO.KakaoUserinfoResponseDTO userinfo = credentialQueryService.getKakaoUserinfo(authCode);
+
+        Credential credential = credentialRepository
+                .findByCredentialTypeAndCredential(CredentialType.KAKAO, Long.toString(userinfo.getId()))
+                .orElseThrow(()-> new GeneralHandler(ErrorStatus.CREDENTIAL_NOT_FOUND));
+
+        return credentialQueryService.getLoginResultDTO(credential.getMember());
+    }
+
+    @Override
+    @Transactional
+    public Member joinMemberByGoogle(String authCode) {
+        OAuth2ResponseDTO.GoogleUserinfoResponseDTO userinfo = credentialQueryService.getGoogleUserinfo(authCode);
+
+        if (isEmailExist(userinfo.getEmail()))
+            throw new GeneralHandler(ErrorStatus.ALREADY_SIGNED_IN_EMAIL);
+
+        Member member = Member.builder()
+                .email(userinfo.getEmail())
+                .name(userinfo.getName())
+                .role(Role.PROVISION)
                 .build();
+        Credential credential = Credential.builder()
+                .credentialType(CredentialType.GOOGLE)
+                .member(member)
+                .credential(userinfo.getSub())
+                .build();
+        Member saved = memberRepository.save(member);
+        credentialRepository.save(credential);
+        return saved;
+    }
+
+    @Override
+    @Transactional
+    public Member joinMemberByKakao(String authCode) {
+        OAuth2ResponseDTO.KakaoUserinfoResponseDTO userinfo = credentialQueryService.getKakaoUserinfo(authCode);
+
+        if (userinfo.getEmail() == null || isEmailExist(userinfo.getEmail()))
+            throw new GeneralHandler(ErrorStatus.ALREADY_SIGNED_IN_EMAIL);
+
+        Member member = Member.builder()
+                .email(userinfo.getEmail())
+                .name(userinfo.getKakao_account().getProfile().getNickname())
+                .profileImageUrl(userinfo.getKakao_account().getProfile().getProfile_image_url())
+                .role(Role.PROVISION)
+                .build();
+        Credential credential = Credential.builder()
+                .credentialType(CredentialType.KAKAO)
+                .member(member)
+                .credential(Long.toString(userinfo.getId()))
+                .build();
+        Member saved = memberRepository.save(member);
+        credentialRepository.save(credential);
+        return saved;
+    }
+
+    @Override
+    @Transactional
+    public Member addGoogleLogin(Member member, String authCode) {
+        if (credentialRepository.existsByCredentialTypeAndMember(CredentialType.GOOGLE, member))
+            throw new GeneralHandler(ErrorStatus.CREDENTIAL_ALREADY_EXIST);
+        OAuth2ResponseDTO.GoogleUserinfoResponseDTO userinfo = credentialQueryService.getGoogleUserinfo(authCode);
+        if (credentialRepository.existsByCredentialTypeAndCredential(CredentialType.GOOGLE, userinfo.getSub()))
+            throw new GeneralHandler(ErrorStatus.CREDENTIAL_ALREADY_USED);
+
+        Credential credential = Credential.builder()
+                .credentialType(CredentialType.GOOGLE)
+                .member(member)
+                .credential(userinfo.getSub())
+                .build();
+        credentialRepository.save(credential);
+        return member;
+    }
+
+    @Override
+    @Transactional
+    public Member addKakaoLogin(Member member, String authCode) {
+        if (credentialRepository.existsByCredentialTypeAndMember(CredentialType.KAKAO, member))
+            throw new GeneralHandler(ErrorStatus.CREDENTIAL_ALREADY_EXIST);
+        OAuth2ResponseDTO.KakaoUserinfoResponseDTO userinfo = credentialQueryService.getKakaoUserinfo(authCode);
+        if (credentialRepository.existsByCredentialTypeAndCredential(CredentialType.KAKAO, Long.toString(userinfo.getId())))
+            throw new GeneralHandler(ErrorStatus.CREDENTIAL_ALREADY_USED);
+
+        Credential credential = Credential.builder()
+                .credentialType(CredentialType.KAKAO)
+                .member(member)
+                .credential(Long.toString(userinfo.getId()))
+                .build();
+        credentialRepository.save(credential);
+        return member;
+    }
+
+    @Override
+    @Transactional
+    public Member addPasswordLogin(Member member, String password) {
+        if (credentialRepository.existsByCredentialTypeAndMember(CredentialType.PASSWORD, member))
+            throw new GeneralHandler(ErrorStatus.CREDENTIAL_ALREADY_EXIST);
+        Credential credential = Credential.builder()
+                .credentialType(CredentialType.PASSWORD)
+                .member(member)
+                .credential(passwordEncoder.encode(password))
+                .build();
+        credentialRepository.save(credential);
+        return member;
+    }
+
+    @Override
+    @Transactional
+    public void removeCredential(Member member, CredentialType credentialType) {
+        if (credentialRepository.countByMember(member) <= 1)
+            throw new GeneralHandler(ErrorStatus.ONLY_CREDENTIAL_REMAIN);
+
+        if (credentialRepository.removeByCredentialTypeAndMember(credentialType, member) == 0)
+            throw new GeneralHandler(ErrorStatus.CREDENTIAL_NOT_FOUND);
     }
 
     @Override

--- a/src/test/java/umc/lightup/members/MemberTest.java
+++ b/src/test/java/umc/lightup/members/MemberTest.java
@@ -1476,8 +1476,8 @@ public class MemberTest {
 
         //Then
         assertAll("Password initialize with wrong email",
-                () -> assertEquals(ErrorStatus.MEMBER_NOT_FOUND.getCode(), change1Response.getCode()),
-                () -> assertEquals(ErrorStatus.MEMBER_NOT_FOUND.getMessage(), change1Response.getMessage())
+                () -> assertEquals(ErrorStatus.CREDENTIAL_NOT_FOUND.getCode(), change1Response.getCode()),
+                () -> assertEquals(ErrorStatus.CREDENTIAL_NOT_FOUND.getMessage(), change1Response.getMessage())
         );
     }
 


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 소셜로그인 구현

---

## 🔧 작업 내용 요약
- 구글, 카카오 로그인 구현
- 구글, 카카오로 회원가입
- 구글 카카오, 비밀번호 로그인 방식 추가 및 삭제
- 로그인 방법 추가에 따른 비밀번호 로그인 일부 수정
- 작업 진행 중 다른 변경사항(다른 PR)의 적용(rebase)으로 해당 내용이 같이 포함될 수 있습니다.

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 코드(함수)의 위치(클래스)가 적절한지
- feign client에서 사용하는 DTO의 정의 방식이 적절한지
- feign client에서 ResponseEntity를 받는 방식이 적절한지

---

## 🔗 관련 이슈
- closes #38

---

## 📝 기타 참고 사항
- 다른 서버와의 통신을 위해 spring cloud openfeign 사용