### PR TITLE
[Member] OAuth2 callback 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/member/controller/AuthRestController.java
+++ b/src/main/java/umc/lightup/member/controller/AuthRestController.java
@@ -60,6 +60,20 @@ public class AuthRestController {
                 .build());
     }
 
+    @PostMapping("/callback/{oauth}")
+    @Operation(summary = "유저 소셜로그인을 통한 로그인/회원가입 API",
+            description = "유저가 소셜로그인으로 로그인/회원가입하는 API입니다. 계정 정보가 있으면 로그인, 없으면 회원가입으로 처리됩니다.")
+    public ApiResponse<MemberResponseDTO.LoginResultDTO> callbackByOAuth(
+            @PathVariable("oauth") CredentialType oauth,
+            @RequestParam("authCode") @NotBlank String authCode) {
+        MemberResponseDTO.LoginResultDTO loginResult = switch (oauth) {
+            case GOOGLE -> credentialQueryService.callbackMemberByGoogle(authCode);
+            case KAKAO -> credentialQueryService.callbackMemberByKakao(authCode);
+            case PASSWORD -> throw new GeneralHandler(ErrorStatus._BAD_REQUEST);
+        };
+        return ApiResponse.onSuccess(loginResult);
+    }
+
     @PostMapping("/login/{oauth}")
     @Operation(summary = "유저 소셜로그인 API",description = "유저가 소셜로그인하는 API입니다.")
     public ApiResponse<MemberResponseDTO.LoginResultDTO> loginByOAuth

--- a/src/main/java/umc/lightup/member/service/CredentialQueryService.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryService.java
@@ -10,7 +10,9 @@ public interface CredentialQueryService {
     Member joinMember(MemberRequestDTO.JoinDto request);
     MemberResponseDTO.LoginResultDTO loginMember(MemberRequestDTO.PasswordLoginRequestDTO request);
     MemberResponseDTO.LoginResultDTO loginMemberByGoogle(String authCode);
+    MemberResponseDTO.LoginResultDTO callbackMemberByGoogle(String authCode);
     MemberResponseDTO.LoginResultDTO loginMemberByKakao(String authCode);
+    MemberResponseDTO.LoginResultDTO callbackMemberByKakao(String authCode);
     Member joinMemberByGoogle(String authCode);
     Member joinMemberByKakao(String authCode);
     Member addGoogleLogin(Member member, String authCode);

--- a/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
@@ -98,6 +98,20 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
     }
 
     @Override
+    public MemberResponseDTO.LoginResultDTO callbackMemberByGoogle(String authCode) {
+        OAuth2ResponseDTO.GoogleUserinfoResponseDTO userinfo = getGoogleUserinfo(authCode);
+
+
+        Optional<Credential> optionalCredential = credentialRepository
+                .findByCredentialTypeAndCredential(CredentialType.GOOGLE, userinfo.getSub());
+
+        if (optionalCredential.isPresent())
+            return getLoginResultDTO(optionalCredential.get().getMember());
+        else return getLoginResultDTO(joinMemberByGoogle(userinfo));
+
+    }
+
+    @Override
     public MemberResponseDTO.LoginResultDTO loginMemberByKakao(String authCode) {
         OAuth2ResponseDTO.KakaoUserinfoResponseDTO userinfo = getKakaoUserinfo(authCode);
 
@@ -109,10 +123,23 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
     }
 
     @Override
+    public MemberResponseDTO.LoginResultDTO callbackMemberByKakao(String authCode) {
+        OAuth2ResponseDTO.KakaoUserinfoResponseDTO userinfo = getKakaoUserinfo(authCode);
+
+        Optional<Credential> optionalCredential = credentialRepository
+                .findByCredentialTypeAndCredential(CredentialType.KAKAO, userinfo.getSub());
+        if (optionalCredential.isPresent())
+            return getLoginResultDTO(optionalCredential.get().getMember());
+        else return getLoginResultDTO(joinMemberByKakao(authCode));
+    }
+
+    @Override
     @Transactional
     public Member joinMemberByGoogle(String authCode) {
-        OAuth2ResponseDTO.GoogleUserinfoResponseDTO userinfo = getGoogleUserinfo(authCode);
+        return joinMemberByGoogle(getGoogleUserinfo(authCode));
+    }
 
+    private Member joinMemberByGoogle(OAuth2ResponseDTO.GoogleUserinfoResponseDTO userinfo) {
         if (memberCommandService.isEmailExist(userinfo.getEmail()))
             throw new GeneralHandler(ErrorStatus.ALREADY_SIGNED_IN_EMAIL);
 
@@ -134,8 +161,10 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
     @Override
     @Transactional
     public Member joinMemberByKakao(String authCode) {
-        OAuth2ResponseDTO.KakaoUserinfoResponseDTO userinfo = getKakaoUserinfo(authCode);
+        return joinMemberByKakao(getKakaoUserinfo(authCode));
+    }
 
+    private Member joinMemberByKakao(OAuth2ResponseDTO.KakaoUserinfoResponseDTO userinfo) {
         if (userinfo.getEmail() == null || memberCommandService.isEmailExist(userinfo.getEmail()))
             throw new GeneralHandler(ErrorStatus.ALREADY_SIGNED_IN_EMAIL);
 


### PR DESCRIPTION
## 💫 PR 제목
- [Member] OAuth2 callback 기능 구현

---

## 🔧 작업 내용 요약
- OAuth2 로그인 시 회원정보가 없으면 회원가입하는 API 개발

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 로직이 적절한지... 근데 테스트를 프론트와 해 봐야 하는 상황에서 API 문서를 참조하지 않는 한 지금 보는 게 의미 없음.
- 기존 API를 삭제하지 않고 두는 게 적절한지

---

## 🔗 관련 이슈
- 이슈 없이 진행

---

## 📝 기타 참고 사항
- 없음