### PR TITLE
[Skill, Strength, Region] 스킬, 강점, 지역 선택 취소 API 구현

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -71,6 +71,9 @@ public enum ErrorStatus implements BaseErrorCode {
     //MemberStrength 관련 에러
     MEMBER_STRENGTH_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_STRENGTH4000", "유저의 강점이 존재하지 않습니다."),
 
+    //MemberRegion 관련 에러
+    MEMBER_REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_REGION4000", "선택 지역이 존재하지 않습니다."),
+
     //Email 관련 에러
     EMAIL_SEND_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "EMAIL5003", "이메일 전송에 실패했습니다.")
     ;

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import umc.lightup.api.ApiResponse;
@@ -213,6 +214,19 @@ public class MemberRestController {
         return ApiResponse.onSuccess(MemberConverter.toSelectSkillResultDTO(skillName, member));
     }
 
+    @DeleteMapping("/skills/{skillId}")
+    @Operation(
+            summary = "스킬 선택 취소 API",
+            description = "유저가 스킬 선택을 취소하는 API입니다. 스킬은 하나씩 취소할 수 있습니다."
+    )
+    public ApiResponse<Void> deleteSkill(Authentication authentication, @PathVariable("skillId") Long skillId) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+
+        memberCommandService.removeMemberSkill(skillId, member.getId());
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+    }
+
     @PostMapping("/strengths")
     @Operation(
             summary = "강점 선택 API",
@@ -228,6 +242,20 @@ public class MemberRestController {
     }
 
 
+    @DeleteMapping("/strengths/{strengthId}")
+    @Operation(
+            summary = "강점 선택 취소 API",
+            description = "유저가 강점 선택을 취소하는 API입니다. 강점은 하나씩 취소할 수 있습니다."
+    )
+    public ApiResponse<Void> deleteStrength(Authentication authentication, @PathVariable("strengthId") Long strengthId) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+
+        memberCommandService.removeMemberStrength(strengthId, member.getId());
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+    }
+
+
     @PostMapping("/regions")
     @Operation(summary = "유저 선호 지역 선택 API", description = "유저가 선호 지역을 선택하는 API입니다.")
     public ApiResponse<MemberResponseDTO.selectRegionResultsDTO> selectRegions(Authentication authentication, @RequestBody @Valid MemberRequestDTO.MemberRegionListRequestDTO request) {
@@ -236,5 +264,16 @@ public class MemberRestController {
 
         List<MemberResponseDTO.singleRegionResultDTO> resultDTOList = memberCommandService.selectRegions(member, request);
         return ApiResponse.onSuccess(MemberConverter.toSelectRegionResultsDTO(resultDTOList));
+    }
+
+    @DeleteMapping("/regions/{memberRegionId}")
+    @Operation(summary = "유저 선호 지역 취소 API", description = "유저가 선호 지역을 취소하는 API입니다. 선호 지역 취소는 하나씩 가능합니다.")
+    public ApiResponse<Void> deleteRegion(Authentication authentication, @PathVariable("memberRegionId") Long memberRegionId) {
+
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+
+        memberCommandService.removeMemberRegion(memberRegionId, member.getId());
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
     }
 }

--- a/src/main/java/umc/lightup/member/repository/MemberRegionRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberRegionRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface MemberRegionRepository extends JpaRepository<MemberRegion, Long> {
     List<MemberRegion> findByMember(Member member);
+    int deleteByIdAndMemberId(Long memberRegionId, Long memberId);
 }

--- a/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberSkillRepository.java
@@ -16,5 +16,6 @@ public interface MemberSkillRepository extends JpaRepository<MemberSkill, Long> 
     @Query("select s.name from MemberSkill ms join ms.skill s where ms.member = :member")
     List<String> findSkillNameByMember(@Param("member") Member member);
     boolean existsByMemberAndSkill(Member member, Skill skill);
+    int deleteByMemberIdAndSkillId(Long memberId, Long skillId);
 }
 

--- a/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberStrengthRepository.java
@@ -15,5 +15,6 @@ public interface MemberStrengthRepository extends JpaRepository<MemberStrength, 
     @Query("select s.name from MemberStrength ms join ms.strength s where ms.member = :member")
     List<String> findStrengthNameByMember(@Param("member") Member member);
     boolean existsByMemberAndStrength(Member member, Strength skill);
+    int deleteByMemberIdAndStrengthId(Long memberId, Long strengthId);
 }
 

--- a/src/main/java/umc/lightup/member/service/MemberCommandService.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandService.java
@@ -13,8 +13,11 @@ public interface MemberCommandService {
     MemberResponseDTO.MemberInfoDTO getMember(long id, String viewerEmail);
     Member putMember(String email, MemberRequestDTO.ChangeDto request);
     String selectSkill(Long skillId,Member member);
+    void removeMemberSkill(Long skillId, Long memberId);
     String selectStrength(Long strengthId,Member member);
+    void removeMemberStrength(Long strengthId, Long memberId);
     List<MemberResponseDTO.singleRegionResultDTO> selectRegions(Member member, MemberRequestDTO.MemberRegionListRequestDTO request);
+    void removeMemberRegion(Long memberRegionId, Long memberId);
     void addMemberLike(Member fromMember, long toMemberId);
     void removeMemberLike(String fromMemberEmail, long toMemberId);
     boolean isNicknameExist(String nickname);

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -184,6 +184,13 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     @Transactional
+    public void removeMemberSkill(Long skillId, Long memberId) {
+        if (memberSkillRepository.deleteByMemberIdAndSkillId(memberId, skillId) == 0)
+            throw new GeneralHandler(ErrorStatus.MEMBER_SKILL_NOT_FOUND);
+    }
+
+    @Override
+    @Transactional
     public String selectStrength(Long strengthId, Member member) {
         Strength foundStrength = strengthRepository.findById(strengthId)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.STRENGTH_NOT_FOUND));
@@ -195,6 +202,13 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         memberStrengthRepository.save(memberStrength);
 
         return foundStrength.getName();
+    }
+
+    @Override
+    @Transactional
+    public void removeMemberStrength(Long strengthId, Long memberId) {
+        if (memberStrengthRepository.deleteByMemberIdAndStrengthId(memberId, strengthId) == 0)
+            throw new GeneralHandler(ErrorStatus.MEMBER_STRENGTH_NOT_FOUND);
     }
 
     @Override
@@ -212,6 +226,13 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             resultDTOList.add(MemberConverter.toSingleRegionResultDTO(memberRegion));
         }
         return resultDTOList;
+    }
+
+    @Override
+    @Transactional
+    public void removeMemberRegion(Long memberRegionId, Long memberId) {
+        if (memberRegionRepository.deleteByIdAndMemberId(memberRegionId, memberId) == 0)
+            throw new GeneralHandler(ErrorStatus.MEMBER_REGION_NOT_FOUND);
     }
 
     @Override


### PR DESCRIPTION
## 💫 PR 제목
- [Skill, Strength, Region] 스킬, 강점, 지역 선택 취소 API 구현

---

## 🔧 작업 내용 요약
- 각각 유저가 선택한 스킬, 강점, 선호 지역을 취소하는 api 입니다.
- DB에서 해당값을 조회하여 존재하지 않으면 해당 도메인의 에러를 발생시키고 존재한다면 삭제합니다.

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 각각의 삭제 로직이 적절한지

---

## 🔗 관련 이슈
-  closes #58 

---

## 📝 기타 참고 사항
- 
