### PR TITLE
[Member] 비밀번호 확인 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -132,6 +132,20 @@ public class MemberRestController {
         //null 반환이 과연 옳은가? 물론 이 null 안 쓰려면 응답 통일 형식부터 갈아엎어야 하는 대공사가 필요하긴 함
     }
 
+    @PostMapping("/password/check")
+    @Operation(
+            summary = "비밀번호 확인 API",
+            description = "비밀번호가 일치하는지 확인하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<Void> passwordCheck(Authentication authentication,
+                                            @RequestBody @Valid MemberRequestDTO.PasswordCheckRequestDTO request) {
+        String email = authentication.getName();
+        credentialQueryService.checkPasswordByEmail(email,request.getPassword());
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+        //null 반환이 과연 옳은가? 물론 이 null 안 쓰려면 응답 통일 형식부터 갈아엎어야 하는 대공사가 필요하긴 함
+    }
+
     @PostMapping("/password/initialize")
     @ResponseStatus(HttpStatus.NO_CONTENT) //명시적으로 쓰기 싫었는데 안 쓰니 200 OK가 나가버리네...
     @Operation(

--- a/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
@@ -110,7 +110,7 @@ public class MemberRequestDTO {
         @NotBlank(message = "패스워드는 필수입니다.")
         private String password;
     }
-  
+
     @Getter
     @Setter
     @Builder
@@ -122,6 +122,16 @@ public class MemberRequestDTO {
 
         @NotBlank(message = "새로운 패스워드는 필수입니다.")
         private String newPassword;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class PasswordCheckRequestDTO {
+        @NotBlank(message = "패스워드는 필수입니다.")
+        private String password;
     }
 
     @Getter

--- a/src/main/java/umc/lightup/member/service/CredentialQueryService.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryService.java
@@ -6,5 +6,6 @@ import umc.lightup.member.dto.MemberRequestDTO;
 public interface CredentialQueryService {
     Credential findByEmail(String email);
     Credential updatePasswordByEmail(String email, MemberRequestDTO.PasswordChangeRequestDTO request);
+    void checkPasswordByEmail(String email, String password);
     void initializePasswordByEmail(String email);
 }

--- a/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
@@ -48,6 +48,14 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
         return target;
     }
 
+    @Override
+    public void checkPasswordByEmail(String email, String password) {
+        Credential target = credentialRepository.findByCredentialTypeAndEmail(CredentialType.PASSWORD, email)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        if (!passwordEncoder.matches(password, target.getCredential())) {
+            throw new GeneralHandler(ErrorStatus.INVALID_PASSWORD);
+        }
+    }
 
     private static final String PASSWORD_CHARACTERS =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*-_=+;,.<>?";


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 비밀번호 확인 기능 구현

---

## 🔧 작업 내용 요약
- 현재 비밀번호와 입력한 비밀번호가 일치하는지 확인하는 API 구현
- 프론트엔드 요청에 따라 API 구현

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 비밀번호가 틀렸을 때 400 반환이 적절한지(다만 프론트에서 OK하긴 했습니다)

---

## 🔗 관련 이슈
- 이슈 없이 진행

---

## 📝 기타 참고 사항
- 이것도 프론트의 요청으로 만든 API입니다.
- **204 No Content를 200 OK로 변경한 PR과 충돌이 발생할 수 있는데, 이때는 204 No Content를 200 OK로 변경한 PR을 먼저 Merge해 주세요.**