### PR TITLE
[Post & Comment] 라잇톡 포스트, 댓글 수정 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -103,6 +103,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //Post 관련 에러
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4000", "포스트가 존재하지 않습니다."),
+    POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST4001", "포스트 수정 권한이 없습니다."),
 
     //PostImage 관련 에러
     TOO_MANY_POST_IMAGE(HttpStatus.BAD_REQUEST, "POST_IMAGE4000", "이미지는 3개까지만 업로드 가능합니다."),

--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -110,6 +110,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //PostComment 관련 에러
     POST_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_COMMENT4000", "해당 포스트의 댓글이 존재하지 않습니다."),
+    POST_COMMENT_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_COMMENT4001", "해당 댓글의 수정 권한이 없습니다."),
 
     //PostLike 관련 에러
     MY_POST_LIKE(HttpStatus.BAD_REQUEST, "POSTLIKE4000", "자신의 포스트에는 좋아요를 누를 수 없습니다."),

--- a/src/main/java/umc/lightup/lighttalk/controller/CommentRestController.java
+++ b/src/main/java/umc/lightup/lighttalk/controller/CommentRestController.java
@@ -34,6 +34,19 @@ public class CommentRestController {
         return ApiResponse.onSuccess(CommentConverter.toCommentJoinResultDTO(comment));
     }
 
+    @PutMapping("/comments/{commentId}")
+    @Operation(summary = "라잇톡 포스트 댓글 수정 API", description = "라잇톡 특정 포스트의 댓글을 수정하는 API 입니다.")
+    public ApiResponse<CommentResponseDTO.CommentChangeResultDTO> changePostComment(
+            Authentication authentication,
+            @PathVariable("commentId") Long commentId,
+            @RequestBody CommentRequestDTO.CommentChangeDTO request) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+
+        Comment comment = commentCommandService.changeComment(commentId, member, request);
+        return ApiResponse.onSuccess(CommentConverter.toCommentChangeResultDTO(comment));
+    }
+
     @DeleteMapping("/comments/{commentId}")
     @Operation(summary = "라잇톡 포스트의 댓글 삭제 API", description = "라잇톡 포스트의 댓글 삭제 API입니다.")
     public ApiResponse<Void> removePostComment(Authentication authentication, @PathVariable("commentId") Long commentId) {

--- a/src/main/java/umc/lightup/lighttalk/controller/PostRestController.java
+++ b/src/main/java/umc/lightup/lighttalk/controller/PostRestController.java
@@ -76,6 +76,26 @@ public class PostRestController {
         return ApiResponse.onSuccess(PostConverter.toPostJoinResultDTO(post));
     }
 
+    @PutMapping(value = "/{postId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @Operation(summary = "라잇톡 포스트 수정 API" , description = "라잇톡 포스트 수정 API 입니다. 이미지는 최대 3개까지만 업로드 가능합니다.")
+    public ApiResponse<PostResponseDTO.PostChangeResultDTO> changePost(
+            Authentication authentication,
+            @PathVariable("postId") Long postId,
+            @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+            @RequestPart("request") @Valid PostRequestDTO.PostChangeRequestDTO request,
+            @RequestPart(value = "postImages", required = false) List<MultipartFile> postImages) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+
+        //업로드 이미지가 3개 초과인지 검증
+        if (postImages != null && postImages.size() > 3) {
+            throw new GeneralHandler(ErrorStatus.TOO_MANY_POST_IMAGE);
+        }
+
+        Post post = postCommandService.changePost(member, postId, request, postImages);
+        return ApiResponse.onSuccess(PostConverter.toPostChangeResultDTO(post));
+    }
+
     @DeleteMapping("/{postId}")
     @Operation(summary = "라잇톡 포스트 삭제 API", description = "라잇톡 포스트를 삭제하는 API입니다.")
     public ApiResponse<Void> removePost(Authentication authentication, @PathVariable("postId") Long postId) {

--- a/src/main/java/umc/lightup/lighttalk/controller/PostRestController.java
+++ b/src/main/java/umc/lightup/lighttalk/controller/PostRestController.java
@@ -76,6 +76,16 @@ public class PostRestController {
         return ApiResponse.onSuccess(PostConverter.toPostJoinResultDTO(post));
     }
 
+    @DeleteMapping("/{postId}")
+    @Operation(summary = "라잇톡 포스트 삭제 API", description = "라잇톡 포스트를 삭제하는 API입니다.")
+    public ApiResponse<Void> removePost(Authentication authentication, @PathVariable("postId") Long postId) {
+        String email = authentication.getName();
+        Member member = memberCommandService.getMember(email);
+
+        postCommandService.removePost(member, postId);
+        return ApiResponse.of(SuccessStatus._NO_CONTENT, null);
+    }
+
     @GetMapping("/{postId}")
     @Operation(summary = "특정 라잇톡 포스트 상세 조회 API", description = "특정 라잇톡 포스트 상세 조회 API 입니다. ")
     public ApiResponse<PostResponseDTO.PostInfoDTO> getPostInfo (@PathVariable("postId") @Min(1) Long postId) {

--- a/src/main/java/umc/lightup/lighttalk/controller/PostRestController.java
+++ b/src/main/java/umc/lightup/lighttalk/controller/PostRestController.java
@@ -76,7 +76,7 @@ public class PostRestController {
         return ApiResponse.onSuccess(PostConverter.toPostJoinResultDTO(post));
     }
 
-    @PutMapping(value = "/{postId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PatchMapping(value = "/{postId}", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @Operation(summary = "라잇톡 포스트 수정 API" , description = "라잇톡 포스트 수정 API 입니다. 이미지는 최대 3개까지만 업로드 가능합니다.")
     public ApiResponse<PostResponseDTO.PostChangeResultDTO> changePost(
             Authentication authentication,

--- a/src/main/java/umc/lightup/lighttalk/converter/CommentConverter.java
+++ b/src/main/java/umc/lightup/lighttalk/converter/CommentConverter.java
@@ -10,4 +10,10 @@ public class CommentConverter {
                 .commentId(comment.getId())
                 .build();
     }
+
+    public static CommentResponseDTO.CommentChangeResultDTO toCommentChangeResultDTO(Comment comment) {
+        return CommentResponseDTO.CommentChangeResultDTO.builder()
+                .commentId(comment.getId())
+                .build();
+    }
 }

--- a/src/main/java/umc/lightup/lighttalk/converter/PostConverter.java
+++ b/src/main/java/umc/lightup/lighttalk/converter/PostConverter.java
@@ -16,6 +16,12 @@ public class PostConverter {
                 .build();
     }
 
+    public static PostResponseDTO.PostChangeResultDTO toPostChangeResultDTO(Post post) {
+        return PostResponseDTO.PostChangeResultDTO.builder()
+                .postId(post.getId())
+                .build();
+    }
+
     public static PostResponseDTO.PostInfoDTO toPostInfoDTO (Post post, List<PostResponseDTO.MemberPositionDTO> memberPositionDTOList, List<PostResponseDTO.PostImageDTO> postImageDTOList, List<PostResponseDTO.PostCommentResultDTO> postCommentResultDTOList) {
         return PostResponseDTO.PostInfoDTO.builder()
                 .authorName(post.getPostMember().getName())

--- a/src/main/java/umc/lightup/lighttalk/domain/Comment.java
+++ b/src/main/java/umc/lightup/lighttalk/domain/Comment.java
@@ -16,6 +16,7 @@ public class Comment extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Setter
     @Column(nullable = false)
     private String content;
 

--- a/src/main/java/umc/lightup/lighttalk/domain/Post.java
+++ b/src/main/java/umc/lightup/lighttalk/domain/Post.java
@@ -21,6 +21,7 @@ public class Post extends BaseEntity {
     private Long id;
 
     @Lob
+    @Setter
     @Column(nullable = false)
     private String content;
 

--- a/src/main/java/umc/lightup/lighttalk/dto/CommentRequestDTO.java
+++ b/src/main/java/umc/lightup/lighttalk/dto/CommentRequestDTO.java
@@ -12,4 +12,11 @@ public class CommentRequestDTO {
         @NotBlank
         private String content;
     }
+
+    @Getter
+    @Setter
+    public static class CommentChangeDTO {
+        @NotBlank
+        private String content;
+    }
 }

--- a/src/main/java/umc/lightup/lighttalk/dto/CommentResponseDTO.java
+++ b/src/main/java/umc/lightup/lighttalk/dto/CommentResponseDTO.java
@@ -14,4 +14,12 @@ public class CommentResponseDTO {
     public static class CommentJoinResultDTO {
         private Long commentId;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentChangeResultDTO {
+        private Long commentId;
+    }
 }

--- a/src/main/java/umc/lightup/lighttalk/dto/PostRequestDTO.java
+++ b/src/main/java/umc/lightup/lighttalk/dto/PostRequestDTO.java
@@ -12,4 +12,11 @@ public class PostRequestDTO {
         @NotBlank
         private String content;
     }
+
+    @Getter
+    @Setter
+    public static class PostChangeRequestDTO {
+        @NotBlank
+        private String content;
+    }
 }

--- a/src/main/java/umc/lightup/lighttalk/dto/PostResponseDTO.java
+++ b/src/main/java/umc/lightup/lighttalk/dto/PostResponseDTO.java
@@ -22,6 +22,14 @@ public class PostResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class PostChangeResultDTO {
+        private Long postId;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class PostInfoDTO {
         private String authorName;
         private List<MemberPositionDTO> positionName;

--- a/src/main/java/umc/lightup/lighttalk/repository/PostRepository.java
+++ b/src/main/java/umc/lightup/lighttalk/repository/PostRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import umc.lightup.lighttalk.domain.Post;
+import umc.lightup.member.domain.Member;
 
 import java.util.Optional;
 
@@ -29,4 +30,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Modifying
     @Query("update Post p set p.likes = p.likes - 1 where p.id = :postId")
     int decreasePostLike(@Param("postId") Long postId);
+
+    int deleteByPostMemberAndId(Member member, Long postId);
 }

--- a/src/main/java/umc/lightup/lighttalk/service/CommentCommandService.java
+++ b/src/main/java/umc/lightup/lighttalk/service/CommentCommandService.java
@@ -6,6 +6,7 @@ import umc.lightup.member.domain.Member;
 
 public interface CommentCommandService {
     Comment createComment(Long postId, Member member, CommentRequestDTO.CommentJoinDTO request);
+    Comment changeComment(Long commentId, Member member, CommentRequestDTO.CommentChangeDTO request);
     void removePostComment(Member member, Long commentId);
     void addCommentLike(Member member, Long commentId);
     void removeCommentLike(String email, Long commentId);

--- a/src/main/java/umc/lightup/lighttalk/service/CommentCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/lighttalk/service/CommentCommandServiceImpl.java
@@ -39,6 +39,21 @@ public class CommentCommandServiceImpl implements CommentCommandService{
 
     @Override
     @Transactional
+    public Comment changeComment(Long commentId, Member member, CommentRequestDTO.CommentChangeDTO request) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.POST_COMMENT_NOT_FOUND));
+
+        if (!comment.getCommentMember().equals(member)) {
+            throw new GeneralHandler(ErrorStatus.POST_COMMENT_UPDATE_FORBIDDEN);
+        }
+
+        comment.setContent(request.getContent());
+
+        return comment;
+    }
+
+    @Override
+    @Transactional
     public void removePostComment(Member member, Long commentId) {
         if (commentRepository.deleteByCommentMemberAndId(member, commentId) == 0) {
             throw new GeneralHandler(ErrorStatus.POST_COMMENT_NOT_FOUND);

--- a/src/main/java/umc/lightup/lighttalk/service/PostCommandService.java
+++ b/src/main/java/umc/lightup/lighttalk/service/PostCommandService.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 public interface PostCommandService {
     Post createPost(Member member, PostRequestDTO.PostJoinRequestDTO request, List<MultipartFile> postImages);
+    Post changePost(Member member, Long postId, PostRequestDTO.PostChangeRequestDTO request, List<MultipartFile> changePostImages);
     Post getSinglePostWithComments(Long postId);
     List<PostResponseDTO.PostResultDTO> getAllPosts(Pageable pageable, Set<Long> likedPostIds);
     List<PostResponseDTO.MemberPositionDTO> getPostMemberPositions(Post post);

--- a/src/main/java/umc/lightup/lighttalk/service/PostCommandService.java
+++ b/src/main/java/umc/lightup/lighttalk/service/PostCommandService.java
@@ -17,6 +17,7 @@ public interface PostCommandService {
     List<PostResponseDTO.MemberPositionDTO> getPostMemberPositions(Post post);
     List<PostResponseDTO.PostImageDTO> getPostImages(Post post);
     List<PostResponseDTO.PostCommentResultDTO> getPostComments(Post post);
+    void removePost(Member member, Long postId);
     void addPostLike(Member member, Long postId);
     void removePostLike(String email, Long itemId);
     Set<Long> findPostLikes(Long memberId);

--- a/src/main/java/umc/lightup/lighttalk/service/PostCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/lighttalk/service/PostCommandServiceImpl.java
@@ -49,24 +49,35 @@ public class PostCommandServiceImpl implements PostCommandService {
         Post savedPost = postRepository.save(post);
 
         if (postImages != null && !postImages.isEmpty()) {
-            for (MultipartFile image : postImages) {
-
-                String uuid = UUID.randomUUID().toString();
-                Uuid savedUuid = uuidRepository.save(Uuid.builder()
-                        .uuid(uuid).build());
-
-                String postImageURL = s3Manager.uploadFile(s3Manager.generatePostImageKeyName(savedUuid), image);
-
-                PostImage postImage = PostImage.builder()
-                        .post(post)
-                        .imageUrl(postImageURL)
-                        .build();
-
-                postImageRepository.save(postImage);
-            }
+            uploadImagesToS3(postImages, post);
         }
 
         return savedPost;
+    }
+
+    @Override
+    @Transactional
+    public Post changePost(Member member, Long postId, PostRequestDTO.PostChangeRequestDTO request, List<MultipartFile> changePostImages) {
+        Post findPost = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.POST_NOT_FOUND));
+
+        if (!findPost.getPostMember().equals(member)) {
+            throw new GeneralHandler(ErrorStatus.POST_UPDATE_FORBIDDEN);
+        }
+
+        findPost.setContent(request.getContent());
+
+        if (changePostImages != null && !changePostImages.isEmpty()) {
+            List<PostImage> oldImages = postImageRepository.findByPost(findPost);
+            /*for (PostImage oldImage : oldImages) {
+                s3Manager.deleteFile(oldImage.getImageUrl()); // S3에서 삭제
+            }*/
+            postImageRepository.deleteAll(oldImages);
+
+            uploadImagesToS3(changePostImages, findPost);
+        }
+
+        return findPost;
     }
 
     @Override
@@ -166,5 +177,23 @@ public class PostCommandServiceImpl implements PostCommandService {
 
                     return PostConverter.toPostResultDTO(post, memberPositionDTOList, postImageDTOList, commentCount, liked);
                 }).toList();
+    }
+
+
+    private void uploadImagesToS3(List<MultipartFile> changePostImages, Post findPost) {
+        for (MultipartFile image : changePostImages) {
+            String uuid = UUID.randomUUID().toString();
+            Uuid savedUuid = uuidRepository.save(Uuid.builder()
+                    .uuid(uuid).build());
+
+            String postImageURL = s3Manager.uploadFile(s3Manager.generatePostImageKeyName(savedUuid), image);
+
+            PostImage postImage = PostImage.builder()
+                    .post(findPost)
+                    .imageUrl(postImageURL)
+                    .build();
+
+            postImageRepository.save(postImage);
+        }
     }
 }

--- a/src/main/java/umc/lightup/lighttalk/service/PostCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/lighttalk/service/PostCommandServiceImpl.java
@@ -70,6 +70,14 @@ public class PostCommandServiceImpl implements PostCommandService {
     }
 
     @Override
+    @Transactional
+    public void removePost(Member member, Long postId) {
+        if (postRepository.deleteByPostMemberAndId(member, postId) == 0) {
+            throw new GeneralHandler(ErrorStatus.POST_NOT_FOUND);
+        }
+    }
+
+    @Override
     public Post getSinglePostWithComments(Long postId) {
         return postRepository.findPostWithCommentsById(postId)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.POST_NOT_FOUND));


### PR DESCRIPTION
## 💫 PR 제목
- [Post & Comment] 라잇톡 포스트, 댓글 수정 기능 구현
---

## 🔧 작업 내용 요약
- 라잇톡 포스트, 댓글 수정하는 기능 구현
- 라잇톡 포스트의 경우에는 포스트 이미지 url에 아무것도 들어오지 않으면 이미지는 그대로 두고 내용만 변경됩니다.
- 포스트 이미지 url이 들어오는 경우에는 기존 이미지들을 삭제하고 새로운 이미지로 교체되도록 구현했습니다.

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 생성 DTO와 수정DTO 형식이 완전히 동일한데 가독성 때문에 새로운 DTO를 만들었는데 적절한지 또는 DTO 재사용이 나은지

---

## 🔗 관련 이슈
- 

---

## 📝 기타 참고 사항
- 
