### PR TITLE
chore: 204 No Content return을 200 OK return으로 변경

### DIFF
--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -80,7 +79,6 @@ public class ItemRestController {
     }
 
     @PostMapping("/{itemId}/like")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "프로젝트 좋아요 등록 API", description = "유저가 특정 프로젝트에 좋아요를 등록하는 API 입니다.")
     public ApiResponse<Void> addItemLike(Authentication authentication, @PathVariable("itemId") long itemId) {
         String email = authentication.getName();
@@ -90,7 +88,6 @@ public class ItemRestController {
     }
 
     @DeleteMapping("/{itemId}/like")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "프로젝트 좋아요 취소 API", description = "유저가 특정 프로젝트의 좋아요를 취소하는 API 입니다.")
     public ApiResponse<Void> removeItemLike(Authentication authentication, @PathVariable("itemId") long itemId) {
         String email = authentication.getName();

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -6,7 +6,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import umc.lightup.api.ApiResponse;
@@ -118,7 +117,6 @@ public class MemberRestController {
     }
 
     @PostMapping("/password/change")
-    @ResponseStatus(HttpStatus.NO_CONTENT) //명시적으로 쓰기 싫었는데 안 쓰니 200 OK가 나가버리네...
     @Operation(
             summary = "비밀번호 변경 API",
             description = "비밀번호를 변경하는 API입니다. 로그아웃이 필요하지는 않습니다.",
@@ -133,7 +131,6 @@ public class MemberRestController {
     }
 
     @PostMapping("/password/initialize")
-    @ResponseStatus(HttpStatus.NO_CONTENT) //명시적으로 쓰기 싫었는데 안 쓰니 200 OK가 나가버리네...
     @Operation(
             summary = "비밀번호 초기화 API",
             description = "비밀번호를 변경하는 API입니다. 사용자가 비밀번호를 잊었을 때 사용합니다."
@@ -156,7 +153,6 @@ public class MemberRestController {
     }
 
     @PostMapping("/{memberId}/like")
-    @ResponseStatus(HttpStatus.NO_CONTENT) //명시적으로 쓰기 싫었는데 안 쓰니 200 OK가 나가버리네...
     @Operation(
             summary = "회원 좋아요 등록 API",
             description = "회원이 다른 회원에게 좋아요를 등록하는 API입니다.",
@@ -173,7 +169,6 @@ public class MemberRestController {
     }
 
     @DeleteMapping("/{memberId}/like")
-    @ResponseStatus(HttpStatus.NO_CONTENT) //명시적으로 쓰기 싫었는데 안 쓰니 200 OK가 나가버리네...
     @Operation(
             summary = "회원 좋아요 등록 취소 API",
             description = "회원이 다른 회원에게 진행한 좋아요 등록을 취소하는 API입니다.",


### PR DESCRIPTION
## 💫 PR 제목
- chore: 204 No Content return을 200 OK return으로 변경

---

## 🔧 작업 내용 요약
- 204 No Content를 반환하는 API를 프론트엔드 요청에 따라 200 OK 반환으로 변경

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 수정 이후의 응답 통일 방식(응답 통일에서 응답 message와 code는 기존 OK와는 다르긴 함)이 적절한지

---

## 🔗 관련 이슈
- 이슈 없이 진행

---

## 📝 기타 참고 사항
- 204 No Content 반환시 body가 없어 응답 통일이 깨지는 문제로 인해 프론트엔드에서 문제 발생, 이를 수정한 것
- @ResponseStatus(HttpStatus.NO_CONTENT)만 제거함