### PR TITLE
[Member] 회원 검색 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ src/main/java/umc/lightup/temp
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+/src/main/generated/
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.3'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'umc'
@@ -40,6 +41,12 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// queryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	annotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -49,4 +56,26 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = generated
+}
+sourceSets {
+	main.java.srcDir generated
+}
+
+compileQuerydsl{
+	options.annotationProcessorPath = configurations.querydsl
+}
+
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/umc/lightup/config/CustomFunctionContributor.java
+++ b/src/main/java/umc/lightup/config/CustomFunctionContributor.java
@@ -1,0 +1,14 @@
+package umc.lightup.config;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.dialect.function.StandardSQLFunction;
+import org.hibernate.type.StandardBasicTypes;
+
+public class CustomFunctionContributor implements FunctionContributor {
+    @Override
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        functionContributions.getFunctionRegistry()
+                .register("bitand", new StandardSQLFunction("bitand", StandardBasicTypes.INTEGER));
+    }
+}

--- a/src/main/java/umc/lightup/config/CustomFunctionContributor.java
+++ b/src/main/java/umc/lightup/config/CustomFunctionContributor.java
@@ -10,5 +10,9 @@ public class CustomFunctionContributor implements FunctionContributor {
     public void contributeFunctions(FunctionContributions functionContributions) {
         functionContributions.getFunctionRegistry()
                 .register("bitand", new StandardSQLFunction("bitand", StandardBasicTypes.INTEGER));
+        functionContributions.getFunctionRegistry()
+                .register("json_objectagg", new StandardSQLFunction("json_objectagg", StandardBasicTypes.STRING));
+        functionContributions.getFunctionRegistry()
+                .register("json_arrayagg", new StandardSQLFunction("json_arrayagg", StandardBasicTypes.STRING));
     }
 }

--- a/src/main/java/umc/lightup/config/QueryDSLConfig.java
+++ b/src/main/java/umc/lightup/config/QueryDSLConfig.java
@@ -1,0 +1,18 @@
+package umc.lightup.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/umc/lightup/config/QueryDSLTemplate.java
+++ b/src/main/java/umc/lightup/config/QueryDSLTemplate.java
@@ -1,0 +1,34 @@
+package umc.lightup.config;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueryDSLTemplate {
+
+    public Expression<String> jsonObjectAgg(Object... args) {
+        return getStringTemplate("json_objectagg", args);
+    }
+
+    public Expression<String> jsonObject(Object... args) {
+        return getStringTemplate("json_object", args);
+    }
+
+    public Expression<String> jsonArrayAgg(Object... args) {
+        return getStringTemplate("json_arrayagg", args);
+    }
+
+    public StringTemplate getStringTemplate(String functionName, Object... args) {
+        StringBuilder builder = new StringBuilder("function('")
+                .append(functionName)
+                .append('\'');
+        for (int i = 0; i != args.length; i++)
+            builder.append(", {").append(i).append('}');
+        return Expressions.stringTemplate(
+                builder.append(')').toString(),
+                args
+        );
+    }
+}

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -5,6 +5,7 @@ import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberRegion;
+import umc.lightup.member.enums.Mbti;
 
 import java.util.List;
 
@@ -53,7 +54,7 @@ public class ItemConverter {
                 .memberName(item.getMember().getName())
                 .gender(item.getMember().getGender())
                 .age(item.getMember().getAge())
-                .mbti(item.getMember().getMbti())
+                .mbti(Mbti.fromByte(item.getMember().getMbti()))
                 .email(item.getMember().getEmail())
                 .school(item.getMember().getSchool())
                 .regions(itemRegionResultDTOList)

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -217,6 +217,25 @@ public class MemberRestController {
         return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
     }
 
+
+
+    @PostMapping("/search")
+    @Operation(
+            summary = "회원 검색 API",
+            description = "회원 프로필을 검색하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.MemberInfoListDTO> searchMember(
+            Authentication authentication,
+            @RequestBody MemberRequestDTO.MemberSearchRequestDTO request) {
+        Member member = null;
+        if (authentication != null) {
+            String email = authentication.getName();
+            member = memberCommandService.getMember(email);
+        }
+        return ApiResponse.onSuccess(memberCommandService.searchMember(member, request));
+    }
+
     @PostMapping("/password/change")
     @Operation(
             summary = "비밀번호 변경 API",

--- a/src/main/java/umc/lightup/member/controller/MemberRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberRestController.java
@@ -227,7 +227,7 @@ public class MemberRestController {
     )
     public ApiResponse<MemberResponseDTO.MemberInfoListDTO> searchMember(
             Authentication authentication,
-            @RequestBody MemberRequestDTO.MemberSearchRequestDTO request) {
+            @RequestBody @Valid MemberRequestDTO.MemberSearchRequestDTO request) {
         Member member = null;
         if (authentication != null) {
             String email = authentication.getName();

--- a/src/main/java/umc/lightup/member/domain/Member.java
+++ b/src/main/java/umc/lightup/member/domain/Member.java
@@ -8,7 +8,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import umc.lightup.AppConfig;
 import umc.lightup.common.BaseEntity;
-import umc.lightup.member.enums.Mbti;
 import umc.lightup.member.enums.Role;
 import umc.lightup.member.service.CredentialQueryService;
 
@@ -43,9 +42,15 @@ public class Member extends BaseEntity implements UserDetails {
     @Column(length = 8)
     private Role role;
 
-    @Enumerated(EnumType.STRING)
-    @Column(length = 4)
-    private Mbti mbti;
+    /**
+     * E +8,
+     * N +4,
+     * F +2,
+     * P +1,
+     * 총 0(ISTJ)~15(ENFP)로 표현
+     * */
+    @Column(columnDefinition = "BIT(4)")
+    private Byte mbti;
 
     @Column(unique = true, nullable = false, length = 30)
     private String email;

--- a/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
@@ -192,6 +192,8 @@ public class MemberRequestDTO {
         private Boolean onlyLiked;
         @Positive
         private Long page;
+        @Positive
+        private Long limit;
     }
 
     @Getter

--- a/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
@@ -92,7 +92,7 @@ public class MemberRequestDTO {
                     .gender(this.gender)
                     .birth(this.birth)
                     .role(this.role)
-                    .mbti(this.mbti)
+                    .mbti(this.mbti.toByte())
                     .email(this.email)
                     .school(this.school)
                     .phoneNumber(this.phoneNumber)
@@ -177,6 +177,16 @@ public class MemberRequestDTO {
     public static class PortFolioRequestDTO {
         @NotNull
         private Long portfolioId;
+    }
+
+    @Getter
+    @Setter
+    public static class MemberSearchRequestDTO {
+        private List<String> positions;
+        // 글자 하나하나 받는것과 각각에 대한 boolean으로 받는 것 모두 가능한데 프론트 입장에서 뭐가 편할지 모르겠음
+        private List<String> mbtiOptions;
+        private List<MemberRegionRequestDTO> regions;
+        private Boolean onlyLiked;
     }
 
     @Getter

--- a/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberRequestDTO.java
@@ -184,9 +184,14 @@ public class MemberRequestDTO {
     public static class MemberSearchRequestDTO {
         private List<String> positions;
         // 글자 하나하나 받는것과 각각에 대한 boolean으로 받는 것 모두 가능한데 프론트 입장에서 뭐가 편할지 모르겠음
-        private List<String> mbtiOptions;
+        private Boolean mbtiE;
+        private Boolean mbtiN;
+        private Boolean mbtiF;
+        private Boolean mbtiP;
         private List<MemberRegionRequestDTO> regions;
         private Boolean onlyLiked;
+        @Positive
+        private Long page;
     }
 
     @Getter

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -99,6 +99,33 @@ public class MemberResponseDTO {
         private String phoneNumber;
         private String profileImageUrl;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberInfoListDTO {
+        List<MemberInfoSimpleDTO> members;
+        int totalPages;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberInfoSimpleDTO {
+        private long id;
+        private String name;
+        private String nickname;
+        private Boolean gender;
+        private Mbti mbti;
+        private String selfIntroduce;
+        private List<String> skills;
+        private List<String> strengths;
+        private List<singleRegionResultDTO> regions;
+        private List<String> positions;
+        private String profileImageUrl;
+    }
     
     @Getter
     @Builder
@@ -236,7 +263,7 @@ public class MemberResponseDTO {
                 .nickname(member.getNickname())
                 .age(member.getAge())
                 .role(member.getRole())
-                .mbti(member.getMbti())
+                .mbti(Mbti.fromByte(member.getMbti()))
                 .birth(member.getBirth())
                 .gender(member.getGender())
                 .school(member.getSchool())

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -106,9 +106,10 @@ public class MemberResponseDTO {
     @AllArgsConstructor
     public static class MemberInfoListDTO {
         List<MemberInfoSimpleDTO> members;
-        int totalPages;
+        long numOfTotalResults;
     }
 
+    @Setter
     @Getter
     @Builder
     @NoArgsConstructor
@@ -119,12 +120,12 @@ public class MemberResponseDTO {
         private String nickname;
         private Boolean gender;
         private Mbti mbti;
-        private String selfIntroduce;
         private List<String> skills;
         private List<String> strengths;
         private List<singleRegionResultDTO> regions;
         private List<String> positions;
         private String profileImageUrl;
+        private boolean liked;
     }
     
     @Getter

--- a/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
+++ b/src/main/java/umc/lightup/member/dto/MemberViewInfo.java
@@ -6,6 +6,7 @@ import umc.lightup.member.domain.Activity;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.MemberRegion;
 import umc.lightup.member.domain.Portfolio;
+import umc.lightup.member.enums.Mbti;
 import umc.lightup.skill.domain.Skill;
 import umc.lightup.strength.domain.Strength;
 
@@ -55,7 +56,7 @@ public class MemberViewInfo {
                 .nickname(member.getNickname())
                 .age(member.getAge())
                 .role(member.getRole())
-                .mbti(member.getMbti())
+                .mbti(Mbti.fromByte(member.getMbti()))
                 .birth(member.getBirth())
                 .gender(member.getGender())
                 .school(member.getSchool())
@@ -111,7 +112,7 @@ public class MemberViewInfo {
                 .age(member.getAge())
                 .gender(member.getGender())
                 .school(member.getSchool())
-                .mbti(member.getMbti())
+                .mbti(Mbti.fromByte(member.getMbti()))
                 .profileImageUrl(member.getProfileImageUrl())
                 .selfIntroduce(member.getSelfIntroduce())
                 .skills(skills.stream()

--- a/src/main/java/umc/lightup/member/enums/Mbti.java
+++ b/src/main/java/umc/lightup/member/enums/Mbti.java
@@ -16,5 +16,39 @@ public enum Mbti {
     ESTJ,
     ESFJ,
     ENFJ,
-    ENTJ
+    ENTJ;
+    /*
+    * E +8
+    * N +4
+    * F +2
+    * P +1
+    * 총 0~15로 표현
+    * */
+
+    public byte toByte() {
+        byte[] textValue = this.toString().getBytes();
+        byte result = 0;
+        if (textValue[0] == 'E') result = 0x08;
+        if (textValue[1] == 'N') result |= 0x04;
+        if (textValue[2] == 'F') result |= 0x02;
+        if (textValue[3] == 'P') result |= 0x01;
+        return result;
+    }
+
+    public static Mbti fromByte(byte b) {
+        StringBuilder textValue = new StringBuilder();
+        if ((b & 0x08) != 0) textValue.append("E");
+        else textValue.append("I");
+
+        if ((b & 0x04) != 0) textValue.append("N");
+        else textValue.append("S");
+
+        if ((b & 0x02) != 0) textValue.append("F");
+        else textValue.append("T");
+
+        if ((b & 0x01) != 0) textValue.append("P");
+        else textValue.append("J");
+
+        return Mbti.valueOf(textValue.toString());
+    }
 }

--- a/src/main/java/umc/lightup/member/repository/MemberRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberRepository.java
@@ -7,7 +7,7 @@ import umc.lightup.member.domain.Member;
 import java.util.Optional;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     Optional<Member> findByEmail(String email);
     boolean existsByEmail(String email);
     boolean existsByPhoneNumber(String phoneNumber);

--- a/src/main/java/umc/lightup/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/umc/lightup/member/repository/MemberRepositoryCustom.java
@@ -1,0 +1,10 @@
+package umc.lightup.member.repository;
+
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.dto.MemberRequestDTO;
+import umc.lightup.member.dto.MemberResponseDTO;
+
+public interface MemberRepositoryCustom {
+    MemberResponseDTO.MemberInfoListDTO getMemberInfos
+            (Member requestedMember, MemberRequestDTO.MemberSearchRequestDTO options);
+}

--- a/src/main/java/umc/lightup/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/umc/lightup/member/repository/MemberRepositoryImpl.java
@@ -1,0 +1,287 @@
+package umc.lightup.member.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import umc.lightup.member.domain.*;
+import umc.lightup.member.dto.MemberRequestDTO;
+import umc.lightup.member.dto.MemberResponseDTO;
+import umc.lightup.member.enums.Mbti;
+import umc.lightup.position.domain.QPosition;
+import umc.lightup.region.domain.QRegion;
+import umc.lightup.skill.domain.QSkill;
+import umc.lightup.strength.domain.QStrength;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom{
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QMember member = QMember.member;
+    private final QMemberPosition memberPosition = QMemberPosition.memberPosition;
+    private final QPosition position = QPosition.position;
+    private final QMemberRegion memberRegion = QMemberRegion.memberRegion;
+    private final QRegion region = QRegion.region;
+    private final QMemberLike memberLike = QMemberLike.memberLike;
+    private final QSkill skill = QSkill.skill;
+    private final QMemberSkill memberSkill = QMemberSkill.memberSkill;
+    private final QStrength strength = QStrength.strength;
+    private final QMemberStrength memberStrength = QMemberStrength.memberStrength;
+
+    @Override
+    public MemberResponseDTO.MemberInfoListDTO getMemberInfos
+            (Member requestedMember, MemberRequestDTO.MemberSearchRequestDTO options) {
+        // 아니 JSON_OBJECTAGG 함수로 일대다들을 한 번에 묶어 가져올 생각 하고 있었는데 QueryDSL이 지원을 안 한다네요???
+        // 그 함수가 MySQL에만 있고 다른 DB에는 없다니 이해는 하는데, 그렇다고 Native Query를 쓰기는 많이 복잡할 것 같은데...
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        // 1) Position.name 리스트 필터
+        if (options.getPositions() != null && !options.getPositions().isEmpty()) {
+            BooleanExpression positionCondition = JPAExpressions
+                    .selectOne()
+                    .from(memberPosition)
+                    .join(memberPosition.position, position)
+                    .where(
+                            memberPosition.member.eq(member),
+                            position.name.in(options.getPositions())
+                    )
+                    .exists();
+
+            // 메인 쿼리에서 predicate에 추가
+            predicate.and(positionCondition);
+        }
+
+        // 2) Region 필터
+        if (options.getRegions() != null && !options.getRegions().isEmpty()) {
+            BooleanBuilder regionBuilder = new BooleanBuilder();
+            for (MemberRequestDTO.MemberRegionRequestDTO cond : options.getRegions()) {
+                if (cond.getSiGunGu() != null)
+                    regionBuilder.or(
+                            JPAExpressions
+                                    .selectOne()
+                                    .from(memberRegion)
+                                    .where(
+                                            memberRegion.member.eq(member),
+                                            memberRegion.siDo.eq(cond.getSiDo()),
+                                            memberRegion.siGunGu.eq(cond.getSiGunGu())
+                                    )
+                                    .exists()
+                    );
+                else regionBuilder.or(
+                        JPAExpressions
+                                .selectOne()
+                                .from(memberRegion)
+                                .where(
+                                        memberRegion.member.eq(member),
+                                        memberRegion.siDo.eq(cond.getSiDo())
+                                )
+                                .exists()
+                );
+            }
+            predicate.and(regionBuilder);
+        }
+
+        // 3) MBTI 비트마스크 필터
+        if (options.getMbtiE() != null) {
+            if (options.getMbtiE()) predicate.and(memberMbtiBitAnd(8).ne(0));
+            else predicate.and(memberMbtiBitAnd(8).eq(0));
+        }
+        if (options.getMbtiN() != null) {
+            if (options.getMbtiN()) predicate.and(memberMbtiBitAnd(4).ne(0));
+            else predicate.and(memberMbtiBitAnd(4).eq(0));
+        }
+        if (options.getMbtiF() != null) {
+            if (options.getMbtiF()) predicate.and(memberMbtiBitAnd(2).ne(0));
+            else predicate.and(memberMbtiBitAnd(2).eq(0));
+        }
+        if (options.getMbtiP() != null) {
+            if (options.getMbtiP()) predicate.and(memberMbtiBitAnd(1).ne(0));
+            else predicate.and(memberMbtiBitAnd(1).eq(0));
+        }
+
+        // 4) 좋아요
+        if (requestedMember != null && options.getOnlyLiked() != null && options.getOnlyLiked()) {
+            BooleanExpression likedExists = JPAExpressions
+                    .selectOne()
+                    .from(memberLike)
+                    .where(
+                            memberLike.toMember.eq(member),         // 이 member가 좋아요 받은 대상
+                            memberLike.fromMember.eq(requestedMember) // 내가 누른 '좋아요' 인가
+                    )
+                    .exists();
+            predicate.and(likedExists);
+        }
+
+        if (options.getPage() == null) options.setPage(1L);
+
+        BooleanExpression likedCondition;
+        if (requestedMember == null) likedCondition = Expressions.FALSE;
+        else likedCondition = JPAExpressions
+                    .selectOne()
+                    .from(memberLike)
+                    .where(
+                            memberLike.toMember.eq(member),          // 조회 중인 멤버가 좋아요 받은 대상
+                            memberLike.fromMember.eq(requestedMember) // 조회자 기준
+                    )
+                    .exists();
+
+
+        List<MemberWithLikeDTO> memberList = jpaQueryFactory
+                .select(Projections.constructor(MemberWithLikeDTO.class,
+                        member.id,
+                        member.name,
+                        member.nickname,
+                        member.gender,
+                        member.mbti,
+                        member.profileImageUrl,
+                        likedCondition.as("liked")))
+                .from(member)
+                .where(predicate)
+                .offset((options.getPage() - 1) * 16)
+                .limit(16)
+                .fetch();
+
+        List<MemberResponseDTO.MemberInfoSimpleDTO> resultList = memberList.stream()
+                .map(m -> MemberResponseDTO.MemberInfoSimpleDTO.builder()
+                        .id(m.getId())
+                        .name(m.getName())
+                        .nickname(m.getNickname())
+                        .gender(m.getGender())
+                        .mbti(Mbti.fromByte(m.getMbti()))
+                        .profileImageUrl(m.getProfileImageUrl())
+                        .liked(m.isLiked())
+                        .positions(List.of())
+                        .regions(List.of())
+                        .skills(List.of())
+                        .strengths(List.of())
+                        .build())
+                .toList();
+
+        //이후 id값을 기준으로 데이터 넣을 때 활용, list로 선형탐색하면 시간복잡도가 증가하기 때문에 쓴 방식
+        Map<Long, MemberResponseDTO.MemberInfoSimpleDTO> mapById =
+                resultList.stream().collect(Collectors.toMap(
+                MemberResponseDTO.MemberInfoSimpleDTO::getId,
+                m -> m));
+
+        List<Long> memberIds = memberList.stream()
+                .map(MemberWithLikeDTO::getId)
+                .toList();
+
+        //positions
+        jpaQueryFactory
+                .select(Projections.constructor(MemberIdAndNameDTO.class,
+                        memberPosition.member.id,
+                        position.name))
+                .from(memberPosition)
+                .join(memberPosition.position, position)
+                .where(memberPosition.member.id.in(memberIds))
+                .fetch().stream()
+                .collect(Collectors.groupingBy(
+                        MemberIdAndNameDTO::getId,
+                        Collectors.mapping(MemberIdAndNameDTO::getName, Collectors.toList())))
+                .forEach((key, value) -> mapById.get(key).setPositions(value));
+
+        //regions
+        jpaQueryFactory
+                .select(Projections.constructor(MemberIdAndRegionDTO.class,
+                        memberRegion.member.id,
+                        memberRegion.siDo,
+                        memberRegion.siGunGu))
+                .from(memberRegion)
+                .where(memberRegion.member.id.in(memberIds))
+                .fetch().stream()
+                .collect(Collectors.groupingBy(
+                        MemberIdAndRegionDTO::getId,
+                        Collectors.mapping(r->
+                                MemberResponseDTO.singleRegionResultDTO.builder()
+                                        .siDo(r.siDo)
+                                        .siGunGu(r.siGunGu)
+                                        .build(), Collectors.toList())))
+                .forEach((key, value) -> mapById.get(key).setRegions(value));
+
+        //skills
+        jpaQueryFactory
+                .select(Projections.constructor(MemberIdAndNameDTO.class,
+                        memberSkill.member.id,
+                        skill.name))
+                .from(memberSkill)
+                .join(memberSkill.skill, skill)
+                .where(memberSkill.member.id.in(memberIds))
+                .fetch().stream()
+                .collect(Collectors.groupingBy(
+                        MemberIdAndNameDTO::getId,
+                        Collectors.mapping(MemberIdAndNameDTO::getName, Collectors.toList())))
+                .forEach((key, value) -> mapById.get(key).setSkills(value));
+
+        //strengths
+        jpaQueryFactory
+                .select(Projections.constructor(MemberIdAndNameDTO.class,
+                        memberStrength.member.id,
+                        strength.name))
+                .from(memberStrength)
+                .join(memberStrength.strength, strength)
+                .where(memberStrength.member.id.in(memberIds))
+                .fetch().stream()
+                .collect(Collectors.groupingBy(
+                        MemberIdAndNameDTO::getId,
+                        Collectors.mapping(MemberIdAndNameDTO::getName, Collectors.toList())))
+                .forEach((key, value) -> mapById.get(key).setStrengths(value));
+
+        long totalResultCount = Optional.ofNullable(jpaQueryFactory
+                .select(member.count())
+                .from(member)
+                .where(predicate)
+                .fetchOne()).orElse(0L);
+
+        return MemberResponseDTO.MemberInfoListDTO.builder()
+                .members(resultList)
+                .numOfTotalResults(totalResultCount)
+                .build();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    //private 사용 불가
+    public static class MemberWithLikeDTO {
+        private long id;
+        private String name;
+        private String nickname;
+        private Boolean gender;
+        private Byte mbti;
+        private String profileImageUrl;
+        private boolean liked;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    //private 사용 불가
+    public static class MemberIdAndNameDTO {
+        private long id;
+        private String name;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    //private 사용 불가
+    public static class MemberIdAndRegionDTO {
+        private long id;
+        private String siDo;
+        private String siGunGu;
+    }
+
+    private NumberTemplate<Integer> memberMbtiBitAnd(int mask) {
+        return Expressions.numberTemplate(Integer.class, "function('bitand', {0}, {1})", member.mbti, mask);
+    }
+}

--- a/src/main/java/umc/lightup/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/umc/lightup/member/repository/MemberRepositoryImpl.java
@@ -1,5 +1,8 @@
 package umc.lightup.member.repository;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -11,6 +14,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import umc.lightup.api.code.status.ErrorStatus;
+import umc.lightup.config.QueryDSLTemplate;
+import umc.lightup.exception.handler.GeneralHandler;
 import umc.lightup.member.domain.*;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
@@ -21,9 +27,7 @@ import umc.lightup.skill.domain.QSkill;
 import umc.lightup.strength.domain.QStrength;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -40,11 +44,13 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
     private final QStrength strength = QStrength.strength;
     private final QMemberStrength memberStrength = QMemberStrength.memberStrength;
 
+    private final QueryDSLTemplate queryDSLTemplate;
+    private final ObjectMapper objectMapper;
+
     @Override
     public MemberResponseDTO.MemberInfoListDTO getMemberInfos
             (Member requestedMember, MemberRequestDTO.MemberSearchRequestDTO options) {
-        // 아니 JSON_OBJECTAGG 함수로 일대다들을 한 번에 묶어 가져올 생각 하고 있었는데 QueryDSL이 지원을 안 한다네요???
-        // 그 함수가 MySQL에만 있고 다른 DB에는 없다니 이해는 하는데, 그렇다고 Native Query를 쓰기는 많이 복잡할 것 같은데...
+        // JSON_OBJECTAGG 구현 버전
         BooleanBuilder predicate = new BooleanBuilder();
 
         // 1) Position.name 리스트 필터
@@ -125,6 +131,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
         }
 
         if (options.getPage() == null) options.setPage(1L);
+        if (options.getLimit() == null) options.setLimit(16L);
 
         BooleanExpression likedCondition;
         if (requestedMember == null) likedCondition = Expressions.FALSE;
@@ -137,8 +144,7 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
                     )
                     .exists();
 
-
-        List<MemberWithLikeDTO> memberList = jpaQueryFactory
+        List<MemberResponseDTO.MemberInfoSimpleDTO> resultList = jpaQueryFactory
                 .select(Projections.constructor(MemberWithLikeDTO.class,
                         member.id,
                         member.name,
@@ -146,98 +152,47 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
                         member.gender,
                         member.mbti,
                         member.profileImageUrl,
+
+                        // Positions 집계
+                        JPAExpressions
+                                .select(queryDSLTemplate.jsonArrayAgg(position.name))
+                                .from(memberPosition)
+                                .join(memberPosition.position, position)
+                                .where(memberPosition.member.id.eq(member.id)),
+
+                        // Regions 집계
+                        JPAExpressions
+                                .select(queryDSLTemplate.jsonArrayAgg(
+                                        queryDSLTemplate.jsonObject(
+                                                Expressions.constant("siDo"), memberRegion.siDo,
+                                                Expressions.constant("siGunGu"), memberRegion.siGunGu
+                                        )
+                                ))
+                                .from(memberRegion)
+                                .where(memberRegion.member.id.eq(member.id)),
+
+                        // Skills 집계
+                        JPAExpressions
+                                .select(queryDSLTemplate.jsonArrayAgg(skill.name))
+                                .from(memberSkill)
+                                .join(memberSkill.skill, skill)
+                                .where(memberSkill.member.id.eq(member.id)),
+
+                        // Strengths 집계
+                        JPAExpressions
+                                .select(queryDSLTemplate.jsonArrayAgg(strength.name))
+                                .from(memberStrength)
+                                .join(memberStrength.strength, strength)
+                                .where(memberStrength.member.id.eq(member.id)),
                         likedCondition.as("liked")))
                 .from(member)
                 .where(predicate)
-                .offset((options.getPage() - 1) * 16)
-                .limit(16)
-                .fetch();
-
-        List<MemberResponseDTO.MemberInfoSimpleDTO> resultList = memberList.stream()
-                .map(m -> MemberResponseDTO.MemberInfoSimpleDTO.builder()
-                        .id(m.getId())
-                        .name(m.getName())
-                        .nickname(m.getNickname())
-                        .gender(m.getGender())
-                        .mbti(Mbti.fromByte(m.getMbti()))
-                        .profileImageUrl(m.getProfileImageUrl())
-                        .liked(m.isLiked())
-                        .positions(List.of())
-                        .regions(List.of())
-                        .skills(List.of())
-                        .strengths(List.of())
-                        .build())
+                .offset((options.getPage() - 1) * options.getLimit())
+                .limit(options.getLimit())
+                .fetch().stream()
+                .map(m -> m.toMemberInfoSimpleDTO(objectMapper))
                 .toList();
 
-        //이후 id값을 기준으로 데이터 넣을 때 활용, list로 선형탐색하면 시간복잡도가 증가하기 때문에 쓴 방식
-        Map<Long, MemberResponseDTO.MemberInfoSimpleDTO> mapById =
-                resultList.stream().collect(Collectors.toMap(
-                MemberResponseDTO.MemberInfoSimpleDTO::getId,
-                m -> m));
-
-        List<Long> memberIds = memberList.stream()
-                .map(MemberWithLikeDTO::getId)
-                .toList();
-
-        //positions
-        jpaQueryFactory
-                .select(Projections.constructor(MemberIdAndNameDTO.class,
-                        memberPosition.member.id,
-                        position.name))
-                .from(memberPosition)
-                .join(memberPosition.position, position)
-                .where(memberPosition.member.id.in(memberIds))
-                .fetch().stream()
-                .collect(Collectors.groupingBy(
-                        MemberIdAndNameDTO::getId,
-                        Collectors.mapping(MemberIdAndNameDTO::getName, Collectors.toList())))
-                .forEach((key, value) -> mapById.get(key).setPositions(value));
-
-        //regions
-        jpaQueryFactory
-                .select(Projections.constructor(MemberIdAndRegionDTO.class,
-                        memberRegion.member.id,
-                        memberRegion.siDo,
-                        memberRegion.siGunGu))
-                .from(memberRegion)
-                .where(memberRegion.member.id.in(memberIds))
-                .fetch().stream()
-                .collect(Collectors.groupingBy(
-                        MemberIdAndRegionDTO::getId,
-                        Collectors.mapping(r->
-                                MemberResponseDTO.singleRegionResultDTO.builder()
-                                        .siDo(r.siDo)
-                                        .siGunGu(r.siGunGu)
-                                        .build(), Collectors.toList())))
-                .forEach((key, value) -> mapById.get(key).setRegions(value));
-
-        //skills
-        jpaQueryFactory
-                .select(Projections.constructor(MemberIdAndNameDTO.class,
-                        memberSkill.member.id,
-                        skill.name))
-                .from(memberSkill)
-                .join(memberSkill.skill, skill)
-                .where(memberSkill.member.id.in(memberIds))
-                .fetch().stream()
-                .collect(Collectors.groupingBy(
-                        MemberIdAndNameDTO::getId,
-                        Collectors.mapping(MemberIdAndNameDTO::getName, Collectors.toList())))
-                .forEach((key, value) -> mapById.get(key).setSkills(value));
-
-        //strengths
-        jpaQueryFactory
-                .select(Projections.constructor(MemberIdAndNameDTO.class,
-                        memberStrength.member.id,
-                        strength.name))
-                .from(memberStrength)
-                .join(memberStrength.strength, strength)
-                .where(memberStrength.member.id.in(memberIds))
-                .fetch().stream()
-                .collect(Collectors.groupingBy(
-                        MemberIdAndNameDTO::getId,
-                        Collectors.mapping(MemberIdAndNameDTO::getName, Collectors.toList())))
-                .forEach((key, value) -> mapById.get(key).setStrengths(value));
 
         long totalResultCount = Optional.ofNullable(jpaQueryFactory
                 .select(member.count())
@@ -261,24 +216,49 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
         private Boolean gender;
         private Byte mbti;
         private String profileImageUrl;
+        private String positionsJson;
+        private String regionsJson;
+        private String skillsJson;
+        private String strengthsJson;
         private boolean liked;
-    }
 
-    @Getter
-    @AllArgsConstructor
-    //private 사용 불가
-    public static class MemberIdAndNameDTO {
-        private long id;
-        private String name;
-    }
+        public MemberResponseDTO.MemberInfoSimpleDTO toMemberInfoSimpleDTO(ObjectMapper objectMapper) {
+            try {
+                //null이 가능하다 했으니 null check 진행
+                List<String> positions;
+                if (positionsJson == null || positionsJson.isBlank()) positions = List.of();
+                else positions = objectMapper.readValue(positionsJson, new TypeReference<>(){});
 
-    @Getter
-    @AllArgsConstructor
-    //private 사용 불가
-    public static class MemberIdAndRegionDTO {
-        private long id;
-        private String siDo;
-        private String siGunGu;
+                List<MemberResponseDTO.singleRegionResultDTO> regions;
+                if (regionsJson == null || regionsJson.isBlank()) regions = List.of();
+                else regions = objectMapper.readValue(regionsJson, new TypeReference<>(){});
+
+                List<String> skills;
+                if (skillsJson == null || skillsJson.isBlank()) skills = List.of();
+                else skills = objectMapper.readValue(skillsJson, new TypeReference<>(){});
+
+                List<String> strengths;
+                if (strengthsJson == null || strengthsJson.isBlank()) strengths = List.of();
+                else strengths = objectMapper.readValue(strengthsJson, new TypeReference<>(){});
+
+                return MemberResponseDTO.MemberInfoSimpleDTO.builder()
+                        .id(id)
+                        .name(name)
+                        .nickname(nickname)
+                        .gender(gender)
+                        .mbti(mbti == null ? null : Mbti.fromByte(mbti))
+                        .profileImageUrl(profileImageUrl)
+                        .positions(positions) // <> 내부 생략 가능
+                        .regions(regions)
+                        .skills(skills)
+                        .strengths(strengths)
+                        .liked(liked)
+                        .build();
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                throw new GeneralHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+            }
+        }
     }
 
     private NumberTemplate<Integer> memberMbtiBitAnd(int mask) {

--- a/src/main/java/umc/lightup/member/service/MemberCommandService.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandService.java
@@ -20,6 +20,7 @@ public interface MemberCommandService {
     Portfolio savePortfolio(Member member, String name, MultipartFile portfolioFile);
     Portfolio savePortfolio(Member member, String name, String portfolioLink);
     void removePortfolio(String memberEmail, long portFolioId);
+    MemberResponseDTO.MemberInfoListDTO searchMember(Member member, MemberRequestDTO.MemberSearchRequestDTO options);
     String selectSkill(Long skillId,Member member);
     void removeMemberSkill(Long skillId, Long memberId);
     String selectStrength(Long strengthId,Member member);

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -266,6 +266,13 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     }
 
     @Override
+    public MemberResponseDTO.MemberInfoListDTO searchMember(
+            Member member,
+            MemberRequestDTO.MemberSearchRequestDTO options) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
     @Transactional
     public String selectSkill(Long skillId, Member member) {
         Skill foundSkill = skillRepository.findById(skillId)

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -269,7 +269,9 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     public MemberResponseDTO.MemberInfoListDTO searchMember(
             Member member,
             MemberRequestDTO.MemberSearchRequestDTO options) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        if (options.getRegions() == null) options.setRegions(List.of());
+        if (options.getPositions() == null) options.setPositions(List.of());
+        return memberRepository.getMemberInfos(member, options);
     }
 
     @Override

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+umc.lightup.config.CustomFunctionContributor


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 회원 검색 기능 구현

---

## 🔧 작업 내용 요약
- 회원을 파트별로 검색하는 기능 구현
- 회원을 MBTI별로 검색하는 기능 구현
- 회원을 위치별로 검색하는 기능 구현
- 좋아요한 회원만 검색하는 기능 구현
- 회원의 MBTI 저장 방식을 Byte(또는 4 bit)로 수정, bitwise 연산자로 검색 구현
- 회원별로 id(이후 상세조회에 활용), name, nickname, gender, mbti, profileImageUrl, positions, regions, skills, strengths, liked(좋아요 표시 여부) 반환
- positions, regions, skills, strengths는 회원이 설정한 모든 데이터 반환
- 16개 단위로 페이징 구현


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- **쿼리가 6개 날라가는 현 상황이 적절한지.** 처음에는 JSON_OBJECTAGG 함수를 적용할 수 없는 것으로 알고 결과 row가 매우 커지는 것을 막기 위해 쿼리를 분리했습니다. 코드를 작성하면서 JSON_OBJECTAGG 함수를 적용할 수 있겠다는 생각이 들어 이는 시간이 허락하면 수정해보고자 합니다.
- 검색 조건이 4개(파트, 지역, MBTI, 좋아요 표시)뿐인데 괜찮을지. 코드를 짜면서 보니 다른 검색 조건 추가는 난이도가 높지 않아 보입니다.
- LEADER, TEAMMATE 필터링이 적용되지 않았는데 적절한지. ADMIN이나 PROVISION(아직 회원정보를 입력하지 않은 회원)도 필터링이 적용되지 않는 상태인데 괜찮은지.
- 매 실행마다 검색 결과의 member 수(numOfTotalResults)를 계산하는 게 적합한지. 쿼리 하나가 아깝긴 한데 JPQL의 Page<T>를 반환하는 모든 함수가 이렇게 구현 되어있긴 합니다. 워크북 2주차 내용에 일부 설명이 있는데, Offset Based 페이징을 진행하는 지금 numOfTotalResults를 매번 가져올까요, 아니면 프론트에서 요청 여부를 받고 이를 토대로 진행할까요?
- option의 validation을 깊게 생각하지 않았는데 적절한지. 이건 뒤늦게 떠올라서 문제가 된 거긴 합니다. 물론 현재 쿼리상 오타나면 결과가 걸리지 않아서 동작에는 문제가 없는데, 그래도 시간 나면 validation을 진행하는 게 좋지 않을까 생각하긴 합니다. 다만 이러면 결국 쿼리가 몇 번 더 날라가게 되는 거니 **이미 쿼리를 6번 보내는 현 상황에서 쿼리 추가로 인한 성능 저하도 생각해보긴 해야 할 것 같아** 이 목록에 넣습니다.
- **positions, regions, skills, strengths에 순서가 없는데 괜찮을지.** 사실 이건 이 기능의 문제가 아니라 ERD(순서를 저장하는 column 추가)와 각각 순서를 저장하는 로직부터 만들어야 하는 문제이긴 합니다. 검색 화면에서는 skill, strength가 최대 2개씩 표시되는데, 현재 상황에서는 회원이 표시될 2개를 고를 수 없고 무작위로 선택된다는(다만 높은 확률로 선택을 오래 전에 한 순서대로 2개가 됨) 문제가 있습니다.(이때문에 2개까지만 가져오는 기능을 일부러 구현하지 않은 상황입니다.) 비록 회원 검색에는 포함되지 않지만, 포트폴리오 순서도 비슷한 문제가 있는 상태입니다.
- 테스트를 데이터 3개밖에 안 넣고 돌렸는데 괜찮을지. 사실 전혀 괜찮지 않은 건 맞습니다. 다만 프론트에서 기능 완성을 요구할 수 있을 것 같아 Draft로 올리지는 않겠습니다. 프론트에서 검색 기능을 요구한다면 이거 그대로 merge하고 배포하셔도 됩니다.(다만 추가 작업을 진행할 수 있으니 branch 삭제는 하지 말아 주시기를 부탁드립니다.) 또한 시간이 여유로우시면 염치없지만 테스트를 부탁드리고 싶습니다.

---

## 🔗 관련 이슈
- closes #61

---

## 📝 기타 참고 사항
- 사용자간 관계에 따라 프로필 이미지를 가리는 건 회원 상세 조회 페이지와 마찬가지로 아직 구현되지 않았습니다. 그러나 모든 사용자의 프로필 이미지를 가리도록 구현된 회원 상세 조회와는 달리, 모든 사용자의 프로필 이미지를 보여주도록 설정되어 있습니다. 이는 회원의 item 참여 관련 로직 구현 상황을 확인하고 진행할 예정입니다.
- 참고자료는... GPT와 함께 코딩해서 뭐라 공유하기 그러네요...
- JSON_OBJECTAGG 함수를 적용할 수 없는 것으로 알아서 먼길 돌아온 상태이긴 합니다. 근데 주석에도 적었지만 이게 MySQL에만 있고 다른 DB에는 없다 하더라고요. 따라서 JSON_OBJECTAGG 함수를 적용하게 되면 MySQL이 아닌 다른 SQL을 사용할 수 없다는 문제가 발생한다는 부작용도 있습니다.
- 저번에 70줄짜리 복잡한 쿼리 예시를 보여드렸는데 이건 200줄이 넘어가네요? 당연한 소리겠지만 이전처럼 string으로 관리하는 것보다는 컴파일 단계에서 문제를 잡을 수 있도록 하는 게 당연히 더 좋다고 생각합니다.
- 6시까지 작업하고 이제 자려는데 오늘 14시 대면회의 정상적으로 참가할 수 있겠죠?