### PR TITLE
[Item][ 프로젝트 전체 조회시 인기순, 최신순 필터링 기능

### DIFF
--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -41,8 +41,12 @@ public class ItemRestController {
 
     @GetMapping("/search")
     @Operation(summary = "전체 프로젝트 조회 API", description = "전체 프로젝트를 조회하는 API이며 페이징을 포함합니다. 요청 파라미터로 page 번호를 입력할 수 있습니다.")
-    public ApiResponse<ItemResponseDTO.ItemResultListDTO> viewAllItems(Authentication authentication, @RequestParam(defaultValue = "0") @Min(1) Integer page) {
-        Pageable pageable = PageRequest.of(page - 1, DEFAULT_ITEM_PAGE_SIZE, Sort.by("createdAt").descending());
+    public ApiResponse<ItemResponseDTO.ItemResultListDTO> viewAllItems(
+            Authentication authentication,
+            @RequestParam(defaultValue = "0") @Min(1) Integer page,
+            @RequestParam(defaultValue = "latest") String sort) {
+        Sort sortOption = getSortOption(sort);
+        Pageable pageable = PageRequest.of(page - 1, DEFAULT_ITEM_PAGE_SIZE, sortOption);
 
         Set<Long> likedItemIds = Collections.emptySet();
 
@@ -137,4 +141,14 @@ public class ItemRestController {
         itemCommandService.removeItemComment(member, commentId);
         return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
     }
+
+
+    //프로젝트 정렬 조건 처리 메서드
+    private Sort getSortOption(String sort) {
+        if (sort.equalsIgnoreCase("popular")) {
+            return Sort.by("viewCount").descending();
+        }
+        return Sort.by("createdAt").descending();
+    }
+
 }

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -16,7 +16,7 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemResponseDTO.ItemResultDTO toItemResultDTO(Item item, String itemImageUrl, int viewCount, int commentCount, boolean itemLike) {
+    public static ItemResponseDTO.ItemResultDTO toItemResultDTO(Item item, String itemImageUrl, int commentCount, boolean itemLike) {
         return ItemResponseDTO.ItemResultDTO.builder()
                 .itemId(item.getId())
                 .itemName(item.getName())
@@ -24,7 +24,7 @@ public class ItemConverter {
                 .itemImageUrl(itemImageUrl)
                 .updatedAt(item.getUpdatedAt().toLocalDate())
                 .recruitStatus(item.isProjectStatus())
-                .viewCount(viewCount)
+                .viewCount(item.getViewCount())
                 .commentCount(commentCount)
                 .likedByCurrentUser(itemLike)
                 .build();

--- a/src/main/java/umc/lightup/item/domain/Item.java
+++ b/src/main/java/umc/lightup/item/domain/Item.java
@@ -66,6 +66,9 @@ public class Item extends BaseEntity {
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
     private List<ItemComment> itemComments = new ArrayList<>();
 
+    @Column(nullable = false)
+    private Long viewCount = 0L;
+
     //프로젝트에 프로젝트 프로필 이미지, 기획서를 제외하고 사진을 추가로 업로드 할 수 있게 하려면 itemImages도 필요함
     public Item uploadItemProfile(String itemProfileImageUrl) {
         this.itemProfileImageUrl = itemProfileImageUrl;

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -33,7 +33,7 @@ public class ItemResponseDTO {
         private String itemImageUrl;
         private LocalDate updatedAt;
         private boolean recruitStatus;
-        private int viewCount;
+        private Long viewCount;
         private int commentCount;
         private boolean likedByCurrentUser;
     }

--- a/src/main/java/umc/lightup/item/repository/ItemRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepository.java
@@ -4,6 +4,7 @@ package umc.lightup.item.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -18,6 +19,9 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     List<Item> findByMember(Member member);
     @Query("select distinct i from Item i left join fetch i.itemComments ic left join fetch ic.commentMember where i.id = :itemId")
     Optional<Item> findByIdWithCommentsAndCommentMembers(@Param("itemId") Long itemId);
+    @Modifying
+    @Query("update Item i set i.viewCount = i.viewCount + 1 where i.id = :itemId")
+    int increaseViewCount(@Param("itemId") Long itemId);
 
     Page<Item> findAll(Pageable pageable);
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -123,9 +123,8 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                     String itemImageUrl = item.getItemProfileImageUrl();
                     boolean liked = likedItemIds != null && likedItemIds.contains(item.getId());
                     int commentCount = itemCommentRepository.countByItemId(item.getId());
-                    int viewCount = itemViewHistoryRepository.countByItemId(item.getId());
 
-                    return ItemConverter.toItemResultDTO(item, itemImageUrl, viewCount, commentCount, liked);
+                    return ItemConverter.toItemResultDTO(item, itemImageUrl, commentCount, liked);
                 }).toList();
     }
 
@@ -217,6 +216,10 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                     .item(item)
                     .viewedAt(LocalDateTime.now())
                     .build());
+        }
+
+        if (itemRepository.increaseViewCount(item.getId()) == 0) {
+            throw new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND);
         }
     }
 


### PR DESCRIPTION
## 💫 PR 제목
- [Item][ 프로젝트 전체 조회시 인기순, 최신순 필터링 기능

---

## 🔧 작업 내용 요약
- 프로젝트 전체 조회시 최신순 (기본값), 인기순 필터링 기능 구현

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 필터링 기능 구현이 적절한지? 
---

## 🔗 관련 이슈
-  closes #70 

---

## 📝 기타 참고 사항
- 현재는 그냥 기본값으로 최신순 정렬을 제공하고 인기순으로도 필터링 가능하게 구현했는데 
- 프로젝트 탐색 필터 별 디자인을 보니까 필터 설정을 안 했을때는 최신순 4개, 인기순 4개, 추천순 4개 이런식으로 해둔 것 같은데 추후 변경해야할 수도 있을 것 같네요
