### PR TITLE
[Item] 프로젝트 상세 조회 페이지 댓글 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -61,6 +61,9 @@ public enum ErrorStatus implements BaseErrorCode {
     //ItemApply 관련 에러
     DUPLICATE_ITEM_APPLY(HttpStatus.BAD_REQUEST, "ITEMAPPLY4000", "이미 지원한 프로젝트입니다."),
 
+    //ItemComment 관련 에러
+    ITEM_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEMCOMMENT4000", "해당 댓글이 존재하지 않습니다."),
+
     //ItemViewHistory 관련 에러
     ITEM_VIEW_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEMVIEWHISTORY4000", "프로젝트 조회 내역이 존재하지 않습니다."),
 

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -82,7 +82,7 @@ public class ItemRestController {
     @Operation(summary = "특정 프로젝트 상세 조회 API", description = "특정 프로젝트를 상세 조회하는 API 입니다.")
     public ApiResponse<ItemResponseDTO.ItemInfoDTO> getItemInfo(Authentication authentication, @PathVariable("itemId") @Min(1) Long itemId) {
         Member member = memberCommandService.getMember(authentication.getName());
-        Item findItem = itemCommandService.getSingleItem(itemId);
+        Item findItem = itemCommandService.getSingleItemWithComments(itemId);
         List<ItemResponseDTO.ItemRegionResultDTO> itemRegions = itemCommandService.getItemRegions(findItem);
         List<ItemResponseDTO.RecruitPositionResultDTO> itemRecruitPositions = itemCommandService.getItemRecruitPositions(findItem);
         List<ItemResponseDTO.ItemCommentResultDTO> itemComments = itemCommandService.getItemComments(findItem);

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -87,8 +87,9 @@ public class ItemRestController {
         List<ItemResponseDTO.RecruitPositionResultDTO> itemRecruitPositions = itemCommandService.getItemRecruitPositions(findItem);
         List<ItemResponseDTO.ItemCommentResultDTO> itemComments = itemCommandService.getItemComments(findItem);
         boolean itemLike = itemCommandService.getItemLike(member.getId(), findItem.getId());
+        int commentCount = itemCommandService.countComments(findItem.getId());
         itemCommandService.updateItemHistory(member, findItem);
-        return ApiResponse.onSuccess(ItemConverter.toItemInfoDTO(findItem, itemRegions, itemRecruitPositions, itemComments, itemLike));
+        return ApiResponse.onSuccess(ItemConverter.toItemInfoDTO(findItem, itemRegions, itemRecruitPositions, itemComments, commentCount, itemLike));
     }
 
     @PostMapping("/{itemId}/like")

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -125,4 +125,14 @@ public class ItemRestController {
         ItemComment itemComment = itemCommandService.createItemComment(member, itemId, request);
         return ApiResponse.onSuccess(ItemConverter.toItemCommentResultDTO(itemComment));
     }
+
+    @DeleteMapping("/comments/{commentId}")
+    @Operation(summary = "프로젝트 댓글 삭제 API", description = "특정 프로젝트 상세 조회 페이지에서 댓글을 삭제하는 API입니다.")
+    public ApiResponse<Void> removeItemComment(Authentication authentication, @PathVariable("commentId") Long commentId) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+
+        itemCommandService.removeItemComment(member, commentId);
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+    }
 }

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -85,9 +85,10 @@ public class ItemRestController {
         Item findItem = itemCommandService.getSingleItem(itemId);
         List<ItemResponseDTO.ItemRegionResultDTO> itemRegions = itemCommandService.getItemRegions(findItem);
         List<ItemResponseDTO.RecruitPositionResultDTO> itemRecruitPositions = itemCommandService.getItemRecruitPositions(findItem);
+        List<ItemResponseDTO.ItemCommentResultDTO> itemComments = itemCommandService.getItemComments(findItem);
         boolean itemLike = itemCommandService.getItemLike(member.getId(), findItem.getId());
         itemCommandService.updateItemHistory(member, findItem);
-        return ApiResponse.onSuccess(ItemConverter.toItemInfoDTO(findItem, itemRegions, itemRecruitPositions, itemLike));
+        return ApiResponse.onSuccess(ItemConverter.toItemInfoDTO(findItem, itemRegions, itemRecruitPositions, itemComments, itemLike));
     }
 
     @PostMapping("/{itemId}/like")

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -18,6 +18,7 @@ import umc.lightup.api.code.status.SuccessStatus;
 import umc.lightup.item.converter.ItemConverter;
 import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemApply;
+import umc.lightup.item.domain.ItemComment;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.item.service.ItemCommandService;
@@ -113,5 +114,15 @@ public class ItemRestController {
         Item item = itemCommandService.getSingleItem(itemId);
         ItemApply itemApply = itemCommandService.applyItem(member, item);
         return ApiResponse.onSuccess(ItemConverter.toItemApplyResultDTO(itemApply));
+    }
+
+    @PostMapping("/{itemId}/comments")
+    @Operation(summary = "프로젝트 댓글 작성 API", description = "특정 프로젝트 상세 조회 페이지에서 댓글을 작성할 수 있는 API입니다.")
+    public ApiResponse<ItemResponseDTO.ItemCommentResultDTO> writeItemComment(Authentication authentication, @PathVariable("itemId") Long itemId, @RequestBody ItemRequestDTO.ItemCommentRequestDTO request) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+
+        ItemComment itemComment = itemCommandService.createItemComment(member, itemId, request);
+        return ApiResponse.onSuccess(ItemConverter.toItemCommentResultDTO(itemComment));
     }
 }

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -102,6 +102,14 @@ public class ItemConverter {
                 .build();
     }
 
+    public static ItemResponseDTO.ItemCommentResultDTO toItemCommentResultDTO (ItemComment itemComment) {
+        return ItemResponseDTO.ItemCommentResultDTO.builder()
+                .authorName(itemComment.getCommentMember().getName())
+                .authorProfileImageURL(itemComment.getCommentMember().getProfileImageUrl())
+                .content(itemComment.getContent())
+                .build();
+    }
+
 /*    public static ItemImage toItemImage(Item item, String imageUrl) {
         return ItemImage.builder()
                 .item(item)

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -16,7 +16,7 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemResponseDTO.ItemResultDTO toItemResultDTO(Item item, String itemImageUrl, int commentCount, boolean itemLike) {
+    public static ItemResponseDTO.ItemResultDTO toItemResultDTO(Item item, String itemImageUrl, int viewCount, int commentCount, boolean itemLike) {
         return ItemResponseDTO.ItemResultDTO.builder()
                 .itemId(item.getId())
                 .itemName(item.getName())
@@ -24,6 +24,7 @@ public class ItemConverter {
                 .itemImageUrl(itemImageUrl)
                 .updatedAt(item.getUpdatedAt().toLocalDate())
                 .recruitStatus(item.isProjectStatus())
+                .viewCount(viewCount)
                 .commentCount(commentCount)
                 .likedByCurrentUser(itemLike)
                 .build();

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -16,7 +16,7 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemResponseDTO.ItemResultDTO toItemResultDTO(Item item, String itemImageUrl, boolean itemLike) {
+    public static ItemResponseDTO.ItemResultDTO toItemResultDTO(Item item, String itemImageUrl, int commentCount, boolean itemLike) {
         return ItemResponseDTO.ItemResultDTO.builder()
                 .itemId(item.getId())
                 .itemName(item.getName())
@@ -24,6 +24,7 @@ public class ItemConverter {
                 .itemImageUrl(itemImageUrl)
                 .updatedAt(item.getUpdatedAt().toLocalDate())
                 .recruitStatus(item.isProjectStatus())
+                .commentCount(commentCount)
                 .likedByCurrentUser(itemLike)
                 .build();
     }
@@ -48,7 +49,7 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemResponseDTO.ItemInfoDTO toItemInfoDTO(Item item, List<ItemResponseDTO.ItemRegionResultDTO> itemRegionResultDTOList, List<ItemResponseDTO.RecruitPositionResultDTO> recruitPositionResultDTOList, List<ItemResponseDTO.ItemCommentResultDTO> itemCommentResultDTOList, boolean itemLike) {
+    public static ItemResponseDTO.ItemInfoDTO toItemInfoDTO(Item item, List<ItemResponseDTO.ItemRegionResultDTO> itemRegionResultDTOList, List<ItemResponseDTO.RecruitPositionResultDTO> recruitPositionResultDTOList, List<ItemResponseDTO.ItemCommentResultDTO> itemCommentResultDTOList, int commentCount, boolean itemLike) {
         return ItemResponseDTO.ItemInfoDTO.builder()
                 .introduce(item.getIntroduce())
                 .itemName(item.getName())
@@ -63,6 +64,7 @@ public class ItemConverter {
                 .description(item.getDescription())
                 .recruitPositions(recruitPositionResultDTOList)
                 .itemComments(itemCommentResultDTOList)
+                .commentCount(commentCount)
                 .likedByCurrentUser(itemLike)
                 .build();
     }

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -48,7 +48,7 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemResponseDTO.ItemInfoDTO toItemInfoDTO(Item item, List<ItemResponseDTO.ItemRegionResultDTO> itemRegionResultDTOList, List<ItemResponseDTO.RecruitPositionResultDTO> recruitPositionResultDTOList, boolean itemLike) {
+    public static ItemResponseDTO.ItemInfoDTO toItemInfoDTO(Item item, List<ItemResponseDTO.ItemRegionResultDTO> itemRegionResultDTOList, List<ItemResponseDTO.RecruitPositionResultDTO> recruitPositionResultDTOList, List<ItemResponseDTO.ItemCommentResultDTO> itemCommentResultDTOList, boolean itemLike) {
         return ItemResponseDTO.ItemInfoDTO.builder()
                 .introduce(item.getIntroduce())
                 .itemName(item.getName())
@@ -62,6 +62,7 @@ public class ItemConverter {
                 .regions(itemRegionResultDTOList)
                 .description(item.getDescription())
                 .recruitPositions(recruitPositionResultDTOList)
+                .itemComments(itemCommentResultDTOList)
                 .likedByCurrentUser(itemLike)
                 .build();
     }
@@ -104,9 +105,11 @@ public class ItemConverter {
 
     public static ItemResponseDTO.ItemCommentResultDTO toItemCommentResultDTO (ItemComment itemComment) {
         return ItemResponseDTO.ItemCommentResultDTO.builder()
+                .itemCommentId(itemComment.getId())
                 .authorName(itemComment.getCommentMember().getName())
                 .authorProfileImageURL(itemComment.getCommentMember().getProfileImageUrl())
                 .content(itemComment.getContent())
+                .updatedAt(itemComment.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/umc/lightup/item/domain/Item.java
+++ b/src/main/java/umc/lightup/item/domain/Item.java
@@ -63,6 +63,9 @@ public class Item extends BaseEntity {
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
     private List<ItemImage> itemImages = new ArrayList<>();
 
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
+    private List<ItemComment> itemComments = new ArrayList<>();
+
     //프로젝트에 프로젝트 프로필 이미지, 기획서를 제외하고 사진을 추가로 업로드 할 수 있게 하려면 itemImages도 필요함
     public Item uploadItemProfile(String itemProfileImageUrl) {
         this.itemProfileImageUrl = itemProfileImageUrl;

--- a/src/main/java/umc/lightup/item/domain/ItemComment.java
+++ b/src/main/java/umc/lightup/item/domain/ItemComment.java
@@ -1,0 +1,27 @@
+package umc.lightup.item.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import umc.lightup.common.BaseEntity;
+import umc.lightup.member.domain.Member;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ItemComment extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member commentMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id")
+    private Item item;
+}

--- a/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
@@ -68,4 +68,11 @@ public class ItemRequestDTO {
         @NotNull
         private Integer recruitNumber;
     }
+
+    @Getter
+    @Setter
+    public static class ItemCommentRequestDTO {
+        @NotBlank
+        private String content;
+    }
 }

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -33,6 +33,7 @@ public class ItemResponseDTO {
         private String itemImageUrl;
         private LocalDate updatedAt;
         private boolean recruitStatus;
+        private int viewCount;
         private int commentCount;
         private boolean likedByCurrentUser;
     }

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -111,4 +111,14 @@ public class ItemResponseDTO {
         private LocalDateTime appliedAt;
         private String message;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemCommentResultDTO {
+        private String authorName;
+        private String authorProfileImageURL;
+        private String content;
+    }
 }

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -79,6 +79,7 @@ public class ItemResponseDTO {
         private List<ItemRegionResultDTO> regions;
         private String description;
         private List<RecruitPositionResultDTO> recruitPositions;
+        private List<ItemCommentResultDTO> itemComments;
         private boolean likedByCurrentUser;
     }
 
@@ -117,8 +118,10 @@ public class ItemResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ItemCommentResultDTO {
+        private Long itemCommentId;
         private String authorName;
         private String authorProfileImageURL;
         private String content;
+        private LocalDateTime updatedAt;
     }
 }

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -33,6 +33,7 @@ public class ItemResponseDTO {
         private String itemImageUrl;
         private LocalDate updatedAt;
         private boolean recruitStatus;
+        private int commentCount;
         private boolean likedByCurrentUser;
     }
 
@@ -80,6 +81,7 @@ public class ItemResponseDTO {
         private String description;
         private List<RecruitPositionResultDTO> recruitPositions;
         private List<ItemCommentResultDTO> itemComments;
+        private int commentCount;
         private boolean likedByCurrentUser;
     }
 

--- a/src/main/java/umc/lightup/item/repository/ItemCommentRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemCommentRepository.java
@@ -3,7 +3,9 @@ package umc.lightup.item.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import umc.lightup.item.domain.ItemComment;
+import umc.lightup.member.domain.Member;
 
 @Repository
 public interface ItemCommentRepository extends JpaRepository<ItemComment, Long> {
+    int deleteByCommentMemberAndId(Member member, Long commentId);
 }

--- a/src/main/java/umc/lightup/item/repository/ItemCommentRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemCommentRepository.java
@@ -1,0 +1,9 @@
+package umc.lightup.item.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.lightup.item.domain.ItemComment;
+
+@Repository
+public interface ItemCommentRepository extends JpaRepository<ItemComment, Long> {
+}

--- a/src/main/java/umc/lightup/item/repository/ItemCommentRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemCommentRepository.java
@@ -8,4 +8,5 @@ import umc.lightup.member.domain.Member;
 @Repository
 public interface ItemCommentRepository extends JpaRepository<ItemComment, Long> {
     int deleteByCommentMemberAndId(Member member, Long commentId);
+    int countByItemId(Long itemId);
 }

--- a/src/main/java/umc/lightup/item/repository/ItemRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepository.java
@@ -4,15 +4,20 @@ package umc.lightup.item.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import umc.lightup.item.domain.Item;
 import umc.lightup.member.domain.Member;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long> {
     List<Item> findByMember(Member member);
+    @Query("select i from Item i left join fetch i.itemComments where i.id = :itemId")
+    Optional<Item> findByIdWithComments(@Param("itemId") Long itemId);
 
     Page<Item> findAll(Pageable pageable);
 }

--- a/src/main/java/umc/lightup/item/repository/ItemRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepository.java
@@ -16,8 +16,8 @@ import java.util.Optional;
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long> {
     List<Item> findByMember(Member member);
-    @Query("select i from Item i left join fetch i.itemComments where i.id = :itemId")
-    Optional<Item> findByIdWithComments(@Param("itemId") Long itemId);
+    @Query("select distinct i from Item i left join fetch i.itemComments ic left join fetch ic.commentMember where i.id = :itemId")
+    Optional<Item> findByIdWithCommentsAndCommentMembers(@Param("itemId") Long itemId);
 
     Page<Item> findAll(Pageable pageable);
 }

--- a/src/main/java/umc/lightup/item/repository/ItemViewHistoryRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemViewHistoryRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface ItemViewHistoryRepository extends JpaRepository<ItemViewHistory, Long> {
     Optional<ItemViewHistory> findByMemberAndItem(Member memberId, Item itemId);
+    int countByItemId(Long itemId);
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -22,6 +22,7 @@ public interface ItemCommandService {
     void removeItemLike(String email, long itemId);
     void updateItemHistory(Member member, Item item);
     ItemComment createItemComment(Member member, Long itemId, ItemRequestDTO.ItemCommentRequestDTO request);
+    void removeItemComment(Member member, Long commentId);
     Set<Long> findItemLikes(long memberId);
 
     List<ItemResponseDTO.ItemResultDTO> getAllItems(Pageable pageable, @Nullable Set<Long> likedItemIds);

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -32,4 +32,6 @@ public interface ItemCommandService {
     List<ItemResponseDTO.ItemRegionResultDTO> getItemRegions(Item item);
 
     List<ItemResponseDTO.RecruitPositionResultDTO> getItemRecruitPositions(Item item);
+
+    List<ItemResponseDTO.ItemCommentResultDTO> getItemComments(Item item);
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemApply;
+import umc.lightup.item.domain.ItemComment;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.member.domain.Member;
@@ -20,6 +21,7 @@ public interface ItemCommandService {
     void addItemLike(Member member, long itemId);
     void removeItemLike(String email, long itemId);
     void updateItemHistory(Member member, Item item);
+    ItemComment createItemComment(Member member, Long itemId, ItemRequestDTO.ItemCommentRequestDTO request);
     Set<Long> findItemLikes(long memberId);
 
     List<ItemResponseDTO.ItemResultDTO> getAllItems(Pageable pageable, @Nullable Set<Long> likedItemIds);

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -28,6 +28,7 @@ public interface ItemCommandService {
     ItemComment createItemComment(Member member, Long itemId, ItemRequestDTO.ItemCommentRequestDTO request);
     void removeItemComment(Member member, Long commentId);
     Set<Long> findItemLikes(long memberId);
+    int countComments(Long itemId);
 
     List<ItemResponseDTO.ItemResultDTO> getAllItems(Pageable pageable, @Nullable Set<Long> likedItemIds);
 

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -2,6 +2,8 @@ package umc.lightup.item.service;
 
 import jakarta.annotation.Nullable;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemApply;
@@ -11,11 +13,13 @@ import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.member.domain.Member;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 public interface ItemCommandService {
     Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile itemProfileImage, MultipartFile itemPlanFile);
     Item getSingleItem(Long itemId);
+    Item getSingleItemWithComments(Long itemId);
     ItemApply applyItem(Member member, Item item);
     boolean getItemLike(long memberId, long itemId);
     void addItemLike(Member member, long itemId);

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -41,6 +41,7 @@ public class ItemCommandServiceImpl implements ItemCommandService {
     private final ItemLikeRepository itemLikeRepository;
     private final ItemViewHistoryRepository itemViewHistoryRepository;
     private final ItemApplyRepository itemApplyRepository;
+    private final ItemCommentRepository itemCommentRepository;
 
     private final AmazonS3Manager s3Manager;
     private final UuidRepository uuidRepository;
@@ -224,5 +225,20 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                 .status(ItemApplyStatus.PENDING)
                 .appliedAt(LocalDateTime.now())
                 .build());
+    }
+
+    @Override
+    @Transactional
+    public ItemComment createItemComment(Member member, Long itemId, ItemRequestDTO.ItemCommentRequestDTO request) {
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND));
+
+        ItemComment createdItemComment = ItemComment.builder()
+                .content(request.getContent())
+                .commentMember(member)
+                .item(item)
+                .build();
+
+        return itemCommentRepository.save(createdItemComment);
     }
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -148,7 +148,7 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
     @Override
     public Item getSingleItemWithComments(Long itemId) {
-        return itemRepository.findByIdWithComments(itemId)
+        return itemRepository.findByIdWithCommentsAndCommentMembers(itemId)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND));
     }
 

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -147,6 +147,12 @@ public class ItemCommandServiceImpl implements ItemCommandService {
     }
 
     @Override
+    public Item getSingleItemWithComments(Long itemId) {
+        return itemRepository.findByIdWithComments(itemId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND));
+    }
+
+    @Override
     public boolean getItemLike(long memberId, long itemId) {
         return itemLikeRepository.existsByMemberIdAndItemId(memberId, itemId);
     }

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -249,4 +249,11 @@ public class ItemCommandServiceImpl implements ItemCommandService {
             throw new GeneralHandler(ErrorStatus.ITEM_COMMENT_NOT_FOUND);
         }
     }
+
+    @Override
+    public List<ItemResponseDTO.ItemCommentResultDTO> getItemComments(Item item) {
+        return item.getItemComments().stream()
+                .map(ItemConverter::toItemCommentResultDTO)
+                .toList();
+    }
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -123,8 +123,9 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                     String itemImageUrl = item.getItemProfileImageUrl();
                     boolean liked = likedItemIds != null && likedItemIds.contains(item.getId());
                     int commentCount = itemCommentRepository.countByItemId(item.getId());
+                    int viewCount = itemViewHistoryRepository.countByItemId(item.getId());
 
-                    return ItemConverter.toItemResultDTO(item, itemImageUrl, commentCount, liked);
+                    return ItemConverter.toItemResultDTO(item, itemImageUrl, viewCount, commentCount, liked);
                 }).toList();
     }
 

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -122,8 +122,9 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                 .map(item -> {
                     String itemImageUrl = item.getItemProfileImageUrl();
                     boolean liked = likedItemIds != null && likedItemIds.contains(item.getId());
+                    int commentCount = itemCommentRepository.countByItemId(item.getId());
 
-                    return ItemConverter.toItemResultDTO(item, itemImageUrl, liked);
+                    return ItemConverter.toItemResultDTO(item, itemImageUrl, commentCount, liked);
                 }).toList();
     }
 
@@ -261,5 +262,10 @@ public class ItemCommandServiceImpl implements ItemCommandService {
         return item.getItemComments().stream()
                 .map(ItemConverter::toItemCommentResultDTO)
                 .toList();
+    }
+
+    @Override
+    public int countComments(Long itemId) {
+        return itemCommentRepository.countByItemId(itemId);
     }
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -241,4 +241,12 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
         return itemCommentRepository.save(createdItemComment);
     }
+
+    @Override
+    @Transactional
+    public void removeItemComment(Member member, Long commentId) {
+        if (itemCommentRepository.deleteByCommentMemberAndId(member, commentId) == 0) {
+            throw new GeneralHandler(ErrorStatus.ITEM_COMMENT_NOT_FOUND);
+        }
+    }
 }


### PR DESCRIPTION
## 💫 PR 제목
- [Item] 프로젝트 상세 조회 페이지 댓글 기능 구현

---

## 🔧 작업 내용 요약
- 프로젝트 상세 조회 페이지에 다른 사용자들이 작성한 댓글이 보이도록 구현했습니다.
- 프로젝트 상세 조회 페이지 맨 밑에 댓글 작성이 가능합니다.
- 본인이 작성한 댓글의 경우 삭제도 가능합니다.


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- ItemCommandServiceImpl의 getItemComments 메서드에서 N + 1 문제가 일어날 수 있는지 궁금합니다.

---

## 🔗 관련 이슈
- closes #63 

---

## 📝 기타 참고 사항
- 
