### PR TITLE
[Item] 회원의 회원 제안 기능

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -72,6 +72,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //ItemApply 관련 에러
     DUPLICATE_ITEM_APPLY(HttpStatus.BAD_REQUEST, "ITEMAPPLY4000", "이미 지원한 프로젝트입니다."),
+    SELF_ITEM_APPLY(HttpStatus.BAD_REQUEST, "ITEMAPPLY4001", "자신의 프로젝트에 대한 요청입니다."),
+    ITEM_APPLY_NOT_FOUND(HttpStatus.BAD_REQUEST, "ITEMAPPLY4002", "프로젝트 지원이나 제안 기록을 찾을 수 없습니다."),
+    NOT_OFFERED(HttpStatus.BAD_REQUEST, "ITEMAPPLY4003", "참여를 제안한 프로젝트가 아닙니다."),
+    ALREADY_CHOSE_OFFER_ACCEPTANCE(HttpStatus.BAD_REQUEST, "ITEMAPPLY4004", "프로젝트 참여 여부를 이미 결정했습니다."),
 
     //ItemComment 관련 에러
     ITEM_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEMCOMMENT4000", "해당 댓글이 존재하지 않습니다."),

--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -74,8 +74,10 @@ public enum ErrorStatus implements BaseErrorCode {
     DUPLICATE_ITEM_APPLY(HttpStatus.BAD_REQUEST, "ITEMAPPLY4000", "이미 지원한 프로젝트입니다."),
     SELF_ITEM_APPLY(HttpStatus.BAD_REQUEST, "ITEMAPPLY4001", "자신의 프로젝트에 대한 요청입니다."),
     ITEM_APPLY_NOT_FOUND(HttpStatus.BAD_REQUEST, "ITEMAPPLY4002", "프로젝트 지원이나 제안 기록을 찾을 수 없습니다."),
-    NOT_OFFERED(HttpStatus.BAD_REQUEST, "ITEMAPPLY4003", "참여를 제안한 프로젝트가 아닙니다."),
+    NOT_OFFERED(HttpStatus.BAD_REQUEST, "ITEMAPPLY4003", "참여를 제안받은 프로젝트가 아닙니다."),
     ALREADY_CHOSE_OFFER_ACCEPTANCE(HttpStatus.BAD_REQUEST, "ITEMAPPLY4004", "프로젝트 참여 여부를 이미 결정했습니다."),
+    NOT_APPLIED(HttpStatus.BAD_REQUEST, "ITEMAPPLY4005", "다른 사용자의 지원이 아닙니다."),
+    NOT_MY_ITEM(HttpStatus.BAD_REQUEST, "ITEMAPPLY4006", "자신의 프로젝트가 아닙니다."),
 
     //ItemComment 관련 에러
     ITEM_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "ITEMCOMMENT4000", "해당 댓글이 존재하지 않습니다."),

--- a/src/main/java/umc/lightup/config/SecurityConfig.java
+++ b/src/main/java/umc/lightup/config/SecurityConfig.java
@@ -40,7 +40,9 @@ public class SecurityConfig {
                                 "/api/v1/members/login/path",
                                 "/api/v1/members/login/path/**",
                                 "/api/v1/notification/{notificationId}",
-                                "/api/v1/members/*/like")
+                                "/api/v1/members/*/like",
+                                "/api/v1/items/*/offer"
+                        )
                         .authenticated()
                         .anyRequest().permitAll()
                 )
@@ -64,7 +66,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of("http://localhost:5173", "https://starlight-up-hyewonimdang-hyewons-projects-4a1d0b91.vercel.app"));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedMethods(List.of("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 

--- a/src/main/java/umc/lightup/config/SecurityConfig.java
+++ b/src/main/java/umc/lightup/config/SecurityConfig.java
@@ -41,7 +41,9 @@ public class SecurityConfig {
                                 "/api/v1/members/login/path/**",
                                 "/api/v1/notification/{notificationId}",
                                 "/api/v1/members/*/like",
-                                "/api/v1/items/*/offer"
+                                "/api/v1/items/offer",
+                                "/api/v1/items/apply",
+                                "/api/v1/items/*/apply"
                         )
                         .authenticated()
                         .anyRequest().permitAll()

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -123,6 +123,29 @@ public class ItemRestController {
         return ApiResponse.onSuccess(ItemConverter.toItemApplyResultDTO(itemApply));
     }
 
+    @PostMapping("/{itemId}/offer")
+    @Operation(summary = "프로젝트 제안 API", description = "프로젝트 주인이 다른 사용자에게 프로젝트 참여 제안 요청을 보내는 API 입니다.")
+    public ApiResponse<ItemResponseDTO.ItemOfferResultDTO> offerItem(
+            Authentication authentication,
+            @PathVariable("itemId") long itemId,
+            @RequestBody @Valid ItemRequestDTO.OfferPositionRequestDTO offerPositionRequestDTO) {
+        Member member = memberCommandService.getMember(authentication.getName());
+        ItemApply itemApply = itemCommandService.offerItem(member, offerPositionRequestDTO.getMemberId(), itemId);
+        return ApiResponse.onSuccess(ItemConverter.toItemOfferResultDTO(itemApply));
+    }
+
+    @PatchMapping("/{itemId}/offer") //Patch가 적절한가?
+    @Operation(summary = "프로젝트 제안 수락/거절 API", description = "프로젝트 제안을 받은 사용자에게 제안을 수락 또는 거절할 수 있는 API 입니다.")
+    public ApiResponse<Void> acceptItemOffer(
+            Authentication authentication,
+            @PathVariable("itemId") long itemId,
+            @RequestBody @Valid ItemRequestDTO.AcceptItemOfferRequestDTO acceptItemOfferRequestDTO) {
+        Member member = memberCommandService.getMember(authentication.getName());
+        itemCommandService.acceptItemOffer(member, itemId, acceptItemOfferRequestDTO.getAccept());
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+    }
+
+
     @PostMapping("/{itemId}/comments")
     @Operation(summary = "프로젝트 댓글 작성 API", description = "특정 프로젝트 상세 조회 페이지에서 댓글을 작성할 수 있는 API입니다.")
     public ApiResponse<ItemResponseDTO.ItemCommentResultDTO> writeItemComment(Authentication authentication, @PathVariable("itemId") Long itemId, @RequestBody ItemRequestDTO.ItemCommentRequestDTO request) {

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -3,6 +3,7 @@ package umc.lightup.item.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -115,33 +116,81 @@ public class ItemRestController {
     }
 
     @PostMapping("/{itemId}/apply")
-    @Operation(summary = "프로젝트 지원 API", description = "유저가 프로젝트에 지원 요청을 보내는 API 입니다.")
-    public ApiResponse<ItemResponseDTO.ItemApplyResultDTO> applyItem(Authentication authentication, @PathVariable("itemId") long itemId) {
+    @Operation(
+            summary = "프로젝트 지원 API",
+            description = "유저가 프로젝트에 지원 요청을 보내는 API 입니다.",
+            security = {@SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<ItemResponseDTO.ItemApplyResultDTO> applyItem(Authentication authentication,
+                                                                     @PathVariable("itemId") long itemId) {
         Member member = memberCommandService.getMember(authentication.getName());
-        Item item = itemCommandService.getSingleItem(itemId);
-        ItemApply itemApply = itemCommandService.applyItem(member, item);
+        ItemApply itemApply = itemCommandService.applyItem(member, itemId);
         return ApiResponse.onSuccess(ItemConverter.toItemApplyResultDTO(itemApply));
     }
 
-    @PostMapping("/{itemId}/offer")
-    @Operation(summary = "프로젝트 제안 API", description = "프로젝트 주인이 다른 사용자에게 프로젝트 참여 제안 요청을 보내는 API 입니다.")
+    @PatchMapping("/apply")
+    @Operation(
+            summary = "프로젝트 지원 수락/거절 API",
+            description = "프로젝트 주인이 지원 요청에 대해 수락/거절을 설정하는 API 입니다.",
+            security = {@SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<ItemResponseDTO.ItemApplyResultDTO> acceptItemApply(
+            Authentication authentication,
+            @RequestBody @Valid ItemRequestDTO.AcceptItemApplyRequestDTO acceptItemApplyRequestDTO) {
+        Member member = memberCommandService.getMember(authentication.getName());
+        itemCommandService.acceptItemApply(member, acceptItemApplyRequestDTO);
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+    }
+
+    @GetMapping("/apply")
+    @Operation(
+            summary = "프로젝트 지원/제안 상태 조회 API",
+            description = "프로젝트 지원 또는 제안 상태를 조회하는 API 입니다." +
+                    " 내가 지원한 프로젝트, 내 프로젝트에 지원한 기록, 내가 제안받은 기록, 내가 제안한 기록 전부 조회됩니다." +
+                    " 프로젝트 주인 여부(itemOwn), 제안(fromOwner=true)/지원(fromOwner=false)로 구분해주시기 바랍니다." +
+                    " 내 프로젝트에 지원한 기록(itemOwn=true, fromOwner=false)과" +
+                    " 내가 제안받은 기록(itemOwn=false, fromOwner=true)은" +
+                    " 수락, 거절 여부 선택이 가능합니다." +
+                    " 선택은 PatchMapping으로 설정된 2개의 API를 이용하여 주시기 바랍니다.",
+            security = {@SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<ItemResponseDTO.ItemApplyStatusListDTO> acceptItemApply(
+            Authentication authentication) {
+        String email = authentication.getName();
+        return ApiResponse.onSuccess(
+                ItemConverter.toItemApplyStatusListDTO(
+                        itemCommandService.getItemApplyStatus(email)
+                )
+        );
+    }
+
+    @PostMapping("/offer")
+    @Operation(
+            summary = "프로젝트 제안 API",
+            description = "프로젝트 주인이 다른 사용자에게 프로젝트 참여 제안 요청을 보내는 API 입니다.",
+            security = {@SecurityRequirement(name = "JWT TOKEN")}
+    )
     public ApiResponse<ItemResponseDTO.ItemOfferResultDTO> offerItem(
             Authentication authentication,
-            @PathVariable("itemId") long itemId,
             @RequestBody @Valid ItemRequestDTO.OfferPositionRequestDTO offerPositionRequestDTO) {
         Member member = memberCommandService.getMember(authentication.getName());
-        ItemApply itemApply = itemCommandService.offerItem(member, offerPositionRequestDTO.getMemberId(), itemId);
+        ItemApply itemApply = itemCommandService.offerItem(member,
+                offerPositionRequestDTO.getMemberId(),
+                offerPositionRequestDTO.getItemId());
         return ApiResponse.onSuccess(ItemConverter.toItemOfferResultDTO(itemApply));
     }
 
-    @PatchMapping("/{itemId}/offer") //Patch가 적절한가?
-    @Operation(summary = "프로젝트 제안 수락/거절 API", description = "프로젝트 제안을 받은 사용자에게 제안을 수락 또는 거절할 수 있는 API 입니다.")
+    @PatchMapping("/offer") //Patch가 적절한가?
+    @Operation(
+            summary = "프로젝트 제안 수락/거절 API",
+            description = "프로젝트 제안을 받은 사용자에게 제안을 수락 또는 거절할 수 있는 API 입니다.",
+            security = {@SecurityRequirement(name = "JWT TOKEN")}
+    )
     public ApiResponse<Void> acceptItemOffer(
             Authentication authentication,
-            @PathVariable("itemId") long itemId,
             @RequestBody @Valid ItemRequestDTO.AcceptItemOfferRequestDTO acceptItemOfferRequestDTO) {
         Member member = memberCommandService.getMember(authentication.getName());
-        itemCommandService.acceptItemOffer(member, itemId, acceptItemOfferRequestDTO.getAccept());
+        itemCommandService.acceptItemOffer(member, acceptItemOfferRequestDTO);
         return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
     }
 

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -112,6 +112,12 @@ public class ItemConverter {
                 .build();
     }
 
+    public static ItemResponseDTO.ItemOfferResultDTO toItemOfferResultDTO (ItemApply itemApply) {
+        return ItemResponseDTO.ItemOfferResultDTO.builder()
+                .appliedAt(itemApply.getAppliedAt())
+                .build();
+    }
+
     public static ItemResponseDTO.ItemCommentResultDTO toItemCommentResultDTO (ItemComment itemComment) {
         return ItemResponseDTO.ItemCommentResultDTO.builder()
                 .itemCommentId(itemComment.getId())

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -112,6 +112,31 @@ public class ItemConverter {
                 .build();
     }
 
+    public static ItemResponseDTO.ItemApplyStatusListDTO toItemApplyStatusListDTO
+            (List<ItemResponseDTO.ItemApplyStatusDTO> itemApplyStatusDTO) {
+        return ItemResponseDTO.ItemApplyStatusListDTO.builder()
+                .itemApplyStatuses(itemApplyStatusDTO)
+                .build();
+    }
+
+    public static ItemResponseDTO.ItemApplyStatusDTO toItemApplyStatusDTO (ItemApply itemApply, Member member) {
+        Member itemOwner = itemApply.getItem().getMember();
+        Member targetMember = itemApply.getMember();
+        return ItemResponseDTO.ItemApplyStatusDTO.builder()
+                .itemOwned(member.equals(itemOwner))
+                .itemId(itemApply.getItem().getId())
+                .itemName(itemApply.getItem().getName())
+                .itemImageUrl(itemApply.getItem().getItemProfileImageUrl())
+                .itemOwnerUsername(itemOwner == null ? null : itemOwner.getUsername())
+                .memberId(targetMember == null ? null : targetMember.getId())
+                .memberUsername(targetMember == null ? null : targetMember.getNameNotNull())
+                .memberProfileImageUrl(targetMember == null ? null : targetMember.getProfileImageUrl())
+                .applyId(itemApply.getId())
+                .fromOwner(itemApply.isFromOwner())
+                .applyStatus(itemApply.getStatus())
+                .build();
+    }
+
     public static ItemResponseDTO.ItemOfferResultDTO toItemOfferResultDTO (ItemApply itemApply) {
         return ItemResponseDTO.ItemOfferResultDTO.builder()
                 .appliedAt(itemApply.getAppliedAt())

--- a/src/main/java/umc/lightup/item/domain/ItemApply.java
+++ b/src/main/java/umc/lightup/item/domain/ItemApply.java
@@ -2,6 +2,7 @@ package umc.lightup.item.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import umc.lightup.item.enums.ItemApplyStatus;
 import umc.lightup.member.domain.Member;
@@ -27,7 +28,21 @@ public class ItemApply {
     @JoinColumn(name = "item_id", nullable = false)
     private Item item;
 
+    /**
+     * item owner의 member에 대한 제안인지, member가 item owner에게 지원한 건지 구분.
+     * <p>
+     * {@code true} item owner가 member에게 제안한 것
+     * <p>
+     * {@code false} member가 item에 지원한 것, 기본값
+     */
+    @Builder.Default
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private boolean fromOwner = false;
+
+    @Setter
     @Enumerated(EnumType.STRING)
+    @ColumnDefault("'PENDING'")
     private ItemApplyStatus status; // 지원 상태: 대기, 수락, 거절
 
     @CreatedDate

--- a/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
@@ -71,6 +71,21 @@ public class ItemRequestDTO {
 
     @Getter
     @Setter
+    public static class OfferPositionRequestDTO {
+        @NotNull
+        // 왜 내가 ExistMember를 안 만들었지??? 물론 만들면 성능은 떨어짐
+        private Long memberId;
+    }
+
+    @Getter
+    @Setter
+    public static class AcceptItemOfferRequestDTO {
+        @NotNull
+        private Boolean accept;
+    }
+
+    @Getter
+    @Setter
     public static class ItemCommentRequestDTO {
         @NotBlank
         private String content;

--- a/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
@@ -71,7 +71,23 @@ public class ItemRequestDTO {
 
     @Getter
     @Setter
+    public static class AcceptItemApplyRequestDTO {
+        @NotNull
+        private Long itemApplyId; //재지원 기능을 만들지는 모르겠으나 만드려면 이걸로 받아야 함
+//        @NotNull
+//        private Long itemId;
+//        @NotNull
+//        // 왜 내가 ExistMember를 안 만들었지??? 물론 만들면 성능은 떨어짐
+//        private Long memberId;
+        @NotNull
+        private Boolean accept;
+    }
+
+    @Getter
+    @Setter
     public static class OfferPositionRequestDTO {
+        @NotNull
+        private Long itemId;
         @NotNull
         // 왜 내가 ExistMember를 안 만들었지??? 물론 만들면 성능은 떨어짐
         private Long memberId;
@@ -80,6 +96,8 @@ public class ItemRequestDTO {
     @Getter
     @Setter
     public static class AcceptItemOfferRequestDTO {
+        @NotNull
+        private Long itemApplyId; //재지원 기능을 만들지는 모르겠으나 만드려면 이걸로 받아야 함
         @NotNull
         private Boolean accept;
     }

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import umc.lightup.member.enums.Gender;
+import umc.lightup.item.enums.ItemApplyStatus;
 import umc.lightup.member.enums.Mbti;
 
 import java.time.LocalDate;
@@ -128,6 +128,32 @@ public class ItemResponseDTO {
     public static class ItemApplyResultDTO {
         private LocalDateTime appliedAt;
         private String message;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemApplyStatusListDTO {
+        private List<ItemApplyStatusDTO> itemApplyStatuses;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemApplyStatusDTO {
+        private boolean itemOwned;
+        private long itemId;
+        private String itemName;
+        private String itemImageUrl;
+        private String itemOwnerUsername;
+        private Long memberId;
+        private String memberUsername;
+        private String memberProfileImageUrl;
+        private long applyId;
+        private boolean fromOwner;
+        private ItemApplyStatus applyStatus;
     }
 
     @Getter

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -134,6 +134,14 @@ public class ItemResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class ItemOfferResultDTO {
+        private LocalDateTime appliedAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ItemCommentResultDTO {
         private Long itemCommentId;
         private String authorName;

--- a/src/main/java/umc/lightup/item/repository/ItemApplyRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemApplyRepository.java
@@ -5,6 +5,9 @@ import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemApply;
 import umc.lightup.member.domain.Member;
 
+import java.util.Optional;
+
 public interface ItemApplyRepository extends JpaRepository<ItemApply, Long> {
     boolean existsByMemberAndItem(Member member, Item item);
+    Optional<ItemApply> findByMemberAndItem(Member member, Item item);
 }

--- a/src/main/java/umc/lightup/item/repository/ItemApplyRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemApplyRepository.java
@@ -1,13 +1,25 @@
 package umc.lightup.item.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemApply;
 import umc.lightup.member.domain.Member;
 
+import java.util.List;
 import java.util.Optional;
 
+@Repository //잠깐만 이걸 지금 추가했다는 건 이전에는 이게 없었어도 돌아갔다는 건가? 왜 돌아갔지?????
 public interface ItemApplyRepository extends JpaRepository<ItemApply, Long> {
     boolean existsByMemberAndItem(Member member, Item item);
     Optional<ItemApply> findByMemberAndItem(Member member, Item item);
+
+    @EntityGraph(attributePaths = {"member", "item", "item.member"})
+    Optional<ItemApply> findById(long id); //아니 long을 소문자로 쓰면 Override가 아니네
+    @Query("select ia " + //Username만 아니었어도 여기서 사영(select)을 진행했을 듯, 지금은 하기 귀찮음
+            "from ItemApply ia join fetch ia.member m join fetch ia.item i join fetch i.member im " +
+            "where m.email = :memberEmail or im.email = :memberEmail")
+    List<ItemApply> findAllByMemberEmail(String memberEmail);
 }

--- a/src/main/java/umc/lightup/item/repository/ItemRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepository.java
@@ -19,9 +19,13 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     List<Item> findByMember(Member member);
     @Query("select distinct i from Item i left join fetch i.itemComments ic left join fetch ic.commentMember where i.id = :itemId")
     Optional<Item> findByIdWithCommentsAndCommentMembers(@Param("itemId") Long itemId);
+    //fetch join 하는 것과 안 하는 것이 둘 다 필요해 별도 쿼리로 작성
+    @Query("select i from Item i join fetch i.member m where i.id = :itemId")
+    Optional<Item> findByIdWithOwner(@Param("itemId") long itemId);
     @Modifying
     @Query("update Item i set i.viewCount = i.viewCount + 1 where i.id = :itemId")
     int increaseViewCount(@Param("itemId") Long itemId);
 
     Page<Item> findAll(Pageable pageable);
+    boolean existsByIdAndMember(long id, Member member);
 }

--- a/src/main/java/umc/lightup/item/repository/ItemViewHistoryRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemViewHistoryRepository.java
@@ -1,12 +1,14 @@
 package umc.lightup.item.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemViewHistory;
 import umc.lightup.member.domain.Member;
 
 import java.util.Optional;
 
+@Repository
 public interface ItemViewHistoryRepository extends JpaRepository<ItemViewHistory, Long> {
     Optional<ItemViewHistory> findByMemberAndItem(Member memberId, Item itemId);
     int countByItemId(Long itemId);

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -20,13 +20,17 @@ public interface ItemCommandService {
     Item createItem(Member member, ItemRequestDTO.ItemJoinRequestDTO request, MultipartFile itemProfileImage, MultipartFile itemPlanFile);
     Item getSingleItem(Long itemId);
     Item getSingleItemWithComments(Long itemId);
-    ItemApply applyItem(Member member, Item item);
+    ItemApply applyItem(Member member, long itemId);
     boolean getItemLike(long memberId, long itemId);
     void addItemLike(Member member, long itemId);
     void removeItemLike(String email, long itemId);
     void updateItemHistory(Member member, Item item);
+    void acceptItemApply(Member itemOwner,
+                         ItemRequestDTO.AcceptItemApplyRequestDTO acceptItemApplyRequestDTO);
+    List<ItemResponseDTO.ItemApplyStatusDTO> getItemApplyStatus(String email);
     ItemApply offerItem(Member offeringMember, long offeredMemberId, long itemId);
-    void acceptItemOffer(Member offeredMember, long itemId, boolean accept);
+    void acceptItemOffer(Member offeredMember,
+                         ItemRequestDTO.AcceptItemOfferRequestDTO acceptItemOfferRequestDTO);
     ItemComment createItemComment(Member member, Long itemId, ItemRequestDTO.ItemCommentRequestDTO request);
     void removeItemComment(Member member, Long commentId);
     Set<Long> findItemLikes(long memberId);

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -25,6 +25,8 @@ public interface ItemCommandService {
     void addItemLike(Member member, long itemId);
     void removeItemLike(String email, long itemId);
     void updateItemHistory(Member member, Item item);
+    ItemApply offerItem(Member offeringMember, long offeredMemberId, long itemId);
+    void acceptItemOffer(Member offeredMember, long itemId, boolean accept);
     ItemComment createItemComment(Member member, Long itemId, ItemRequestDTO.ItemCommentRequestDTO request);
     void removeItemComment(Member member, Long commentId);
     Set<Long> findItemLikes(long memberId);

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -20,6 +20,12 @@ import umc.lightup.item.enums.ItemApplyStatus;
 import umc.lightup.item.repository.*;
 import umc.lightup.member.domain.Member;
 import umc.lightup.member.repository.MemberRegionRepository;
+import umc.lightup.member.repository.MemberRepository;
+import umc.lightup.notification.dto.NotificationEventRequestDTO;
+import umc.lightup.notification.enums.NotificationType;
+import umc.lightup.notification.enums.ReferenceType;
+import umc.lightup.notification.service.NotificationCommandService;
+import umc.lightup.notification.utli.NotificationEventSender;
 import umc.lightup.position.domain.Position;
 import umc.lightup.position.repository.PositionRepository;
 
@@ -40,7 +46,10 @@ public class ItemCommandServiceImpl implements ItemCommandService {
     private final ItemViewHistoryRepository itemViewHistoryRepository;
     private final ItemApplyRepository itemApplyRepository;
     private final ItemCommentRepository itemCommentRepository;
+    private final MemberRepository memberRepository;
 
+    private final NotificationEventSender notificationEventSender;
+    private final NotificationCommandService notificationCommandService;
     private final AmazonS3Manager s3Manager;
     private final UuidRepository uuidRepository;
     private final ItemCategoryRepository itemCategoryRepository;
@@ -241,6 +250,86 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                 .status(ItemApplyStatus.PENDING)
                 .appliedAt(LocalDateTime.now())
                 .build());
+    }
+
+    @Override
+    @Transactional
+    public ItemApply offerItem(Member offeringMember, long offeredMemberId, long itemId) {
+        if (offeringMember.getId().equals(offeredMemberId))
+            throw new GeneralHandler(ErrorStatus.SELF_ITEM_APPLY);
+        if (!itemRepository.existsByIdAndMember(itemId, offeringMember))
+            throw new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND);
+        Member offeredMember = memberRepository.findById(offeredMemberId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Item item = itemRepository.findById(itemId) //Comment와 fetch join할 이유 없음
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND));
+        if (itemApplyRepository.existsByMemberAndItem(offeredMember, item))
+            throw new GeneralHandler(ErrorStatus.DUPLICATE_ITEM_APPLY);
+
+        //알림 전송
+        StringBuilder message = new StringBuilder();
+        if (offeringMember.getNickname() != null) message.append(offeringMember.getNickname());
+        else if (offeringMember.getName() != null) message.append(offeringMember.getName());
+        else message.append(offeringMember.getEmail());
+        message.append("님에게서 ");
+        message.append(item.getName());
+        message.append("의 제안이 도착했어요!");
+        NotificationEventRequestDTO.NotificationEventDTO eventDTO =
+                NotificationEventRequestDTO.NotificationEventDTO.builder()
+                        .senderId(offeringMember.getId())
+                        .receiverId(offeredMember.getId())
+                        .notificationType(NotificationType.INVITE)
+                        .message(message.toString())
+                        .referenceType(ReferenceType.ITEM)
+                        .referenceId(item.getId())
+                        .build();
+        notificationCommandService.saveNotification(eventDTO);
+        notificationEventSender.send(eventDTO);
+
+        return itemApplyRepository.save(ItemApply.builder()
+                .member(offeredMember)
+                .item(item)
+                .fromOwner(true)
+                .status(ItemApplyStatus.PENDING)
+                .appliedAt(LocalDateTime.now())
+                .build());
+    }
+
+    @Override
+    @Transactional
+    public void acceptItemOffer(Member offeredMember, long itemId, boolean accept) {
+        Item item = itemRepository.findByIdWithOwner(itemId) //Owner Id가 notification에 사용됨
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND));
+        ItemApply itemApply = itemApplyRepository.findByMemberAndItem(offeredMember, item)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_APPLY_NOT_FOUND));
+        if (!itemApply.isFromOwner())
+            throw new GeneralHandler(ErrorStatus.NOT_OFFERED);
+        if (itemApply.getStatus() != ItemApplyStatus.PENDING)
+            throw new GeneralHandler(ErrorStatus.ALREADY_CHOSE_OFFER_ACCEPTANCE);
+
+        if (accept) itemApply.setStatus(ItemApplyStatus.ACCEPTED);
+        else itemApply.setStatus(ItemApplyStatus.REJECTED);
+
+        //알림 전송
+        StringBuilder message = new StringBuilder();
+        if (offeredMember.getNickname() != null) message.append(offeredMember.getNickname());
+        else if (offeredMember.getName() != null) message.append(offeredMember.getName());
+        else message.append(offeredMember.getEmail());
+        message.append("님이 ");
+        message.append(item.getName());
+        message.append("의 요청 수락 여부를 결정했어요!"); // 이렇게 보내는 게 좋은가? 다른 좋은 Message 없나?
+        // 그렇다고 알림에서부터 수락/거절 사실을 통보하면 마음아플 것 같음... 취업준비할 때 거절은 이를 돌려 말하는 것처럼...
+        NotificationEventRequestDTO.NotificationEventDTO eventDTO =
+                NotificationEventRequestDTO.NotificationEventDTO.builder()
+                        .senderId(offeredMember.getId())
+                        .receiverId(item.getMember().getId())
+                        .notificationType(NotificationType.INVITE)
+                        .message(message.toString())
+                        .referenceType(ReferenceType.ITEM)
+                        .referenceId(item.getId())
+                        .build();
+        notificationCommandService.saveNotification(eventDTO);
+        notificationEventSender.send(eventDTO);
     }
 
     @Override

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -239,10 +239,28 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
     @Override
     @Transactional
-    public ItemApply applyItem(Member member, Item item) {
+    public ItemApply applyItem(Member member, long itemId) {
+        Item item = itemRepository.findByIdWithOwner(itemId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND));
         if (itemApplyRepository.existsByMemberAndItem(member, item)) {
             throw new GeneralHandler(ErrorStatus.DUPLICATE_ITEM_APPLY);
         }
+
+        //알림 전송
+        NotificationEventRequestDTO.NotificationEventDTO eventDTO =
+                NotificationEventRequestDTO.NotificationEventDTO.builder()
+                        .senderId(member.getId())
+                        .receiverId(item.getMember().getId())
+                        .notificationType(NotificationType.INVITE)
+                        .message(member.getNameNotNull() +
+                                "님에게서 " +
+                                item.getName() +
+                                "에 지원했어요!")
+                        .referenceType(ReferenceType.ITEM)
+                        .referenceId(item.getId())
+                        .build();
+        notificationCommandService.saveNotification(eventDTO);
+        notificationEventSender.send(eventDTO);
 
         return itemApplyRepository.save(ItemApply.builder()
                 .member(member)
@@ -250,6 +268,62 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                 .status(ItemApplyStatus.PENDING)
                 .appliedAt(LocalDateTime.now())
                 .build());
+    }
+
+    @Override
+    @Transactional
+    public void acceptItemApply(Member itemOwner,
+                                ItemRequestDTO.AcceptItemApplyRequestDTO acceptItemApplyRequestDTO) {
+        ItemApply itemApply = itemApplyRepository.findById(acceptItemApplyRequestDTO.getItemApplyId().longValue())
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_APPLY_NOT_FOUND));
+        if (!itemOwner.equals(itemApply.getItem().getMember())) //owner가 맞는지 확인
+            throw new GeneralHandler(ErrorStatus.NOT_MY_ITEM);
+        if (itemApply.isFromOwner()) //제안이 아닌 지원인지 확인
+            throw new GeneralHandler(ErrorStatus.NOT_APPLIED);
+        if (itemApply.getStatus() != ItemApplyStatus.PENDING) //이미 수락 여부를 결정했는지 확인
+            throw new GeneralHandler(ErrorStatus.ALREADY_CHOSE_OFFER_ACCEPTANCE);
+
+        if (acceptItemApplyRequestDTO.getAccept()) itemApply.setStatus(ItemApplyStatus.ACCEPTED);
+        else itemApply.setStatus(ItemApplyStatus.REJECTED);
+
+        //알림 전송
+        NotificationEventRequestDTO.NotificationEventDTO eventDTO =
+                NotificationEventRequestDTO.NotificationEventDTO.builder()
+                        .senderId(itemOwner.getId())
+                        .receiverId(itemApply.getMember().getId())
+                        .notificationType(NotificationType.INVITE)
+                        .message(itemOwner.getNameNotNull() +
+                                        "님이 " +
+                                        itemApply.getItem().getName() +
+                                        "의 지원에 대해 응답했어요! 응답을 확인해보세요!"
+                                // 이렇게 보내는 게 좋은가? 다른 좋은 Message 없나?
+                                // 그렇다고 알림에서부터 수락/거절 사실을 통보하면 마음아플 것 같음...
+                                // 취업준비할 때 거절은 이를 돌려 말하는 것처럼...
+                        )
+                        .referenceType(ReferenceType.ITEM)
+                        .referenceId(itemApply.getItem().getId())
+                        .build();
+        notificationCommandService.saveNotification(eventDTO);
+        notificationEventSender.send(eventDTO);
+    }
+
+    @Override
+    public List<ItemResponseDTO.ItemApplyStatusDTO> getItemApplyStatus(String email) {
+        return itemApplyRepository.findAllByMemberEmail(email)
+                .stream().map(i -> ItemResponseDTO.ItemApplyStatusDTO.builder()
+                        .itemOwned(i.getItem().getMember() != null && i.getItem().getMember().getEmail().equals(email))
+                        .itemId(i.getItem().getId())
+                        .itemName(i.getItem().getName())
+                        .itemImageUrl(i.getItem().getItemProfileImageUrl())
+                        .itemOwnerUsername(i.getItem().getMember() == null ? null : i.getItem().getMember().getNameNotNull())
+                        .memberId(i.getMember() == null ? null : i.getMember().getId())
+                        .memberUsername(i.getMember() == null ? null : i.getMember().getNameNotNull())
+                        .memberProfileImageUrl(i.getMember() == null ? null : i.getMember().getProfileImageUrl())
+                        .applyId(i.getId())
+                        .fromOwner(i.isFromOwner())
+                        .applyStatus(i.getStatus())
+                        .build())
+                .toList();
     }
 
     @Override
@@ -293,35 +367,33 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
     @Override
     @Transactional
-    public void acceptItemOffer(Member offeredMember, long itemId, boolean accept) {
-        Item item = itemRepository.findByIdWithOwner(itemId) //Owner Id가 notification에 사용됨
-                .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND));
-        ItemApply itemApply = itemApplyRepository.findByMemberAndItem(offeredMember, item)
+    public void acceptItemOffer(Member offeredMember, ItemRequestDTO.AcceptItemOfferRequestDTO acceptItemOfferRequestDTO) {
+        ItemApply itemApply = itemApplyRepository.findById(acceptItemOfferRequestDTO.getItemApplyId().longValue())
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.ITEM_APPLY_NOT_FOUND));
-        if (!itemApply.isFromOwner())
+        if (!itemApply.isFromOwner() || !offeredMember.equals(itemApply.getMember()))
             throw new GeneralHandler(ErrorStatus.NOT_OFFERED);
         if (itemApply.getStatus() != ItemApplyStatus.PENDING)
             throw new GeneralHandler(ErrorStatus.ALREADY_CHOSE_OFFER_ACCEPTANCE);
 
-        if (accept) itemApply.setStatus(ItemApplyStatus.ACCEPTED);
+        if (acceptItemOfferRequestDTO.getAccept()) itemApply.setStatus(ItemApplyStatus.ACCEPTED);
         else itemApply.setStatus(ItemApplyStatus.REJECTED);
 
         //알림 전송
         NotificationEventRequestDTO.NotificationEventDTO eventDTO =
                 NotificationEventRequestDTO.NotificationEventDTO.builder()
                         .senderId(offeredMember.getId())
-                        .receiverId(item.getMember().getId())
+                        .receiverId(itemApply.getItem().getMember().getId())
                         .notificationType(NotificationType.INVITE)
                         .message(offeredMember.getNameNotNull() +
                                 "님이 " +
-                                item.getName() +
-                                "의 요청에 대해 응답했어요! 응답을 확인해보세요!"
+                                itemApply.getItem().getName() +
+                                "의 제안에 대해 응답했어요! 응답을 확인해보세요!"
                                 // 이렇게 보내는 게 좋은가? 다른 좋은 Message 없나?
                                 // 그렇다고 알림에서부터 수락/거절 사실을 통보하면 마음아플 것 같음...
                                 // 취업준비할 때 거절은 이를 돌려 말하는 것처럼...
                         )
                         .referenceType(ReferenceType.ITEM)
-                        .referenceId(item.getId())
+                        .referenceId(itemApply.getItem().getId())
                         .build();
         notificationCommandService.saveNotification(eventDTO);
         notificationEventSender.send(eventDTO);

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -267,19 +267,15 @@ public class ItemCommandServiceImpl implements ItemCommandService {
             throw new GeneralHandler(ErrorStatus.DUPLICATE_ITEM_APPLY);
 
         //알림 전송
-        StringBuilder message = new StringBuilder();
-        if (offeringMember.getNickname() != null) message.append(offeringMember.getNickname());
-        else if (offeringMember.getName() != null) message.append(offeringMember.getName());
-        else message.append(offeringMember.getEmail());
-        message.append("님에게서 ");
-        message.append(item.getName());
-        message.append("의 제안이 도착했어요!");
         NotificationEventRequestDTO.NotificationEventDTO eventDTO =
                 NotificationEventRequestDTO.NotificationEventDTO.builder()
                         .senderId(offeringMember.getId())
                         .receiverId(offeredMember.getId())
                         .notificationType(NotificationType.INVITE)
-                        .message(message.toString())
+                        .message(offeringMember.getNameNotNull() +
+                                "님에게서 " +
+                                item.getName() +
+                                "의 제안이 도착했어요!")
                         .referenceType(ReferenceType.ITEM)
                         .referenceId(item.getId())
                         .build();
@@ -311,20 +307,19 @@ public class ItemCommandServiceImpl implements ItemCommandService {
         else itemApply.setStatus(ItemApplyStatus.REJECTED);
 
         //알림 전송
-        StringBuilder message = new StringBuilder();
-        if (offeredMember.getNickname() != null) message.append(offeredMember.getNickname());
-        else if (offeredMember.getName() != null) message.append(offeredMember.getName());
-        else message.append(offeredMember.getEmail());
-        message.append("님이 ");
-        message.append(item.getName());
-        message.append("의 요청 수락 여부를 결정했어요!"); // 이렇게 보내는 게 좋은가? 다른 좋은 Message 없나?
-        // 그렇다고 알림에서부터 수락/거절 사실을 통보하면 마음아플 것 같음... 취업준비할 때 거절은 이를 돌려 말하는 것처럼...
         NotificationEventRequestDTO.NotificationEventDTO eventDTO =
                 NotificationEventRequestDTO.NotificationEventDTO.builder()
                         .senderId(offeredMember.getId())
                         .receiverId(item.getMember().getId())
                         .notificationType(NotificationType.INVITE)
-                        .message(message.toString())
+                        .message(offeredMember.getNameNotNull() +
+                                "님이 " +
+                                item.getName() +
+                                "의 요청에 대해 응답했어요! 응답을 확인해보세요!"
+                                // 이렇게 보내는 게 좋은가? 다른 좋은 Message 없나?
+                                // 그렇다고 알림에서부터 수락/거절 사실을 통보하면 마음아플 것 같음...
+                                // 취업준비할 때 거절은 이를 돌려 말하는 것처럼...
+                        )
                         .referenceType(ReferenceType.ITEM)
                         .referenceId(item.getId())
                         .build();

--- a/src/main/java/umc/lightup/member/domain/Member.java
+++ b/src/main/java/umc/lightup/member/domain/Member.java
@@ -113,6 +113,12 @@ public class Member extends BaseEntity implements UserDetails {
         return getEmail();
     }
 
+    public String getNameNotNull() {
+        if (getNickname() != null) return getNickname();
+        else if (getName() != null) return getName();
+        else return getEmail();
+    }
+
 //    @Column(length = 32)
 //    private String briefExplanation; // 추가
 //

--- a/src/main/java/umc/lightup/member/domain/Member.java
+++ b/src/main/java/umc/lightup/member/domain/Member.java
@@ -21,9 +21,11 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = false) //Member에 대한 Equals 적용을 위해 필요함
 public class Member extends BaseEntity implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include //Id만 비교하면 끝이라서 Include와 onlyExplicitlyIncluded = true 설정 진행
     private Long id;
 
     @Column(length = 20) //소셜로그인 회원가입 시 안 들어올 수 있음

--- a/src/main/java/umc/lightup/notification/utli/NotificationEventSender.java
+++ b/src/main/java/umc/lightup/notification/utli/NotificationEventSender.java
@@ -18,6 +18,10 @@ public class NotificationEventSender {
     NotificationEventRequestDTO.NotificationEventDTO event = new NotificationEventRequestDTO.NotificationEventDTO(
             senderId, receiverId, type, message, referenceType, referenceId
     );
+    send(event);
+  }
+
+  public void send(NotificationEventRequestDTO.NotificationEventDTO event) {
     if (TransactionSynchronizationManager.isActualTransactionActive()) {
       // 트랜잭션 존재 시, AFTER_COMMIT 이후 발행
       TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {


### PR DESCRIPTION
## 💫 PR 제목
- [Item] 회원의 회원 제안 기능

---

## 🔧 작업 내용 요약
- Item을 만든 사용자가 다른 사용자에게 프로젝트 참여 제안을 보내는 기능
- 제안을 받은 사용자가 프로젝트 제안 수락/거절을 선택하는 기능
- 제안 발송 및 수락/거절 시 상대에게 알림 발송

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- ERD를 수정한 게 적절한 선택이었는지
- ItemController, Service를 활용한 게 적절한지
- 알림 메시지가 적절한지(특히 수락/거절 시)
- 사용자의 username을 가져오는 로직을 Member 클래스에 두지 않고 별도로 구현한 게 적절한지
- PatchMapping을 사용한 게 적절한지
- CORS 설정이 문제 없는지(Patch 추가)
- SecurityConfig 수정이 다른 PR과 충돌이 발생할 것을 알면서 저렇게 두는 게 옳은지(충돌을 피하도록 수정사항을 적용할 수 있었음)
- **알림 발송 로직이 적절한지** (Postman 테스트 결과 알림이 정상적으로 오긴 옴)
- 알림 발송 로직을 수정했는데 적절한지
- 이외 Item 관련 Entity를 사용하는 것 등 기타 로직이 적절한지
- **알림 발송 로직을 알림 담당자도 아닌데, 담당자에게 허가를 받지 않고 함부로 수정한 게 올바른 행위인지**(이건 코드가 아닌 협업의 관점)
### 추가
- 지원/제안을 수락/거절할 때 itemApplyId를 받아 처리하는 게 적절한지
- 추후 중복지원을 고려한 설계를 하는 게 적절한지
- 추후 회원탈퇴시 member가 null이 될 것을 대비한 설계를 진행한 것이 적절한지(정작 저래놓고 member가 null일 때에 대한 테스트는 진행하지 않은 상태)
- Item 지원/제안 내역에서 상대의 Position을 제공하지 않는 게 적절한지(사용자 입장에서 Item 지원/제안 내역 창에서 각 상대의 Position을 볼 수 없고, 프로필 상세 조회를 진행해야 하는 상태)

---

## 🔗 관련 이슈
- closes #86

---

## 📝 기타 참고 사항
- **ERD가 또 수정되었습니다.**
- 알림 발송 로직 수정은 cherry-pick이 가능하도록 별도의 commit으로 올렸습니다. ```git cherry-pick a1fa3c9```으로 해당 수정사항만 가져올 수 있습니다.