### PR TITLE
[Member] 회원 프로필 수정 구현 및 ERD 수정, 프로필 이미지 및 포트폴리오 파일 업로드

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus implements BaseErrorCode {
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4004", "이미 존재하는 이메일입니다."),
     DUPLICATE_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "MEMBER4005", "이미 존재하는 휴대폰 번호입니다."),
     INVALID_ROLE(HttpStatus.BAD_REQUEST, "MEMBER4006", "올바른 Role이 아닙니다. LEADER, TEAMMATE 중 하나를 선택해 주세요."),
+    NOT_IMAGE(HttpStatus.BAD_REQUEST, "MEMBER4008", "이미지 파일이 아닙니다."), //MEMBER4007 에러를 만들었던 기억이 있는데 왜 없지?
     NO_CREDENTIAL(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER5000", "저장된 패스워드가 없습니다."),
 
     //MemberLike 관련 에러

--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -30,6 +30,10 @@ public enum ErrorStatus implements BaseErrorCode {
     LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4101", "좋아요하지 않은 회원입니다. 좋아요를 하려면 Post Method로 요청을 보내 주세요."),
     SELF_LIKE(HttpStatus.BAD_REQUEST, "MEMBER4102", "회원 자신에 대한 좋아요 요청입니다."),
 
+    //PortFolio 관련 에러
+    NOT_READABLE_FILE(HttpStatus.BAD_REQUEST, "MEMBER4200", "읽을 수 있는 파일 형태가 아닙니다."),
+    PORTFOLIO_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4201", "포트폴리오를 찾을 수 없습니다."),
+
     //Region 관련 에러
     REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION4000", "해당 지역이 존재하지 않습니다."),
   

--- a/src/main/java/umc/lightup/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/umc/lightup/aws/s3/AmazonS3Manager.java
@@ -48,4 +48,8 @@ public class AmazonS3Manager {
     public String generateProfileImageKeyName(Uuid uuid) {
         return amazonConfig.getProfileImagePath() + '/' + uuid.getUuid();
     }
+
+    public String generatePortFolioKeyName(Uuid uuid) {
+        return amazonConfig.getPortfolioPath() + '/' + uuid.getUuid();
+    }
 }

--- a/src/main/java/umc/lightup/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/umc/lightup/aws/s3/AmazonS3Manager.java
@@ -44,4 +44,8 @@ public class AmazonS3Manager {
     public String generateItemFileKeyName(Uuid uuid) {
         return amazonConfig.getItemFilePath() + '/' + uuid.getUuid();
     }
+
+    public String generateProfileImageKeyName(Uuid uuid) {
+        return amazonConfig.getProfileImagePath() + '/' + uuid.getUuid();
+    }
 }

--- a/src/main/java/umc/lightup/config/AmazonConfig.java
+++ b/src/main/java/umc/lightup/config/AmazonConfig.java
@@ -33,6 +33,9 @@ public class AmazonConfig {
     @Value("${cloud.aws.s3.path.profileImage}")
     private String profileImagePath;
 
+    @Value("${cloud.aws.s3.path.portfolio}")
+    private String portfolioPath;
+
     @Value("${cloud.aws.s3.path.itemProfileImage}")
     private String itemProfileImagePath;
 

--- a/src/main/java/umc/lightup/config/SecurityConfig.java
+++ b/src/main/java/umc/lightup/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests((requests) -> requests
                         .requestMatchers("/api/v1/members/me",
-                                "/api/v1/members/me/profile",
+                                "/api/v1/members/me/**",
                                 "/api/v1/members/password/change",
                                 "/api/v1/members/*/like")
                         .authenticated()

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -5,9 +5,12 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.api.ApiResponse;
 import umc.lightup.api.code.status.SuccessStatus;
 import umc.lightup.member.converter.MemberConverter;
@@ -16,6 +19,7 @@ import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
 import umc.lightup.member.service.CredentialQueryService;
 import umc.lightup.member.service.MemberCommandService;
+import umc.lightup.member.validation.annotation.ImageFile;
 
 import java.util.List;
 
@@ -144,6 +148,23 @@ public class MemberRestController {
         Member member = memberCommandService.getMember(email);
         if (request.getActivities() == null) request.setActivities(List.of()); //nullable하니 오류 방지를 위함
         return ApiResponse.onSuccess(memberCommandService.putMemberProfile(member, request));
+    }
+
+    @PostMapping(value = "/me/profile/image/edit", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Operation(
+            summary = "회원 프로필 사진 변경 API",
+            description = "회원 프로필 사진을 변경하는 API입니다. 프로필 사진 업로드가 필요합니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.ProfileImageSaveResultDTO> changeMemberImage(
+            Authentication authentication,
+            @RequestPart(value = "profileImage") @NotNull @ImageFile MultipartFile profileImage) {
+        Member member = memberCommandService.getMember(authentication.getName());
+        String profileImageUrl = memberCommandService.saveMemberProfileImage(member, profileImage);
+        return ApiResponse.onSuccess(
+                MemberResponseDTO.ProfileImageSaveResultDTO.builder()
+                        .profileImageUrl(profileImageUrl)
+                        .build());
     }
 
     @PostMapping("/password/change")

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -18,6 +18,8 @@ import umc.lightup.member.dto.MemberResponseDTO;
 import umc.lightup.member.service.CredentialQueryService;
 import umc.lightup.member.service.MemberCommandService;
 
+import java.util.List;
+
 import static umc.lightup.member.dto.MemberResponseDTO.memberPositionDeleteResultDTOBuilder;
 import static umc.lightup.member.dto.MemberResponseDTO.memberPositionResultDTOBuilder;
 
@@ -66,7 +68,7 @@ public class MemberRestController {
             security = { @SecurityRequirement(name = "JWT TOKEN")}
     )
     public ApiResponse<MemberResponseDTO.MemberInfoDTO> getMemberInfo(Authentication authentication,
-                                                                  @PathVariable("memberId") long id) {
+                                                                      @PathVariable("memberId") long id) {
         String email = null;
         if (authentication != null)
             email = authentication.getName();
@@ -115,6 +117,34 @@ public class MemberRestController {
         //로그아웃이 필수인 이유가 jwt에 이메일을 저장하기 때문인데, 이 때문에 A와 B가 서로의 비밀번호를 몰라도 서로 이메일을 바꾸면 A는 B 계정에, B는 A 계정에 접속할 수 있음.
         String email = authentication.getName();
         return ApiResponse.onSuccess(MemberResponseDTO.toMyInfoDTO(memberCommandService.putMember(email, request)));
+    }
+
+    @GetMapping("/me/profile")
+    @Operation(
+            summary = "회원 프로필 조회 API",
+            description = "자신의 회원 프로필을 조회하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.MyProfileDTO> getMemberProfile(
+            Authentication authentication) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+        return ApiResponse.onSuccess(memberCommandService.getMemberProfile(member));
+    }
+
+    @PutMapping("/me/profile")
+    @Operation(
+            summary = "회원 프로필 변경 API",
+            description = "회원 프로필을 변경하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.MyProfileDTO> changeMemberProfile(
+            Authentication authentication,
+            @RequestBody @Valid MemberRequestDTO.ProfileChangeDto request) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+        if (request.getActivities() == null) request.setActivities(List.of()); //nullable하니 오류 방지를 위함
+        return ApiResponse.onSuccess(memberCommandService.putMemberProfile(member, request));
     }
 
     @PostMapping("/password/change")

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -1,11 +1,11 @@
 package umc.lightup.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -15,11 +15,14 @@ import umc.lightup.api.ApiResponse;
 import umc.lightup.api.code.status.SuccessStatus;
 import umc.lightup.member.converter.MemberConverter;
 import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.Portfolio;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
+import umc.lightup.member.dto.PortfolioInfoDTO;
 import umc.lightup.member.service.CredentialQueryService;
 import umc.lightup.member.service.MemberCommandService;
 import umc.lightup.member.validation.annotation.ImageFile;
+import umc.lightup.member.validation.annotation.ReadableDocumentFile;
 
 import java.util.List;
 
@@ -153,7 +156,7 @@ public class MemberRestController {
     @PostMapping(value = "/me/profile/image/edit", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @Operation(
             summary = "회원 프로필 사진 변경 API",
-            description = "회원 프로필 사진을 변경하는 API입니다. 프로필 사진 업로드가 필요합니다.",
+            description = "회원 프로필 사진을 변경하는 API입니다. 프로필 사진 업로드가 필요합니다. 사진 파일만 업로드가 가능합니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN")}
     )
     public ApiResponse<MemberResponseDTO.ProfileImageSaveResultDTO> changeMemberImage(
@@ -165,6 +168,53 @@ public class MemberRestController {
                 MemberResponseDTO.ProfileImageSaveResultDTO.builder()
                         .profileImageUrl(profileImageUrl)
                         .build());
+    }
+
+    @PostMapping(value = "/me/profile/portfolio/file", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Operation(
+            summary = "회원 프로필의 포트폴리오 등록 API",
+            description = "회원 프로필의 포트폴리오를 파일로 등록하는 API입니다. 포트폴리오 파일 업로드가 필요합니다. 이름은 최대 30자까지만 입력할 수 있습니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.PortfolioInfoWithIdDTO> portFolioFileRegister(
+            Authentication authentication,
+            // 아니 이걸 DTO로 안 받고 바로 String으로 받으면 에러나네...
+            @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+            @RequestPart("request") @Valid MemberRequestDTO.PortFolioNameRequestDTO request,
+            @RequestPart(value = "portfolioFile") @NotNull @ReadableDocumentFile MultipartFile portfolioFile) {
+        Member member = memberCommandService.getMember(authentication.getName());
+        Portfolio saved = memberCommandService.savePortfolio(member, request.getName(), portfolioFile);
+        return ApiResponse.onSuccess(MemberConverter.toPortfolioInfoWithIdDTO(saved));
+    }
+
+    @PostMapping(value = "/me/profile/portfolio/link")
+    @Operation(
+            summary = "회원 프로필의 포트폴리오 등록 API",
+            description = "회원 프로필의 포트폴리오를 링크로 등록하는 API입니다. 유효한 링크인지는 확인하지 않습니다. 이름은 최대 30자까지만 입력할 수 있습니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.PortfolioInfoWithIdDTO> portFolioLinkRegister(
+            Authentication authentication,
+            @RequestBody @Valid PortfolioInfoDTO portfolioInfo) {
+        Member member = memberCommandService.getMember(authentication.getName());
+        Portfolio saved = memberCommandService.savePortfolio(member,
+                portfolioInfo.getName(),
+                portfolioInfo.getFileUrl());
+        return ApiResponse.onSuccess(MemberConverter.toPortfolioInfoWithIdDTO(saved));
+    }
+
+    @DeleteMapping(value = "/me/profile/portfolio")
+    @Operation(
+            summary = "회원 프로필의 포트폴리오 삭제 API",
+            description = "회원 프로필의 포트폴리오를 삭제하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.ProfileImageSaveResultDTO> removePortFolio(
+            Authentication authentication,
+            @RequestBody @Valid MemberRequestDTO.PortFolioRequestDTO portfolioRequestDTO) {
+        String email = authentication.getName();
+        memberCommandService.removePortfolio(email, portfolioRequestDTO.getPortfolioId());
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
     }
 
     @PostMapping("/password/change")

--- a/src/main/java/umc/lightup/member/converter/MemberConverter.java
+++ b/src/main/java/umc/lightup/member/converter/MemberConverter.java
@@ -2,6 +2,7 @@ package umc.lightup.member.converter;
 
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberRegion;
+import umc.lightup.member.domain.Portfolio;
 import umc.lightup.member.dto.MemberResponseDTO;
 
 import java.util.List;
@@ -32,6 +33,14 @@ public class MemberConverter {
         return MemberResponseDTO.singleRegionResultDTO.builder()
                 .siDo(memberRegion.getSiDo())
                 .siGunGu(memberRegion.getSiGunGu())
+                .build();
+    }
+
+    public static MemberResponseDTO.PortfolioInfoWithIdDTO toPortfolioInfoWithIdDTO(Portfolio portfolio) {
+        return MemberResponseDTO.PortfolioInfoWithIdDTO.builder()
+                .id(portfolio.getId())
+                .name(portfolio.getName())
+                .fileUrl(portfolio.getFileUrl())
                 .build();
     }
 }

--- a/src/main/java/umc/lightup/member/domain/Activity.java
+++ b/src/main/java/umc/lightup/member/domain/Activity.java
@@ -1,0 +1,30 @@
+package umc.lightup.member.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Activity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Member member;
+
+    @Column(length = 72, nullable = false)
+    private String name;
+
+    @Column(nullable = false) // 일 value는 아무거나 넣어서 진행
+    private LocalDate startDate;
+
+    @Column // 기간이 아닌 특정 시점이면 null이 들어감
+    private LocalDate endDate;
+}

--- a/src/main/java/umc/lightup/member/domain/Member.java
+++ b/src/main/java/umc/lightup/member/domain/Member.java
@@ -55,8 +55,13 @@ public class Member extends BaseEntity implements UserDetails {
     @Column(unique = true, length = 20)
     private String phoneNumber;
 
+    @Setter
     @Column(length = 80)
-    private String career;
+    private String profileTitle;
+
+    @Setter
+    @Column(columnDefinition = "TEXT")
+    private String selfIntroduce;
 
     private String profileImageUrl; // 추가, S3 필요
 

--- a/src/main/java/umc/lightup/member/domain/Member.java
+++ b/src/main/java/umc/lightup/member/domain/Member.java
@@ -64,6 +64,7 @@ public class Member extends BaseEntity implements UserDetails {
     @Column(columnDefinition = "TEXT")
     private String selfIntroduce;
 
+    @Setter
     private String profileImageUrl; // 추가, S3 필요
 
     @Builder.Default

--- a/src/main/java/umc/lightup/member/dto/ActivityInfoDTO.java
+++ b/src/main/java/umc/lightup/member/dto/ActivityInfoDTO.java
@@ -1,0 +1,20 @@
+package umc.lightup.member.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityInfoDTO {
+    private String name;
+    // 일 value는 아무거나 넣어서 진행
+    private LocalDate startDate;
+
+    private Boolean hasEndDate;
+    // 기간이 아닌 특정 시점이면 null이 들어감
+    private LocalDate endDate;
+}

--- a/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
@@ -166,6 +166,21 @@ public class MemberRequestDTO {
 
     @Getter
     @Setter
+    public static class PortFolioNameRequestDTO {
+        @NotEmpty
+        @Size(max = 30)
+        private String name;
+    }
+
+    @Getter
+    @Setter
+    public static class PortFolioRequestDTO {
+        @NotNull
+        private Long portfolioId;
+    }
+
+    @Getter
+    @Setter
     public static class MemberPositionRequestDTO {
         @NotEmpty
         private String position;

--- a/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
@@ -14,6 +14,7 @@ import umc.lightup.member.validation.annotation.ValidRole;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 public class MemberRequestDTO {
 
@@ -95,6 +96,32 @@ public class MemberRequestDTO {
                     .age((int) this.birth.until(LocalDate.now(), ChronoUnit.YEARS))
                     .build();
         }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ProfileChangeDto {
+//        @NotNull
+//        @Size(max = 4) //length는 0일 수 있으나 null일 수는 없음
+//        private List<Long> skillIds;
+//        @NotNull
+//        @Size(max = 4)
+//        private List<Long> strengthIds;
+//        @NotNull
+//        @Size(max = 4)
+//        private List<Long> regionIds;
+//        @NotNull
+//        @Size(max = 4)
+//        private List<PortfolioInfoDTO> portfolios;
+        @NotEmpty
+        @Size(max = 80)
+        private String profileTitle;
+        @Size(max = 3000) //Nullable
+        private String selfIntroduction;
+        private List<ActivityInfoDTO> activities;
     }
 
     @Getter

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -125,6 +125,14 @@ public class MemberResponseDTO {
     public static class EmailExistResultDTO{
         boolean exist;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfileImageSaveResultDTO {
+        String profileImageUrl;
+    }
   
     @Getter
     @Builder

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -68,7 +68,7 @@ public class MemberResponseDTO {
         private List<StrengthResultWithIdDTO> strengths; //수정을 위한 ID 반환 필요할 수도 있음
         private List<RegionResultWithIdDTO> regions; //수정을 위한 ID 반환 필요할 수도 있음
         private List<String> positions; //이건 수정도 String으로 진행하니 이렇게 둠
-        private List<PortfolioInfoDTO> portfolios;
+        private List<PortfolioInfoWithIdDTO> portfolios;
         private String selfIntroduce;
         private List<ActivityInfoDTO> activities;
     }
@@ -132,6 +132,17 @@ public class MemberResponseDTO {
     @AllArgsConstructor
     public static class ProfileImageSaveResultDTO {
         String profileImageUrl;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode
+    public static class PortfolioInfoWithIdDTO {
+        private long id;
+        private String name;
+        private String fileUrl;
     }
   
     @Getter

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -4,6 +4,9 @@ import lombok.*;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.enums.Mbti;
 import umc.lightup.member.enums.Role;
+import umc.lightup.region.domain.Region;
+import umc.lightup.skill.domain.Skill;
+import umc.lightup.strength.domain.Strength;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -44,15 +47,40 @@ public class MemberResponseDTO {
         private String email;
         private String school;
         private String phoneNumber;
-        private String career;
+        private String selfIntroduce;
         private String profileImageUrl;
     }
-  
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyProfileDTO {
+        private String profileTitle;
+        private String name;
+        private String nickname;
+        private int age;
+        private boolean gender;
+        private Mbti mbti;
+        private String school;
+        private String profileImageUrl;
+        private String email;
+        private List<Skill> skills; //수정을 위한 ID 반환 필요할 수도 있음
+        private List<Strength> strengths; //수정을 위한 ID 반환 필요할 수도 있음
+        private List<Region> regions; //수정을 위한 ID 반환 필요할 수도 있음
+        private List<String> positions; //이건 수정도 String으로 진행하니 이렇게 둠
+        private List<PortfolioInfoDTO> portfolios;
+        private String selfIntroduce;
+        private List<ActivityInfoDTO> activities;
+    }
+
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MemberInfoDTO {
+        private long id;
+        private String profileTitle;
         private String name;
         private String nickname;
         private Integer age;
@@ -60,12 +88,14 @@ public class MemberResponseDTO {
         private LocalDate birth;
         private Role role;
         private Mbti mbti;
-        private String career;
+        private String selfIntroduce;
         private String school;
         private List<String> skills;
         private List<String> strengths;
         private List<String> regions;
+        private List<String> positions;
         private List<PortfolioInfoDTO> portfolios;
+        private List<ActivityInfoDTO> activities;
         private String email;
         private String phoneNumber;
         private String profileImageUrl;
@@ -87,16 +117,6 @@ public class MemberResponseDTO {
     public static class MemberPositionDeleteResultDTO {
         private String memberName;
         private String deletePositionName;
-    }
-  
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @EqualsAndHashCode
-    public static class PortfolioInfoDTO {
-        private String name;
-        private String fileUrl;
     }
 
     @Builder
@@ -154,7 +174,7 @@ public class MemberResponseDTO {
                 .gender(member.getGender())
                 .school(member.getSchool())
                 .phoneNumber(member.getPhoneNumber())
-                .career(member.getCareer())
+                .selfIntroduce(member.getSelfIntroduce())
                 .profileImageUrl(member.getProfileImageUrl())
                 .build();
     }

--- a/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
+++ b/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
@@ -136,7 +136,9 @@ public class MemberViewInfo {
                                 .build())
                         .toList())
                 .positions(positionNames)
-                .portfolios(getPortfolioInfoDTOs())
+                .portfolios(portfolios.stream()
+                        .map(MemberConverter::toPortfolioInfoWithIdDTO)
+                        .toList())
                 .activities(getActivityInfoDTOs())
                 .build();
     }

--- a/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
+++ b/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
@@ -1,9 +1,12 @@
 package umc.lightup.member.dto;
 
 import lombok.*;
+import umc.lightup.member.domain.Activity;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.Portfolio;
 import umc.lightup.region.domain.Region;
+import umc.lightup.skill.domain.Skill;
+import umc.lightup.strength.domain.Strength;
 
 import java.util.List;
 
@@ -20,16 +23,33 @@ import java.util.List;
 @AllArgsConstructor
 public class MemberViewInfo {
     private Member member;
-    private List<String> skills;
-    private List<String> strengths;
-    private List<Region> regions;
-    private List<Portfolio> portfolios;
+    @Builder.Default
+    private List<String> positionNames = List.of();
+    @Builder.Default
+    private List<String> skillNames = List.of();
+    @Builder.Default
+    private List<String> strengthNames = List.of();
+    @Builder.Default
+    private List<Skill> skills = List.of();
+    @Builder.Default
+    private List<Strength> strengths = List.of();
+    @Builder.Default
+    private List<Region> regions = List.of();
+    @Builder.Default
+    private List<Portfolio> portfolios = List.of();
+    @Builder.Default
+    private List<Activity> activities = List.of();
+    @Builder.Default
     private boolean emailOpen = false;
+    @Builder.Default
     private boolean phoneOpen = false;
+    @Builder.Default
     private boolean pictureOpen = false;
 
     public MemberResponseDTO.MemberInfoDTO toMemberInfoDTO() {
         return MemberResponseDTO.MemberInfoDTO.builder()
+                .id(member.getId())
+                .profileTitle(member.getProfileTitle())
                 .name(member.getName())
                 .nickname(member.getNickname())
                 .age(member.getAge())
@@ -38,23 +58,65 @@ public class MemberViewInfo {
                 .birth(member.getBirth())
                 .gender(member.getGender())
                 .school(member.getSchool())
-                .career(member.getCareer())
+                .selfIntroduce(member.getSelfIntroduce())
 
-                .skills(skills)
-                .strengths(strengths)
-                .regions(regions.stream()
-                        .map(r->r.getSiDo()+" "+r.getSiGunGu())
-                        .toList())
-                .portfolios(portfolios.stream()
-                        .map(portfolio -> MemberResponseDTO.PortfolioInfoDTO.builder()
-                                .name(portfolio.getName())
-                                .fileUrl(portfolio.getFileUrl())
-                                .build())
-                        .toList())
+                .skills(skillNames)
+                .strengths(strengthNames)
+                .positions(positionNames)
+                .regions(getRegionAsList())
+                .portfolios(getPortfolioInfoDTOs())
+                .activities(getActivityInfoDTOs())
 
                 .email(emailOpen?member.getEmail():null)
                 .phoneNumber(phoneOpen?member.getPhoneNumber():null)
                 .profileImageUrl(pictureOpen?member.getProfileImageUrl():null)
+                .build();
+    }
+
+    private List<ActivityInfoDTO> getActivityInfoDTOs() {
+        return activities.stream()
+                .map(activity -> ActivityInfoDTO.builder()
+                        .name(activity.getName())
+                        .startDate(activity.getStartDate())
+                        .hasEndDate(activity.getEndDate() != null)
+                        .endDate(activity.getEndDate())
+                        .build())
+                .toList();
+    }
+
+    private List<PortfolioInfoDTO> getPortfolioInfoDTOs() {
+        return portfolios.stream()
+                .map(portfolio -> PortfolioInfoDTO.builder()
+                        .name(portfolio.getName())
+                        .fileUrl(portfolio.getFileUrl())
+                        .build())
+                .toList();
+    }
+
+    private List<String> getRegionAsList() {
+        return regions.stream()
+                .map(r -> r.getSiDo() + " " + r.getSiGunGu())
+                .toList();
+    }
+
+    public MemberResponseDTO.MyProfileDTO toMyProfileDTO() {
+        return MemberResponseDTO.MyProfileDTO.builder()
+                .profileTitle(member.getProfileTitle())
+                .name(member.getName())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .age(member.getAge())
+                .gender(member.getGender())
+                .school(member.getSchool())
+                .mbti(member.getMbti())
+                .profileImageUrl(member.getProfileImageUrl())
+                .selfIntroduce(member.getSelfIntroduce())
+                .skills(skills)
+                .strengths(strengths)
+                .regions(regions)
+                .positions(positionNames)
+                .portfolios(getPortfolioInfoDTOs())
+                .activities(getActivityInfoDTOs())
                 .build();
     }
 }

--- a/src/main/java/umc/lightup/member/dto/PortfolioInfoDTO.java
+++ b/src/main/java/umc/lightup/member/dto/PortfolioInfoDTO.java
@@ -1,0 +1,13 @@
+package umc.lightup.member.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class PortfolioInfoDTO {
+    private String name;
+    private String fileUrl;
+}

--- a/src/main/java/umc/lightup/member/dto/PortfolioInfoDTO.java
+++ b/src/main/java/umc/lightup/member/dto/PortfolioInfoDTO.java
@@ -1,5 +1,7 @@
 package umc.lightup.member.dto;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Getter
@@ -8,6 +10,9 @@ import lombok.*;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class PortfolioInfoDTO {
+    @NotEmpty
+    @Size(max = 30)
     private String name;
+    @NotEmpty
     private String fileUrl;
 }

--- a/src/main/java/umc/lightup/member/repository/ActivityRepository.java
+++ b/src/main/java/umc/lightup/member/repository/ActivityRepository.java
@@ -1,0 +1,14 @@
+package umc.lightup.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.lightup.member.domain.Activity;
+import umc.lightup.member.domain.Member;
+
+import java.util.List;
+
+@Repository
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+    long removeAllByMember(Member member);
+    List<Activity> findByMember(Member member);
+}

--- a/src/main/java/umc/lightup/member/repository/MemberPositionRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberPositionRepository.java
@@ -1,9 +1,13 @@
 package umc.lightup.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberPosition;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +15,6 @@ public interface MemberPositionRepository extends JpaRepository<MemberPosition, 
     Optional<MemberPosition> findByMemberIdAndPositionId(Long memberId, Long positionId);
     boolean existsByMemberIdAndPositionId(Long memberId, Long positionId);
     void deleteByMemberIdAndPositionId(Long memberId, Long positionId);
+    @Query("select p.name from MemberPosition mp join mp.position p where mp.member = :member")
+    List<String> findPositionNameByMember(@Param("member") Member member);
 }

--- a/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
@@ -15,6 +15,8 @@ import java.util.List;
 public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> {
     @Query("select s.name from MemberSkill ms join ms.skill s where ms.member = :member")
     List<String> findSkillNameByMember(@Param("member") Member member);
+    @Query("select s from MemberSkill ms join ms.skill s where ms.member = :member")
+    List<Skill> findSkillByMember(@Param("member") Member member);
     boolean existsByMemberAndSkill(Member member, Skill skill);
 }
 

--- a/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
@@ -14,6 +14,8 @@ import java.util.List;
 public interface MemberStrengthRepository extends JpaRepository<MemberStrength, Long> {
     @Query("select s.name from MemberStrength ms join ms.strength s where ms.member = :member")
     List<String> findStrengthNameByMember(@Param("member") Member member);
+    @Query("select s from MemberStrength ms join ms.strength s where ms.member = :member")
+    List<Strength> findStrengthByMember(@Param("member") Member member);
     boolean existsByMemberAndStrength(Member member, Strength skill);
 }
 

--- a/src/main/java/umc/lightup/member/repository/PortfolioRepository.java
+++ b/src/main/java/umc/lightup/member/repository/PortfolioRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 @Repository
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
     List<Portfolio> findByMember(Member member);
+    // 다른 Member의 것을 삭제하면 안 되니 확인 절차 진행
+    long removeByIdAndMemberEmail(Long id, String memberEmail);
 }

--- a/src/main/java/umc/lightup/member/service/MemberCommandService.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandService.java
@@ -2,6 +2,7 @@ package umc.lightup.member.service;
 
 import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.Portfolio;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
 
@@ -16,6 +17,9 @@ public interface MemberCommandService {
     MemberResponseDTO.MyProfileDTO getMemberProfile(Member member);
     MemberResponseDTO.MyProfileDTO putMemberProfile(Member member, MemberRequestDTO.ProfileChangeDto request);
     String saveMemberProfileImage(Member member, MultipartFile profileImage);
+    Portfolio savePortfolio(Member member, String name, MultipartFile portfolioFile);
+    Portfolio savePortfolio(Member member, String name, String portfolioLink);
+    void removePortfolio(String memberEmail, long portFolioId);
     String selectSkill(Long skillId,Member member);
     String selectStrength(Long strengthId,Member member);
     List<MemberResponseDTO.singleRegionResultDTO> selectRegions(Member member, MemberRequestDTO.MemberRegionListRequestDTO request);

--- a/src/main/java/umc/lightup/member/service/MemberCommandService.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandService.java
@@ -10,6 +10,8 @@ public interface MemberCommandService {
     Member getMember(String email);
     MemberResponseDTO.MemberInfoDTO getMember(long id, String viewerEmail);
     Member putMember(String email, MemberRequestDTO.ChangeDto request);
+    MemberResponseDTO.MyProfileDTO getMemberProfile(Member member);
+    MemberResponseDTO.MyProfileDTO putMemberProfile(Member member, MemberRequestDTO.ProfileChangeDto request);
     String selectSkill(Long skillId,Member member);
     String selectStrength(Long strengthId,Member member);
     void addMemberLike(Member fromMember, long toMemberId);

--- a/src/main/java/umc/lightup/member/service/MemberCommandService.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandService.java
@@ -1,5 +1,6 @@
 package umc.lightup.member.service;
 
+import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
@@ -14,6 +15,7 @@ public interface MemberCommandService {
     Member putMember(String email, MemberRequestDTO.ChangeDto request);
     MemberResponseDTO.MyProfileDTO getMemberProfile(Member member);
     MemberResponseDTO.MyProfileDTO putMemberProfile(Member member, MemberRequestDTO.ProfileChangeDto request);
+    String saveMemberProfileImage(Member member, MultipartFile profileImage);
     String selectSkill(Long skillId,Member member);
     String selectStrength(Long strengthId,Member member);
     List<MemberResponseDTO.singleRegionResultDTO> selectRegions(Member member, MemberRequestDTO.MemberRegionListRequestDTO request);

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -6,7 +6,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.aws.s3.AmazonS3Manager;
+import umc.lightup.common.Uuid;
+import umc.lightup.common.repository.UuidRepository;
 import umc.lightup.config.JwtTokenProvider;
 import umc.lightup.exception.handler.GeneralHandler;
 import umc.lightup.member.converter.MemberConverter;
@@ -33,6 +37,7 @@ import java.util.Collections;
 import umc.lightup.member.repository.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -53,6 +58,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final AmazonS3Manager amazonS3Manager;
+    private final UuidRepository uuidRepository;
 
 
     @Override
@@ -211,6 +218,20 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .phoneOpen(true)
                 .pictureOpen(true)
                 .build().toMyProfileDTO();
+    }
+
+    @Override
+    @Transactional
+    public String saveMemberProfileImage(Member member, MultipartFile profileImage) {
+        //삭제가 가능하면 관련 로직 시행
+        String uuid = UUID.randomUUID().toString();
+        Uuid savedUuid = uuidRepository.save(Uuid.builder()
+                .uuid(uuid).build());
+        String generatedName = amazonS3Manager.generateProfileImageKeyName(savedUuid);
+        String profileImageUrl = amazonS3Manager.uploadFile(generatedName, profileImage);
+        member.setProfileImageUrl(profileImageUrl);
+        memberRepository.save(member);
+        return profileImageUrl;
     }
 
     @Override

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -223,7 +223,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     @Override
     @Transactional
     public String saveMemberProfileImage(Member member, MultipartFile profileImage) {
-        //삭제가 가능하면 관련 로직 시행
+        //삭제가 가능하면 진행하는 게 좋긴 함
         String uuid = UUID.randomUUID().toString();
         Uuid savedUuid = uuidRepository.save(Uuid.builder()
                 .uuid(uuid).build());
@@ -232,6 +232,37 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         member.setProfileImageUrl(profileImageUrl);
         memberRepository.save(member);
         return profileImageUrl;
+    }
+
+    @Override
+    @Transactional
+    public Portfolio savePortfolio(Member member, String name, MultipartFile portfolioFile) {
+        String uuid = UUID.randomUUID().toString();
+        Uuid savedUuid = uuidRepository.save(Uuid.builder()
+                .uuid(uuid).build());
+        String generatedName = amazonS3Manager.generatePortFolioKeyName(savedUuid);
+        String profileImageUrl = amazonS3Manager.uploadFile(generatedName, portfolioFile);
+        return savePortfolio(member, name, profileImageUrl);
+    }
+
+    @Override
+    @Transactional
+    public Portfolio savePortfolio(Member member, String name, String portfolioLink) {
+        Portfolio portfolio = Portfolio.builder()
+                .name(name)
+                .fileUrl(portfolioLink)
+                .member(member)
+                .build();
+        return portfolioRepository.save(portfolio);
+    }
+
+    @Override
+    @Transactional
+    public void removePortfolio(String memberEmail, long portFolioId) {
+        //삭제가 가능하면 진행하는 게 좋긴 함
+        if (portfolioRepository.removeByIdAndMemberEmail(portFolioId, memberEmail) == 0)
+            //데이터를 지우면서 지운 row의 수가 0은 아닌지 확인(1이어야 함)
+            throw new GeneralHandler(ErrorStatus.PORTFOLIO_NOT_FOUND);
     }
 
     @Override

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -49,7 +49,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final RegionRepository regionRepository;
     private final PortfolioRepository portfolioRepository;
     private final MemberLikeRepository memberLikeRepository;
-  
+    private final ActivityRepository activityRepository;
+
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -132,13 +133,17 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         List<String> skills = memberSkillRepository.findSkillNameByMember(member);
         List<String> strengths = memberStrengthRepository.findStrengthNameByMember(member);
         List<Region> regions = regionRepository.findByMember(member);
+        List<String> positions = memberPositionRepository.findPositionNameByMember(member);
         List<Portfolio> portfolios = portfolioRepository.findByMember(member);
+        List<Activity> activities = activityRepository.findByMember(member);
         return MemberViewInfo.builder()
                 .member(member)
-                .skills(skills)
-                .strengths(strengths)
+                .skillNames(skills)
+                .strengthNames(strengths)
                 .regions(regions)
+                .positionNames(positions)
                 .portfolios(portfolios)
+                .activities(activities)
                 .emailOpen(false)
                 .phoneOpen(false)
                 .pictureOpen(false)
@@ -161,7 +166,53 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             throw new GeneralHandler(ErrorStatus.DUPLICATE_NICKNAME);
         return memberRepository.save(request.toMember(member.getId()));
     }
-  
+
+    @Override
+    public MemberResponseDTO.MyProfileDTO getMemberProfile(Member member) {
+        return MemberViewInfo.builder()
+                .member(member)
+                .skills(memberSkillRepository.findSkillByMember(member))
+                .strengths(memberStrengthRepository.findStrengthByMember(member))
+                .regions(regionRepository.findByMember(member))
+                .positionNames(memberPositionRepository.findPositionNameByMember(member))
+                .portfolios(portfolioRepository.findByMember(member))
+                .activities(activityRepository.findByMember(member))
+                .emailOpen(true)
+                .phoneOpen(true)
+                .pictureOpen(true)
+                .build().toMyProfileDTO();
+    }
+
+    @Override
+    @Transactional
+    public MemberResponseDTO.MyProfileDTO putMemberProfile(Member member, MemberRequestDTO.ProfileChangeDto request) {
+        member.setSelfIntroduce(request.getSelfIntroduction());
+        member.setProfileTitle(request.getProfileTitle());
+        activityRepository.removeAllByMember(member);
+        memberRepository.save(member);
+        List<Activity> activities = activityRepository.saveAll(request.getActivities().stream()
+                .map(a -> Activity.builder()
+                        .member(member)
+                        .name(a.getName())
+                        .startDate(a.getStartDate())
+                        .endDate(a.getEndDate())
+                        .build())
+                .toList());
+
+        return MemberViewInfo.builder()
+                .member(member)
+                .skills(memberSkillRepository.findSkillByMember(member))
+                .strengths(memberStrengthRepository.findStrengthByMember(member))
+                .regions(regionRepository.findByMember(member))
+                .positionNames(memberPositionRepository.findPositionNameByMember(member))
+                .portfolios(portfolioRepository.findByMember(member))
+                .activities(activities)
+                .emailOpen(true)
+                .phoneOpen(true)
+                .pictureOpen(true)
+                .build().toMyProfileDTO();
+    }
+
     @Override
     @Transactional
     public String selectSkill(Long skillId, Member member) {

--- a/src/main/java/umc/lightup/member/validation/annotation/ImageFile.java
+++ b/src/main/java/umc/lightup/member/validation/annotation/ImageFile.java
@@ -1,0 +1,17 @@
+package umc.lightup.member.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.lightup.member.validation.validator.ImageFileValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ImageFileValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ImageFile {
+    String message() default "이미지 파일이 아닙니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/lightup/member/validation/annotation/ReadableDocumentFile.java
+++ b/src/main/java/umc/lightup/member/validation/annotation/ReadableDocumentFile.java
@@ -1,0 +1,17 @@
+package umc.lightup.member.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.lightup.member.validation.validator.ReadableDocumentFileValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ReadableDocumentFileValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ReadableDocumentFile {
+    String message() default "이미지 파일이 아닙니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/lightup/member/validation/validator/ImageFileValidator.java
+++ b/src/main/java/umc/lightup/member/validation/validator/ImageFileValidator.java
@@ -1,0 +1,30 @@
+package umc.lightup.member.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.web.multipart.MultipartFile;
+import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.member.validation.annotation.ImageFile;
+
+public class ImageFileValidator implements ConstraintValidator<ImageFile, MultipartFile> {
+    @Override
+    public void initialize(ImageFile constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(MultipartFile value, ConstraintValidatorContext context) {
+        boolean isValid = true;
+        if (value != null) {
+            String contentType = value.getContentType();
+            isValid = contentType != null && contentType.startsWith("image/");
+        }
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.NOT_IMAGE.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/umc/lightup/member/validation/validator/ImageFileValidator.java
+++ b/src/main/java/umc/lightup/member/validation/validator/ImageFileValidator.java
@@ -2,10 +2,12 @@ package umc.lightup.member.validation.validator;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.api.code.status.ErrorStatus;
 import umc.lightup.member.validation.annotation.ImageFile;
 
+@Component
 public class ImageFileValidator implements ConstraintValidator<ImageFile, MultipartFile> {
     @Override
     public void initialize(ImageFile constraintAnnotation) {

--- a/src/main/java/umc/lightup/member/validation/validator/ReadableDocumentFileValidator.java
+++ b/src/main/java/umc/lightup/member/validation/validator/ReadableDocumentFileValidator.java
@@ -1,0 +1,46 @@
+package umc.lightup.member.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.member.validation.annotation.ReadableDocumentFile;
+
+import java.util.Set;
+
+@Component
+public class ReadableDocumentFileValidator implements ConstraintValidator<ReadableDocumentFile, MultipartFile> {
+
+    private final Set<String> readableDocumentContentTypes = Set.of(
+            "text/plain", // 일반 텍스트 파일
+            "text/html", // HTML 파일
+            "application/pdf", // PDF 문서
+            "application/msword", // MS Word 문서, .doc
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // MS Word 문서, .docx
+            "application/vnd.ms-powerpoint", // MS PowerPoint 프레젠테이션, .ppt
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation" // MS PowerPoint 프레젠테이션, .pptx
+    ); // word나 ppt를 pdf로 변경하는 기술이 존재하긴 할텐데 일단 그냥 둠
+    // 이 파일 목록은 프론트와의 협의가 필요함
+
+    @Override
+    public void initialize(ReadableDocumentFile constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(MultipartFile value, ConstraintValidatorContext context) {
+        boolean isValid = true;
+        if (value != null) {
+            String contentType = value.getContentType();
+            isValid = contentType != null && readableDocumentContentTypes.contains(contentType);
+        }
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.NOT_READABLE_FILE.toString()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/test/java/umc/lightup/members/MemberTest.java
+++ b/src/test/java/umc/lightup/members/MemberTest.java
@@ -21,6 +21,7 @@ import umc.lightup.member.domain.*;
 import umc.lightup.member.dto.EmailRequestDTO;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
+import umc.lightup.member.dto.PortfolioInfoDTO;
 import umc.lightup.member.enums.Mbti;
 import umc.lightup.member.enums.Role;
 import umc.lightup.member.repository.*;
@@ -482,7 +483,7 @@ public class MemberTest {
                 () -> assertEquals(email3, myInfoResponse.getResult().getEmail()),
                 () -> assertEquals(null, myInfoResponse.getResult().getPhoneNumber()),
                 () -> assertNull(myInfoResponse.getResult().getSchool()),
-                () -> assertNull(myInfoResponse.getResult().getCareer()),
+                () -> assertNull(myInfoResponse.getResult().getSelfIntroduce()),
                 () -> assertNull(myInfoResponse.getResult().getProfileImageUrl())
         );
 
@@ -546,7 +547,7 @@ public class MemberTest {
                 () -> assertEquals(gender3, result.getGender()),
                 () -> assertEquals(role3, result.getRole()),
                 () -> assertEquals(mbti3, result.getMbti()),
-                () -> assertNull(result.getCareer()),
+                () -> assertNull(result.getSelfIntroduce()),
                 () -> assertNull(result.getSchool()),
                 () -> assertIterableEquals(List.of(), result.getSkills()),
                 () -> assertIterableEquals(List.of(), result.getStrengths()),
@@ -698,7 +699,7 @@ public class MemberTest {
                 () -> assertEquals(member.getGender(), result.getGender()),
                 () -> assertEquals(member.getRole(), result.getRole()),
                 () -> assertEquals(member.getMbti(), result.getMbti()),
-                () -> assertEquals(member.getCareer(), result.getCareer()),
+                () -> assertEquals(member.getSelfIntroduce(), result.getSelfIntroduce()),
                 () -> assertEquals(member.getSchool(), result.getSchool())
         );
 
@@ -721,7 +722,7 @@ public class MemberTest {
                 "region information"); //순서도 같도록 의도한 것
 
         assertIterableEquals(
-                portfolioSet.stream().map(portfolio -> MemberResponseDTO.PortfolioInfoDTO.builder()
+                portfolioSet.stream().map(portfolio -> PortfolioInfoDTO.builder()
                         .name(portfolio.getName())
                         .fileUrl(portfolio.getFileUrl())
                         .build()).toList(),
@@ -791,7 +792,7 @@ public class MemberTest {
                 () -> assertEquals(member.getGender(), result.getGender()),
                 () -> assertEquals(member.getRole(), result.getRole()),
                 () -> assertEquals(member.getMbti(), result.getMbti()),
-                () -> assertEquals(member.getCareer(), result.getCareer()),
+                () -> assertEquals(member.getSelfIntroduce(), result.getSelfIntroduce()),
                 () -> assertEquals(member.getSchool(), result.getSchool())
         );
 
@@ -814,7 +815,7 @@ public class MemberTest {
                 "region information"); //순서도 같도록 의도한 것
 
         assertIterableEquals(
-                portfolioSet.stream().map(portfolio -> MemberResponseDTO.PortfolioInfoDTO.builder()
+                portfolioSet.stream().map(portfolio -> PortfolioInfoDTO.builder()
                         .name(portfolio.getName())
                         .fileUrl(portfolio.getFileUrl())
                         .build()).toList(),
@@ -935,7 +936,7 @@ public class MemberTest {
                 () -> assertEquals(email4, myInfoResponseResult.getEmail()),
                 () -> assertEquals(null, myInfoResponseResult.getPhoneNumber()),
                 () -> assertNull(myInfoResponseResult.getSchool()),
-                () -> assertNull(myInfoResponseResult.getCareer()),
+                () -> assertNull(myInfoResponseResult.getSelfIntroduce()),
                 () -> assertNull(myInfoResponseResult.getProfileImageUrl())
         );
 
@@ -979,7 +980,7 @@ public class MemberTest {
                 () -> assertEquals(email4, change1ResponseResult.getEmail()),
                 () -> assertEquals(phoneNumber4, change1ResponseResult.getPhoneNumber()),
                 () -> assertNull(change1ResponseResult.getSchool()),
-                () -> assertNull(change1ResponseResult.getCareer()),
+                () -> assertNull(change1ResponseResult.getSelfIntroduce()),
                 () -> assertNull(change1ResponseResult.getProfileImageUrl())
         );
 
@@ -1057,7 +1058,7 @@ public class MemberTest {
                 () -> assertEquals(email4, change2ResponseResult.getEmail()),
                 () -> assertEquals(phoneNumber4, change2ResponseResult.getPhoneNumber()),
                 () -> assertNull(change2ResponseResult.getSchool()),
-                () -> assertNull(change2ResponseResult.getCareer()),
+                () -> assertNull(change2ResponseResult.getSelfIntroduce()),
                 () -> assertNull(change2ResponseResult.getProfileImageUrl())
         );
 
@@ -1101,7 +1102,7 @@ public class MemberTest {
                 () -> assertEquals("newEmail@example.com", change3ResponseResult.getEmail()),
                 () -> assertEquals("010-1111-2222", change3ResponseResult.getPhoneNumber()),
                 () -> assertNull(change3ResponseResult.getSchool()),
-                () -> assertNull(change3ResponseResult.getCareer()),
+                () -> assertNull(change3ResponseResult.getSelfIntroduce()),
                 () -> assertNull(change3ResponseResult.getProfileImageUrl())
         );
 


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 회원 프로필 수정 구현 및 ERD 수정, 프로필 이미지 및 포트폴리오 파일 업로드

---

## 🔧 작업 내용 요약
- 회원의 프로필 이름, 자기소개, 수상 활동 이력 수정
- 회원 자신의 프로필 이름, 자기소개, 수상 활동 이력 조회
- 활동 이력 table 추가
- Member table 수정(자기소개와 프로필 이름이 들어가도록 수정)
- 타인의 프로필 조회 시 조회 대상자의 id(PK)값 반환(프론트엔드 요구사항)
- 타인의 프로필 조회 시 프로필 이름, 자기소개, 활동 이력, 파트 추가 반환
- 파트 조회 기능(Repository) 구현
- 프로필 이미지 업로드 구현
- 포트폴리오 파일 업로드 구현
- 포트폴리오 링크 형태 업로드, 삭제 구현


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- DTO의 재활용이 적절한지(현재 일부 DTO가 Request, Response 모두에 사용되고 있음)
- Entity class를 응답으로 직접 반환하는 게 적절한지
- Activity를 별도 table로 분리하는 현재의 설계가 적절한지, 아니면 반정규화를 진행해 Member table에 flat하게 담을지
- commit의 크기가 매우 큰데 괜찮은지
- 응답 반환 시 id는 mapping class가 아니라 원본 id(예를 들어 skill이면 MemberSkill의 id가 아닌 Skill의 id)가 반환되고 있는데 이 방식이 적절한지(id 반환 목적이 삭제 시 활용하라는 건데, 이러면 mapping class의 id를 제공하는 것이 더 성능이 좋기 때문, 단 직관적이지 않아, 저번 해커톤에서 이 때문에 30분을 디버깅으로 날린 적이 있음)
- S3에 파일을 업로드하는 로직이 적절한지
- 삭제 시 S3 파일을 삭제하지는 않는 상태인데 괜찮은지
- 포트폴리오 이름을 DTO 클래스로 받는 현 상황이 적절한지
- (github에는 올라가지 않지만) application.yml 파일 설정이 적절한지(제가 S3는 잘 몰라서, 현재 다른 path 값을 그대로 복사해놓은 상태입니다.)

---

## 🔗 관련 이슈
- closes #37 
- closes #60 

---

## 📝 기타 참고 사항
- **ERD가 또 수정되었습니다. 반영되지 않으면 정상 작동하지 않을 수 있습니다.** 사실 지금까지의 ERD 수정 내역은 코드가 서버에 올라가면 제가 직접 DB에 접근해서 수정해 놓긴 했습니다.
- test code 작성 전이지만 프론트엔드 분들께서 빨리 실행해 보실 수 있도록 Draft로 올리지는 않았습니다. 정작 저도 점점 test code 작성에 소홀해지네요.
- **S3 파일 업로드 구현으로 인해 application.yml 파일이 변경되었습니다.** 한 줄 변경이지만 확인해 주세요. 그 내용이 적절한지도 확인 부탁드립니다.