### PR TITLE
[Member] 회원(타인) 정보 조회 시 응답에 좋아요 여부 필드 추가

### DIFF
--- a/src/main/java/umc/lightup/member/controller/MemberCommonRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberCommonRestController.java
@@ -55,16 +55,17 @@ public class MemberCommonRestController {
     @GetMapping("/{memberId}")
     @Operation(
             summary = "회원(타인) 정보 조회 API",
-            description = "타인의 회원 정보를 조회하는 API입니다." +
-                    " 프로젝트에 참여했을 때 일부 데이터를 추가로 공개하는 작업은 아직 진행하지 않았습니다.",
+            description = "타인의 회원 정보를 조회하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN")}
     )
     public ApiResponse<MemberResponseDTO.MemberInfoDTO> getMemberInfo(Authentication authentication,
                                                                       @PathVariable("memberId") long id) {
-        String email = null;
-        if (authentication != null)
-            email = authentication.getName();
-        return ApiResponse.onSuccess(memberCommandService.getMember(id, email));
+        Member member = null;
+        if (authentication != null) {
+            String email = authentication.getName();
+            member = memberCommandService.getMember(email);
+        }
+        return ApiResponse.onSuccess(memberCommandService.getMember(id, member));
     }
 
     @GetMapping("/search")

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -99,6 +99,7 @@ public class MemberResponseDTO {
         private String email;
         private String phoneNumber;
         private String profileImageUrl;
+        private boolean liked;
     }
 
     @Getter

--- a/src/main/java/umc/lightup/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/umc/lightup/member/repository/MemberRepositoryCustom.java
@@ -11,4 +11,6 @@ public interface MemberRepositoryCustom {
             (Member requestedMember, MemberRequestDTO.MemberSearchRequestDTO options);
     List<MemberResponseDTO.HistoryInfoDTO> getMemberViewHistoryInfos
             (Member requestedMember, long size);
+    MemberResponseDTO.MemberInfoDTO getSingleMemberInfo
+            (Member requestedMember, long id);
 }

--- a/src/main/java/umc/lightup/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/umc/lightup/member/repository/MemberRepositoryImpl.java
@@ -13,19 +13,24 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.springframework.stereotype.Repository;
 import umc.lightup.api.code.status.ErrorStatus;
 import umc.lightup.config.QueryDSLTemplate;
 import umc.lightup.exception.handler.GeneralHandler;
 import umc.lightup.member.domain.*;
+import umc.lightup.member.dto.ActivityInfoDTO;
 import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.dto.MemberResponseDTO;
+import umc.lightup.member.dto.PortfolioInfoDTO;
 import umc.lightup.member.enums.Mbti;
+import umc.lightup.member.enums.Role;
 import umc.lightup.position.domain.QPosition;
 import umc.lightup.region.domain.QRegion;
 import umc.lightup.skill.domain.QSkill;
 import umc.lightup.strength.domain.QStrength;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,6 +49,8 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
     private final QStrength strength = QStrength.strength;
     private final QMemberStrength memberStrength = QMemberStrength.memberStrength;
     private final QMemberViewHistory memberViewHistory = QMemberViewHistory.memberViewHistory;
+    private final QPortfolio portfolio = QPortfolio.portfolio;
+    private final QActivity activity = QActivity.activity;
 
     private final QueryDSLTemplate queryDSLTemplate;
     private final ObjectMapper objectMapper;
@@ -317,6 +324,198 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom{
             } catch (JsonProcessingException e) {
                 e.printStackTrace();
                 throw new GeneralHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+            }
+        }
+    }
+
+    @Override
+    public MemberResponseDTO.MemberInfoDTO getSingleMemberInfo
+            (Member requestedMember, long id) {
+        // JSON_OBJECTAGG 구현 버전
+
+        BooleanExpression likedCondition;
+        if (requestedMember == null) likedCondition = Expressions.FALSE;
+        else likedCondition = getLikedCondition(requestedMember);
+
+        return Optional.ofNullable(jpaQueryFactory
+                        .select(Projections.constructor(SingleMemberLikeDTO.class,
+                                member.id,
+                                member.profileTitle,
+                                member.name,
+                                member.nickname,
+                                member.age,
+                                member.gender,
+                                member.birth,
+                                member.role,
+                                member.mbti,
+                                member.selfIntroduce,
+                                member.school, //이거 school API 나오면 한 번 수정해야 할텐데
+
+                                // Positions 집계
+                                JPAExpressions
+                                        .select(queryDSLTemplate.jsonArrayAgg(position.name))
+                                        .from(memberPosition)
+                                        .join(memberPosition.position, position)
+                                        .where(memberPosition.member.id.eq(member.id)),
+
+                                // Regions 집계
+                                JPAExpressions
+                                        .select(queryDSLTemplate.jsonArrayAgg(
+                                                queryDSLTemplate.jsonObject(
+                                                        Expressions.constant("siDo"), memberRegion.siDo,
+                                                        Expressions.constant("siGunGu"), memberRegion.siGunGu
+                                                )
+                                        ))
+                                        .from(memberRegion)
+                                        .where(memberRegion.member.id.eq(member.id)),
+
+                                // Skills 집계
+                                JPAExpressions
+                                        .select(queryDSLTemplate.jsonArrayAgg(skill.name))
+                                        .from(memberSkill)
+                                        .join(memberSkill.skill, skill)
+                                        .where(memberSkill.member.id.eq(member.id)),
+
+                                // Strengths 집계
+                                JPAExpressions
+                                        .select(queryDSLTemplate.jsonArrayAgg(strength.name))
+                                        .from(memberStrength)
+                                        .join(memberStrength.strength, strength)
+                                        .where(memberStrength.member.id.eq(member.id)),
+
+                                // Portfolios 집계
+                                JPAExpressions
+                                        .select(queryDSLTemplate.jsonArrayAgg(
+                                                queryDSLTemplate.jsonObject(
+                                                        Expressions.constant("name"), portfolio.name,
+                                                        Expressions.constant("fileUrl"), portfolio.fileUrl
+                                                )
+                                        ))
+                                        .from(portfolio)
+                                        .where(portfolio.member.id.eq(member.id)),
+
+                                // Activities 집계
+                                JPAExpressions
+                                        .select(queryDSLTemplate.jsonArrayAgg(
+                                                queryDSLTemplate.jsonObject(
+                                                        Expressions.constant("name"), activity.name,
+                                                        Expressions.constant("startDate"), activity.startDate,
+                                                        Expressions.constant("endDate"), activity.endDate
+                                                )
+                                        ))
+                                        .from(activity)
+                                        .where(activity.member.id.eq(member.id)),
+
+                                member.email,
+                                member.phoneNumber,
+                                member.profileImageUrl,
+                                likedCondition.as("liked")))
+                        .from(member)
+                        .where(member.id.eq(id))
+                        .fetchOne())
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND))
+                .toMemberInfoDTO(objectMapper); //왜 Nullable 경고가 나오지?
+    }
+
+    @Getter
+    @AllArgsConstructor
+    //private 사용 불가
+    public static class SingleMemberLikeDTO {
+        private long id;
+        private String profileTitle;
+        private String name;
+        private String nickname;
+        private Integer age;
+        private Boolean gender;
+        private LocalDate birth;
+        private Role role;
+        private Byte mbti;
+        private String selfIntroduce;
+        private String school;
+        private String positionsJson;
+        private String regionsJson;
+        private String skillsJson;
+        private String strengthsJson;
+        private String portfoliosJson;
+        private String activitiesJson;
+        private String email;
+        private String phoneNumber;
+        private String profileImageUrl;
+        private boolean liked;
+
+        public MemberResponseDTO.MemberInfoDTO toMemberInfoDTO(ObjectMapper objectMapper) {
+            try {
+                //null이 가능하다 했으니 null check 진행
+                List<String> positions;
+                if (positionsJson == null || positionsJson.isBlank()) positions = List.of();
+                else positions = objectMapper.readValue(positionsJson, new TypeReference<>(){});
+
+                List<MemberResponseDTO.singleRegionResultDTO> regions;
+                if (regionsJson == null || regionsJson.isBlank()) regions = List.of();
+                else regions = objectMapper.readValue(regionsJson, new TypeReference<>(){});
+
+                List<String> skills;
+                if (skillsJson == null || skillsJson.isBlank()) skills = List.of();
+                else skills = objectMapper.readValue(skillsJson, new TypeReference<>(){});
+
+                List<String> strengths;
+                if (strengthsJson == null || strengthsJson.isBlank()) strengths = List.of();
+                else strengths = objectMapper.readValue(strengthsJson, new TypeReference<>(){});
+
+                List<PortfolioInfoDTO> portfolios;
+                if (portfoliosJson == null || portfoliosJson.isBlank()) portfolios = List.of();
+                else portfolios = objectMapper.readValue(portfoliosJson, new TypeReference<>(){});
+
+                List<ActivityInfoDTO> activities;
+                if (activitiesJson == null || activitiesJson.isBlank()) activities = List.of();
+                else activities = objectMapper.readValue(activitiesJson,
+                                new TypeReference<List<ActivityInfoDBIODTO>>(){})
+                        .stream()
+                        .map(ActivityInfoDBIODTO::toActivityInfoDTO)
+                        .toList();
+
+                return MemberResponseDTO.MemberInfoDTO.builder()
+                        .id(id)
+                        .profileTitle(profileTitle)
+                        .name(name)
+                        .nickname(nickname)
+                        .age(age)
+                        .gender(gender)
+                        .birth(birth)
+                        .role(role)
+                        .mbti(Mbti.fromByte(mbti))
+                        .positions(positions) // <> 내부 생략 가능
+                        .regions(regions)
+                        .skills(skills)
+                        .strengths(strengths)
+                        .portfolios(portfolios)
+                        .activities(activities)
+                        .email(email)
+                        .phoneNumber(phoneNumber)
+                        .profileImageUrl(profileImageUrl)
+                        .liked(liked)
+                        .build();
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+                throw new GeneralHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+            }
+        }
+
+        @Setter
+        @Getter
+        @AllArgsConstructor
+        public static class ActivityInfoDBIODTO {
+            private String name;
+            private LocalDate startDate;
+            private LocalDate endDate;
+
+            private ActivityInfoDTO toActivityInfoDTO() {
+                return ActivityInfoDTO.builder()
+                        .name(name)
+                        .startDate(startDate)
+                        .hasEndDate(endDate != null)
+                        .endDate(endDate)
+                        .build();
             }
         }
     }

--- a/src/main/java/umc/lightup/member/repository/MemberViewHistoryRepository.java
+++ b/src/main/java/umc/lightup/member/repository/MemberViewHistoryRepository.java
@@ -18,4 +18,9 @@ public interface MemberViewHistoryRepository extends JpaRepository<MemberViewHis
             "WHERE mvh.fromMember.id = (SELECT m.id FROM Member m WHERE m.email = :fromMemberEmail) " +
             "AND mvh.toMember = :toMember")
     int updateTimestamp(@Param("fromMemberEmail") String fromMemberEmail, @Param("toMember") Member toMember);
+    @Modifying
+    @Query("UPDATE MemberViewHistory mvh SET mvh.updatedAt = CURRENT_TIMESTAMP " +
+            "WHERE mvh.fromMember = :fromMember " +
+            "AND mvh.toMember.id = :toMemberId")
+    int updateTimestamp(@Param("fromMember") Member fromMember, @Param("toMemberId") long toMemberId);
 }

--- a/src/main/java/umc/lightup/member/service/MemberCommandService.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandService.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface MemberCommandService {
     Member getMember(String email);
-    MemberResponseDTO.MemberInfoDTO getMember(long id, String viewerEmail);
+    MemberResponseDTO.MemberInfoDTO getMember(long id, Member requestedMember);
     List<MemberResponseDTO.HistoryInfoDTO> getHistory(Member member, long size);
     Member putMember(String email, MemberRequestDTO.ChangeDto request);
     MemberResponseDTO.MyProfileDTO getMemberProfile(Member member);

--- a/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/MemberCommandServiceImpl.java
@@ -50,11 +50,15 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
     }
 
+    private Member getMember(long toMemberId) {
+        return memberRepository.findById(toMemberId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
     @Override
     @Transactional
     public void selectPosition(Long memberId, String positionName) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Member member = getMember(memberId);
         Position position = positionRepository.findByName(positionName)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.POSITION_NOT_FOUND));
 
@@ -68,8 +72,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     @Override
     @Transactional
     public void deletePosition(Long memberId, String positionName) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Member member = getMember(memberId);
         Position position = positionRepository.findByName(positionName)
                 .orElseThrow(() -> new GeneralHandler(ErrorStatus.POSITION_NOT_FOUND));
 
@@ -81,41 +84,48 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     @Transactional
-    public MemberResponseDTO.MemberInfoDTO getMember(long id, String viewerEmail){
-        // 한 번에 반환하기 위해 DTO 반환을 사용했는데 좋은 설계 방식인지는 한번 고민할 필요가 있음
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
-        List<String> skills = memberSkillRepository.findSkillNameByMember(member);
-        List<String> strengths = memberStrengthRepository.findStrengthNameByMember(member);
-        List<String> positions = memberPositionRepository.findPositionNameByMember(member);
-        List<MemberRegion> regions = memberRegionRepository.findByMember(member);
-        List<Portfolio> portfolios = portfolioRepository.findByMember(member);
-        List<Activity> activities = activityRepository.findByMember(member);
+    public MemberResponseDTO.MemberInfoDTO getMember(long id, Member requestedMember) {
+//        // 한 번에 반환하기 위해 DTO 반환을 사용했는데 좋은 설계 방식인지는 한번 고민할 필요가 있음
+//        Member member = getMember(id);
+//        List<String> skills = memberSkillRepository.findSkillNameByMember(member);
+//        List<String> strengths = memberStrengthRepository.findStrengthNameByMember(member);
+//        List<String> positions = memberPositionRepository.findPositionNameByMember(member);
+//        List<MemberRegion> regions = memberRegionRepository.findByMember(member);
+//        List<Portfolio> portfolios = portfolioRepository.findByMember(member);
+//        List<Activity> activities = activityRepository.findByMember(member);
+
+        MemberResponseDTO.MemberInfoDTO memberInfo =
+                memberRepository.getSingleMemberInfo(requestedMember, id);
 
         //조회기록 설정
-        if (viewerEmail != null && !viewerEmail.equals(member.getEmail())) {
-            int updatedResult = memberViewHistoryRepository.updateTimestamp(viewerEmail, member);
-            if (updatedResult == 0) { // update 내역이 없을 때
-                MemberViewHistory history = MemberViewHistory.builder()
-                        .fromMember(getMember(viewerEmail))
-                        .toMember(member)
-                        .build();
-                memberViewHistoryRepository.save(history);
+        if (requestedMember != null) {
+            long toMemberId = memberInfo.getId();
+            if (!requestedMember.getId().equals(toMemberId)) {
+                int updatedResult = memberViewHistoryRepository.updateTimestamp(requestedMember, toMemberId);
+                if (updatedResult == 0) { // update 내역이 없을 때
+                    MemberViewHistory history = MemberViewHistory.builder()
+                            .fromMember(requestedMember)
+                            .toMember(getMember(toMemberId)) //아 그냥 FK만 가지고 만들면 안되나?
+                            .build();
+                    memberViewHistoryRepository.save(history);
+                }
             }
         }
 
-        return MemberViewInfo.builder()
-                .member(member)
-                .skillNames(skills)
-                .strengthNames(strengths)
-                .regions(regions)
-                .positionNames(positions)
-                .portfolios(portfolios)
-                .activities(activities)
-                .emailOpen(true)
-                .phoneOpen(true)
-                .pictureOpen(true)
-                .build().toMemberInfoDTO();
+        return memberInfo;
+
+//        return MemberViewInfo.builder()
+//                .member(member)
+//                .skillNames(skills)
+//                .strengthNames(strengths)
+//                .regions(regions)
+//                .positionNames(positions)
+//                .portfolios(portfolios)
+//                .activities(activities)
+//                .emailOpen(true)
+//                .phoneOpen(true)
+//                .pictureOpen(true)
+//                .build().toMemberInfoDTO();
     }
 
     @Override
@@ -313,8 +323,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     public void addMemberLike(Member fromMember, long toMemberId) {
         if (fromMember.getId() == toMemberId)
             throw new GeneralHandler(ErrorStatus.SELF_LIKE);
-        Member toMember = memberRepository.findById(toMemberId) //아 괜히 검색쿼리 더 날리고 싶지 않은데
-                .orElseThrow(() -> new GeneralHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Member toMember = getMember(toMemberId); //아 괜히 검색쿼리 더 날리고 싶지 않은데
         if (memberLikeRepository.existsByFromMemberIdAndToMemberId(fromMember.getId(), toMemberId))
             throw new GeneralHandler(ErrorStatus.ALREADY_LIKED);
         memberLikeRepository.save(MemberLike.builder()


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 회원(타인) 정보 조회 시 응답에 좋아요 여부 필드 추가

---

## 🔧 작업 내용 요약
- 회원(타인) 정보 조회 시 응답에 좋아요 여부 필드 추가(프론트엔드 요청사항)
- 회원 단독 조회시 좋아요 여부 같이 가져오기
- 회원(타인) 단독 조회 로직을 QueryDSL, JSON_ARRAYAGG를 이용하도록 변경

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 로직이 적절한지
- QueryDSL 코드에서 objectMapper를 사용할 때 NullPointerException 관련 경고가 나오는 것을 무시하고 올린 게 괜찮은지
- 기존 코드를 완전히 지우지 않고 주석처리한 게 괜찮은지
- 프론트엔드가 요구한 것만 추가하지 않고 이것저것 리팩터링도 같이 수행한 게 괜찮은지(협업의 관점에서)(물론 이건 프론트가 6시에 요구했으나 12시에 작업 시작한 것부터 단단히 틀려먹긴 했음)

---

## 🔗 관련 이슈
- 프론트엔드 요구사항이므로 이슈 없이 진행

---

## 📝 기타 참고 사항
- 프론트엔드 요청사항이므로 문제 없으면 바로 반영해주시고, 반영 후 양혜원님에게 해당사항 전달 부탁드립니다.