### PR TITLE
[AWS S3] S3 파일 삭제 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
+++ b/src/main/java/umc/lightup/api/code/status/ErrorStatus.java
@@ -110,6 +110,7 @@ public enum ErrorStatus implements BaseErrorCode {
     //Post 관련 에러
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST4000", "포스트가 존재하지 않습니다."),
     POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST4001", "포스트 수정 권한이 없습니다."),
+    NOT_MY_POST(HttpStatus.FORBIDDEN, "POST4002", "내 포스트가 아닙니다."),
 
     //PostImage 관련 에러
     TOO_MANY_POST_IMAGE(HttpStatus.BAD_REQUEST, "POST_IMAGE4000", "이미지는 3개까지만 업로드 가능합니다."),

--- a/src/main/java/umc/lightup/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/umc/lightup/aws/s3/AmazonS3Manager.java
@@ -1,6 +1,9 @@
 package umc.lightup.aws.s3;
 
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +38,25 @@ public class AmazonS3Manager {
         }
 
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+    public void deleteFile(String imageUrl) {
+        String keyName = extractKeyNameFromUrl(imageUrl);
+
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(amazonConfig.getBucket(), keyName));
+            log.info("Deleted file from S3: {}", keyName);
+        } catch (AmazonServiceException e) {
+            log.error("AWS error while deleting file: {}", e.getErrorMessage());
+            throw e;
+        } catch (SdkClientException e) {
+            log.error("Client error while deleting file: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    private String extractKeyNameFromUrl(String url) {
+        return url.substring(url.indexOf(".com/") + 5);
     }
 
     public String generateItemProfileImageKeyName(Uuid uuid) {

--- a/src/main/java/umc/lightup/lighttalk/domain/Post.java
+++ b/src/main/java/umc/lightup/lighttalk/domain/Post.java
@@ -38,12 +38,12 @@ public class Post extends BaseEntity {
     private School school;*/
 
     @Builder.Default
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     @BatchSize(size = 100)
     private List<Comment> postComments = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     @BatchSize(size = 50)
     private List<PostImage> postImages = new ArrayList<>();
 }

--- a/src/main/java/umc/lightup/lighttalk/service/PostCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/lighttalk/service/PostCommandServiceImpl.java
@@ -69,9 +69,9 @@ public class PostCommandServiceImpl implements PostCommandService {
 
         if (changePostImages != null && !changePostImages.isEmpty()) {
             List<PostImage> oldImages = postImageRepository.findByPost(findPost);
-            /*for (PostImage oldImage : oldImages) {
-                s3Manager.deleteFile(oldImage.getImageUrl()); // S3에서 삭제
-            }*/
+            for (PostImage oldImage : oldImages) {
+                s3Manager.deleteFile(oldImage.getImageUrl());
+            }
             postImageRepository.deleteAll(oldImages);
 
             uploadImagesToS3(changePostImages, findPost);
@@ -83,9 +83,19 @@ public class PostCommandServiceImpl implements PostCommandService {
     @Override
     @Transactional
     public void removePost(Member member, Long postId) {
-        if (postRepository.deleteByPostMemberAndId(member, postId) == 0) {
-            throw new GeneralHandler(ErrorStatus.POST_NOT_FOUND);
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralHandler(ErrorStatus.POST_NOT_FOUND));
+
+        if (!post.getPostMember().equals(member)) {
+            throw new GeneralHandler(ErrorStatus.NOT_MY_POST);
         }
+
+        List<PostImage> postImages = postImageRepository.findByPost(post);
+        for (PostImage image : postImages) {
+            s3Manager.deleteFile(image.getImageUrl());
+        }
+
+        postRepository.deleteById(postId);
     }
 
     @Override


### PR DESCRIPTION
## 💫 PR 제목
- [AWS S3] S3 파일 삭제 기능 구현

---

## 🔧 작업 내용 요약
- S3 파일 삭제 기능 구현
- AmazonS3Manager 클래스의 deleteFile 메서드 사용하시면 S3 파일 삭제 기능 사용 가능합니다!
- 인자로는 저장된 S3 Url 넣으면 keyName만 추출해서 정상적으로 삭제됩니다!


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 로직이 적절한지

---

## 🔗 관련 이슈
- closes #99 

---

## 📝 기타 참고 사항
- 생각보다 간단했네요... 이렇게 간단한 줄 알았으면 진작 만드는건데 오래 걸렸네요 ㅎ...
