### PR TITLE
[Notification] 알림 총 갯수 조회 API 및 오류 수정

### DIFF
--- a/src/main/java/umc/lightup/config/SecurityConfig.java
+++ b/src/main/java/umc/lightup/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/members/me",
                                 "/api/v1/members/me/**",
                                 "/api/v1/members/password/change",
-                                "/api/v1/notification/{notificationId}")
+                                "/api/v1/notification/{notificationId}",
                                 "/api/v1/members/*/like")
                         .authenticated()
                         .anyRequest().permitAll()

--- a/src/main/java/umc/lightup/notification/controller/NotificationRestController.java
+++ b/src/main/java/umc/lightup/notification/controller/NotificationRestController.java
@@ -43,6 +43,21 @@ public class NotificationRestController {
     return ApiResponse.onSuccess(NotificationConverter.notificationListDTO(notificationList));
   }
 
+  @GetMapping("/size")
+  @Operation(
+          summary = "수신 알림 총 갯수 API",
+          description = "수신 받은 알림 총 갯수 조회를 위한 API 입니다.",
+          security = { @SecurityRequirement(name = "JWT TOKEN")}
+  )
+  @ApiResponses({
+          @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+  })
+  public ApiResponse<NotificationResponseDTO.NotificationTotal> getNotificationTotal(Authentication authentication){
+    Member member = memberCommandService.getMember(authentication.getName());
+    Long totalSize = notificationQueryService.getTotal(member).getTotal();
+    return ApiResponse.onSuccess(NotificationConverter.notificationTotal(totalSize));
+  }
+
   @DeleteMapping("/{notificationId}")
   @Operation(
           summary = "알림 지우기 API",

--- a/src/main/java/umc/lightup/notification/converter/NotificationConverter.java
+++ b/src/main/java/umc/lightup/notification/converter/NotificationConverter.java
@@ -34,6 +34,12 @@ public class NotificationConverter {
             .build();
   }
 
+  public static NotificationResponseDTO.NotificationTotal notificationTotal(Long totalSize){
+    return NotificationResponseDTO.NotificationTotal.builder()
+            .total(totalSize)
+            .build();
+  }
+
   public static NotificationResponseDTO.NotificationDeleteDTO notificationDeleteDTO(Notification notification){
     return NotificationResponseDTO.NotificationDeleteDTO.builder()
             .notificationId(notification.getId())

--- a/src/main/java/umc/lightup/notification/converter/NotificationConverter.java
+++ b/src/main/java/umc/lightup/notification/converter/NotificationConverter.java
@@ -18,6 +18,7 @@ public class NotificationConverter {
             .message(notification.getMessage())
             .notificationType(String.valueOf(notification.getType()))
             .isRead(notification.getIsRead())
+            .referenceId(notification.getReferenceId())
             .build();
   }
 

--- a/src/main/java/umc/lightup/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/umc/lightup/notification/dto/NotificationResponseDTO.java
@@ -36,6 +36,14 @@ public class NotificationResponseDTO {
   @Getter
   @NoArgsConstructor
   @AllArgsConstructor
+  public static class NotificationTotal{
+    Long total;
+  }
+
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class NotificationDeleteDTO{
     Long notificationId;
     String message;

--- a/src/main/java/umc/lightup/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/umc/lightup/notification/dto/NotificationResponseDTO.java
@@ -30,6 +30,7 @@ public class NotificationResponseDTO {
     String message;       // 알림 메시지 내용
     String notificationType;  // 알림 종류
     Boolean isRead;           // 알림 읽음 여부
+    Long referenceId;         // 래퍼런스 아이디
   }
 
   @Builder

--- a/src/main/java/umc/lightup/notification/repository/NotificationRepostiory.java
+++ b/src/main/java/umc/lightup/notification/repository/NotificationRepostiory.java
@@ -5,7 +5,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.lightup.member.domain.Member;
 import umc.lightup.notification.domain.Notification;
+import umc.lightup.notification.dto.NotificationResponseDTO;
 
 public interface NotificationRepostiory extends JpaRepository<Notification, Long> {
   Page<Notification> findAllByReceiver(Member member, PageRequest pageRequest);
+  Long countByReceiver(Member member);
 }

--- a/src/main/java/umc/lightup/notification/service/NotificationQueryService.java
+++ b/src/main/java/umc/lightup/notification/service/NotificationQueryService.java
@@ -10,6 +10,7 @@ import umc.lightup.notification.dto.NotificationResponseDTO;
 public interface NotificationQueryService {
   SseEmitter subscribe(Member member, String lastEventId);
   NotificationResponseDTO.SSETestDTO testSend(long id, String message);
+  NotificationResponseDTO.NotificationTotal getTotal(Member member);
   Page<Notification> getNotificationList(Member member, Integer page, Integer size);
 
   void sendToClient(SseEmitter emitter, String id, Object data);

--- a/src/main/java/umc/lightup/notification/service/NotificationQueryServiceImpl.java
+++ b/src/main/java/umc/lightup/notification/service/NotificationQueryServiceImpl.java
@@ -82,6 +82,12 @@ public class NotificationQueryServiceImpl implements NotificationQueryService {
     return NotificationConverter.sseTestDTO(message);
   }
 
+  @Override
+  public NotificationResponseDTO.NotificationTotal getTotal(Member member) {
+    Long totalSize = notificationRepostiory.countByReceiver(member);
+    return NotificationConverter.notificationTotal(totalSize);
+  }
+
   // 알림목록 조회 api 전용
   @Override
   public Page<Notification> getNotificationList(Member member, Integer page, Integer size) {


### PR DESCRIPTION
## 💫 PR 제목
- [도메인명] 간단한 요약 (예: [Post] 게시글 작성 기능 구현)

---

## 🔧 작업 내용 요약
- 수신 받은 알림의 총 갯수를 받을 수 있는 api를 제작했습니다.
- 알림 목록 조회시, referencId도 반환 되도록 api를 수정했습니다! 


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요.
- 예: 로직이 복잡한 부분 / 설계 고민한 부분 / 리팩토링한 코드 등

---

## 🔗 관련 이슈
- 관련된 이슈 번호나 기능 이름을 작성해주세요.
- ex) closes #66 

---

## 📝 기타 참고 사항
- 참고 자료, 테스트 방법 등 필요 시 자유롭게 작성
