### PR TITLE
[Member] OAuth2 callback 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/member/dto/OAuth2ResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/OAuth2ResponseDTO.java
@@ -3,6 +3,8 @@ package umc.lightup.member.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 public class OAuth2ResponseDTO {
     @Getter
     @Setter
@@ -46,34 +48,53 @@ public class OAuth2ResponseDTO {
     @Getter
     @Setter
     public static class KakaoUserinfoResponseDTO {
-        private String iss;
-        private String aud;
-        private String sub;
-        private String iat;
-        private String exp;
-        private String auth_time;
-        private String nickname;
-        private String picture;
-        private String email;
-//        long id;
-//        KakaoAccount kakao_account;
-//
-//        @Getter
-//        @Setter
-//        public static class KakaoAccount {
-//            String email;
-//            Profile profile;
-//        }
-//
-//        @Getter
-//        @Setter
-//        public static class Profile {
-//            String nickname;
-//            String profile_image_url;
-//        }
-//
-//        public String getEmail() {
-//            return kakao_account.getEmail();
-//        }
+//        private String iss;
+//        private String aud;
+//        private String sub;
+//        private String iat;
+//        private String exp;
+//        private String auth_time;
+//        private String nickname;
+//        private String picture;
+//        private String email;
+        long id;
+        LocalDateTime connected_at;
+        Properties properties;
+        KakaoAccount kakao_account;
+
+        @Getter
+        @Setter
+        public static class Properties {
+            private String nickname;
+            private String profile_image;
+            private String thumbnail_image;
+        }
+
+        @Getter
+        @Setter
+        public static class KakaoAccount {
+            Boolean profile_nickname_needs_agreement;
+            Boolean profile_image_needs_agreement;
+            Profile profile;
+            Boolean has_email;
+            Boolean email_needs_agreement;
+            Boolean is_email_valid;
+            Boolean is_email_verified;
+            String email;
+        }
+
+        @Getter
+        @Setter
+        public static class Profile {
+            String nickname;
+            String thumbnail_image_url;
+            String profile_image_url;
+            Boolean is_default_image;
+            Boolean is_default_nickname;
+        }
+
+        public String getEmail() {
+            return kakao_account.getEmail();
+        }
     }
 }

--- a/src/main/java/umc/lightup/member/openfeign/GoogleApiClient.java
+++ b/src/main/java/umc/lightup/member/openfeign/GoogleApiClient.java
@@ -9,7 +9,7 @@ import umc.lightup.member.dto.OAuth2ResponseDTO;
 
 @FeignClient(name = "googleApiClient", url = "https://www.googleapis.com")
 public interface GoogleApiClient {
-    @GetMapping(value = "/userinfo/v2/me",
+    @GetMapping(value = "/oauth2/v3/userinfo",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<OAuth2ResponseDTO.GoogleUserinfoResponseDTO> getUserinfo

--- a/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
@@ -116,7 +116,7 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
         OAuth2ResponseDTO.KakaoUserinfoResponseDTO userinfo = getKakaoUserinfo(authCode);
 
         Credential credential = credentialRepository
-                .findByCredentialTypeAndCredential(CredentialType.KAKAO, userinfo.getSub())
+                .findByCredentialTypeAndCredential(CredentialType.KAKAO, Long.toString(userinfo.getId()))
                 .orElseThrow(()-> new GeneralHandler(ErrorStatus.CREDENTIAL_NOT_FOUND));
 
         return getLoginResultDTO(credential.getMember());
@@ -128,10 +128,10 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
         OAuth2ResponseDTO.KakaoUserinfoResponseDTO userinfo = getKakaoUserinfo(authCode);
 
         Optional<Credential> optionalCredential = credentialRepository
-                .findByCredentialTypeAndCredential(CredentialType.KAKAO, userinfo.getSub());
+                .findByCredentialTypeAndCredential(CredentialType.KAKAO, Long.toString(userinfo.getId()));
         if (optionalCredential.isPresent())
             return getLoginResultDTO(optionalCredential.get().getMember());
-        else return getLoginResultDTO(joinMemberByKakao(authCode));
+        else return getLoginResultDTO(joinMemberByKakao(userinfo));
     }
 
     @Override
@@ -169,19 +169,19 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
         if (userinfo.getEmail() == null || memberCommandService.isEmailExist(userinfo.getEmail()))
             throw new GeneralHandler(ErrorStatus.ALREADY_SIGNED_IN_EMAIL);
 
-        if (memberCommandService.isNicknameExist(userinfo.getNickname()))
-            userinfo.setNickname(null);
+        String nickname = userinfo.getKakao_account().getProfile().getNickname();
+        if (memberCommandService.isNicknameExist(nickname)) nickname = null;
 
         Member member = Member.builder()
                 .email(userinfo.getEmail())
-                .nickname(userinfo.getNickname())
-                .profileImageUrl(userinfo.getPicture())
+                .nickname(nickname)
+                .profileImageUrl(userinfo.getKakao_account().getProfile().getProfile_image_url())
                 .role(Role.PROVISION)
                 .build();
         Credential credential = Credential.builder()
                 .credentialType(CredentialType.KAKAO)
                 .member(member)
-                .credential(userinfo.getSub())
+                .credential(Long.toString(userinfo.getId()))
                 .build();
         Member saved = memberRepository.save(member);
         credentialRepository.save(credential);
@@ -212,13 +212,13 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
         if (credentialRepository.existsByCredentialTypeAndMember(CredentialType.KAKAO, member))
             throw new GeneralHandler(ErrorStatus.CREDENTIAL_ALREADY_EXIST);
         OAuth2ResponseDTO.KakaoUserinfoResponseDTO userinfo = getKakaoUserinfo(authCode);
-        if (credentialRepository.existsByCredentialTypeAndCredential(CredentialType.KAKAO, userinfo.getSub()))
+        if (credentialRepository.existsByCredentialTypeAndCredential(CredentialType.KAKAO, Long.toString(userinfo.getId())))
             throw new GeneralHandler(ErrorStatus.CREDENTIAL_ALREADY_USED);
 
         Credential credential = Credential.builder()
                 .credentialType(CredentialType.KAKAO)
                 .member(member)
-                .credential(userinfo.getSub())
+                .credential(Long.toString(userinfo.getId()))
                 .build();
         credentialRepository.save(credential);
         return member;


### PR DESCRIPTION
## 💫 PR 제목
- [Member] OAuth2 callback 기능 구현

---

## 🔧 작업 내용 요약
- OAuth2 로그인 시 회원정보가 없으면 회원가입하는 API 개발
- Transaction이 readonly이어서 발생하는 문제 수정

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 로직이 적절한지... 근데 테스트를 프론트와 해 봐야 하는 상황에서 API 문서를 참조하지 않는 한 지금 보는 게 의미 없음.
- 기존 API를 삭제하지 않고 두는 게 적절한지
- 같은 branch를 계속 사용하는 것도 괜찮은지

---

## 🔗 관련 이슈
- 이슈 없이 진행

---

## 📝 기타 참고 사항
- 없음