### PR TITLE
[Item] 프로젝트 필터링 기능 구현

### DIFF
--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -24,10 +24,12 @@ import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.item.service.ItemCommandService;
 import umc.lightup.member.domain.Member;
+import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.service.MemberCommandService;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 @RestController
@@ -69,7 +71,8 @@ public class ItemRestController {
             @RequestParam(value = "page", defaultValue = "0") @Min(1) Integer page,
             @RequestParam(value = "sort", defaultValue = "latest") String sort,
             @RequestParam(value = "category", required = false) String category,
-            @RequestParam(value = "positionId", required = false) Long positionId) {
+            @RequestParam(value = "positionId", required = false) Long positionId,
+            @RequestParam(value = "regions", required = false) List<String> regions) {
         Pageable pageable = PageRequest.of(page - 1, DEFAULT_ITEM_PAGE_SIZE);
 
         Set<Long> likedItemIds = Collections.emptySet();
@@ -80,7 +83,21 @@ public class ItemRestController {
             likedItemIds = itemCommandService.findItemLikes(member.getId());
         }
 
-        List<ItemResponseDTO.ItemResultDTO> allItems = itemCommandService.searchItems(pageable, likedItemIds, category, positionId, sort);
+        ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs = ItemRequestDTO.ItemRegionSearchRequestDTO.builder()
+                .itemRegions(regions==null?null:regions.stream()
+                        .map(r -> {
+                            String[] split = r.split("\\s+", 2);
+                            if (split.length == 0) return null;
+                            else return ItemRequestDTO.CollaborationRegionRequestDTO.builder()
+                                    .siDo(split[0])
+                                    .siGunGu(split.length == 1 ? null : split[1])
+                                    .build();
+                        })
+                        .filter(Objects::nonNull)
+                        .toList())
+                .build();
+
+        List<ItemResponseDTO.ItemResultDTO> allItems = itemCommandService.searchItems(pageable, likedItemIds, category, positionId, itemRegionDTOs, sort);
         return ApiResponse.onSuccess(ItemConverter.toItemResultListDTO(allItems));
     }
 

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -24,13 +24,10 @@ import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.item.service.ItemCommandService;
 import umc.lightup.member.domain.Member;
-import umc.lightup.member.dto.MemberRequestDTO;
 import umc.lightup.member.service.MemberCommandService;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 @RestController
 @RequiredArgsConstructor
@@ -72,16 +69,15 @@ public class ItemRestController {
             @RequestParam(value = "sort", defaultValue = "latest") String sort,
             @RequestParam(value = "category", required = false) String category,
             @RequestParam(value = "positionId", required = false) Long positionId,
-            @RequestParam(value = "regions", required = false) List<String> regions) {
-        Pageable pageable = PageRequest.of(page - 1, DEFAULT_ITEM_PAGE_SIZE);
-
-        Set<Long> likedItemIds = Collections.emptySet();
-
+            @RequestParam(value = "regions", required = false) List<String> regions,
+            @RequestParam(value = "onlyLiked", required = false) Boolean onlyLiked) {
+        Member member = null;
         if (authentication != null) {
             String email = authentication.getName();
-            Member member = memberCommandService.getMember(email);
-            likedItemIds = itemCommandService.findItemLikes(member.getId());
+            member = memberCommandService.getMember(email);
         }
+
+        Pageable pageable = PageRequest.of(page - 1, DEFAULT_ITEM_PAGE_SIZE);
 
         ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs = ItemRequestDTO.ItemRegionSearchRequestDTO.builder()
                 .itemRegions(regions==null?null:regions.stream()
@@ -97,44 +93,9 @@ public class ItemRestController {
                         .toList())
                 .build();
 
-        List<ItemResponseDTO.ItemResultDTO> allItems = itemCommandService.searchItems(pageable, likedItemIds, category, positionId, itemRegionDTOs, sort);
+        List<ItemResponseDTO.ItemResultDTO> allItems = itemCommandService.searchItems(member, pageable, category, positionId, itemRegionDTOs, onlyLiked, sort);
         return ApiResponse.onSuccess(ItemConverter.toItemResultListDTO(allItems));
     }
-
-/*    @GetMapping("/search")
-    @Operation(summary = "전체 프로젝트 조회 API", description = "전체 프로젝트를 조회하는 API이며 페이징을 포함합니다. 요청 파라미터로 page 번호를 입력할 수 있습니다.")
-    public ApiResponse<ItemResponseDTO.ItemInfoListDTO> viewAllItems(
-            Authentication authentication,
-            @RequestParam(value = "page", defaultValue = "0") @Min(1) Long page,
-            @RequestParam(value = "sort", defaultValue = "latest") String sort,
-            @RequestParam(value = "category", required = false) String category,
-            @RequestParam(value = "positionId", required = false) Long positionId,
-            @RequestParam(value = "regions", required = false) List<String> regions) {
-        Member member = null;
-        if (authentication != null) {
-            String email = authentication.getName();
-            member = memberCommandService.getMember(email);
-        }
-
-        ItemRequestDTO.ItemSearchRequestDTO request = ItemRequestDTO.ItemSearchRequestDTO.builder()
-                .category(category)
-                .positionId(positionId)
-                .itemRegions(regions == null ? null : regions.stream()
-                        .map(r -> {
-                            String[] split = r.split("\\s+", 2);
-                            if (split.length == 0) return null;
-                            else return ItemRequestDTO.CollaborationRegionRequestDTO.builder()
-                                    .siDo(split[0])
-                                    .siGunGu(split.length == 1 ? null : split[1])
-                                    .build();
-                        })
-                        .filter(Objects::nonNull)
-                        .toList())
-                .page(page)
-                .build();
-
-        return ApiResponse.onSuccess(itemCommandService.searchItems(member, request));
-    }*/
 
     @GetMapping("/me")
     @Operation(summary = "본인 프로젝트 조회 API", description = "사용자의 프로젝트를 조회하는 API 입니다. 등록한 사진이 없다면 itemImageUrl은 null을 반환합니다.")

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -68,7 +68,8 @@ public class ItemRestController {
             Authentication authentication,
             @RequestParam(value = "page", defaultValue = "0") @Min(1) Integer page,
             @RequestParam(value = "sort", defaultValue = "latest") String sort,
-            @RequestParam(value = "category", required = false) String category) {
+            @RequestParam(value = "category", required = false) String category,
+            @RequestParam(value = "positionId", required = false) Long positionId) {
         Pageable pageable = PageRequest.of(page - 1, DEFAULT_ITEM_PAGE_SIZE);
 
         Set<Long> likedItemIds = Collections.emptySet();
@@ -79,7 +80,7 @@ public class ItemRestController {
             likedItemIds = itemCommandService.findItemLikes(member.getId());
         }
 
-        List<ItemResponseDTO.ItemResultDTO> allItems = itemCommandService.searchItems(pageable, likedItemIds, category, sort);
+        List<ItemResponseDTO.ItemResultDTO> allItems = itemCommandService.searchItems(pageable, likedItemIds, category, positionId, sort);
         return ApiResponse.onSuccess(ItemConverter.toItemResultListDTO(allItems));
     }
 

--- a/src/main/java/umc/lightup/item/controller/ItemRestController.java
+++ b/src/main/java/umc/lightup/item/controller/ItemRestController.java
@@ -40,12 +40,13 @@ public class ItemRestController {
 
     private static final int DEFAULT_ITEM_PAGE_SIZE = 12;
 
-    @GetMapping("/search")
+/*    @GetMapping("/search")
     @Operation(summary = "전체 프로젝트 조회 API", description = "전체 프로젝트를 조회하는 API이며 페이징을 포함합니다. 요청 파라미터로 page 번호를 입력할 수 있습니다.")
     public ApiResponse<ItemResponseDTO.ItemResultListDTO> viewAllItems(
             Authentication authentication,
             @RequestParam(value = "page", defaultValue = "0") @Min(1) Integer page,
-            @RequestParam(value = "sort", defaultValue = "latest") String sort) {
+            @RequestParam(value = "sort", defaultValue = "latest") String sort,
+            @RequestParam(value = "category", required = false) String category) {
         Sort sortOption = getSortOption(sort);
         Pageable pageable = PageRequest.of(page - 1, DEFAULT_ITEM_PAGE_SIZE, sortOption);
 
@@ -57,7 +58,28 @@ public class ItemRestController {
             likedItemIds = itemCommandService.findItemLikes(member.getId());
         }
 
-        List<ItemResponseDTO.ItemResultDTO> allItems = itemCommandService.getAllItems(pageable, likedItemIds);
+        List<ItemResponseDTO.ItemResultDTO> allItems = itemCommandService.getAllItems(pageable, likedItemIds, category);
+        return ApiResponse.onSuccess(ItemConverter.toItemResultListDTO(allItems));
+    }*/
+
+    @GetMapping("/search")
+    @Operation(summary = "전체 프로젝트 조회 API", description = "전체 프로젝트를 조회하는 API이며 페이징을 포함합니다. 요청 파라미터로 page 번호를 입력할 수 있습니다.")
+    public ApiResponse<ItemResponseDTO.ItemResultListDTO> viewAllItems(
+            Authentication authentication,
+            @RequestParam(value = "page", defaultValue = "0") @Min(1) Integer page,
+            @RequestParam(value = "sort", defaultValue = "latest") String sort,
+            @RequestParam(value = "category", required = false) String category) {
+        Pageable pageable = PageRequest.of(page - 1, DEFAULT_ITEM_PAGE_SIZE);
+
+        Set<Long> likedItemIds = Collections.emptySet();
+
+        if (authentication != null) {
+            String email = authentication.getName();
+            Member member = memberCommandService.getMember(email);
+            likedItemIds = itemCommandService.findItemLikes(member.getId());
+        }
+
+        List<ItemResponseDTO.ItemResultDTO> allItems = itemCommandService.searchItems(pageable, likedItemIds, category, sort);
         return ApiResponse.onSuccess(ItemConverter.toItemResultListDTO(allItems));
     }
 

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -23,7 +23,7 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemResponseDTO.ItemResultDTO toItemResultDTO(Item item, int commentCount, boolean itemLike) {
+    public static ItemResponseDTO.ItemResultDTO toItemResultDTO(Item item, Long commentCount, boolean itemLike) {
         return ItemResponseDTO.ItemResultDTO.builder()
                 .itemId(item.getId())
                 .itemName(item.getName())
@@ -32,7 +32,7 @@ public class ItemConverter {
                 .introduce(item.getIntroduce())
                 .memberProfileImageUrl(item.getMember().getProfileImageUrl())
                 .itemImageUrl(item.getItemProfileImageUrl())
-                .updatedAt(item.getUpdatedAt().toLocalDate())
+                .updatedAt(item.getUpdatedAt())
                 .recruitStatus(item.isProjectStatus())
                 .viewCount(item.getViewCount())
                 .commentCount(commentCount)

--- a/src/main/java/umc/lightup/item/converter/ItemConverter.java
+++ b/src/main/java/umc/lightup/item/converter/ItemConverter.java
@@ -23,7 +23,7 @@ public class ItemConverter {
                 .build();
     }
 
-    public static ItemResponseDTO.ItemResultDTO toItemResultDTO(Item item, String itemImageUrl, int commentCount, boolean itemLike) {
+    public static ItemResponseDTO.ItemResultDTO toItemResultDTO(Item item, int commentCount, boolean itemLike) {
         return ItemResponseDTO.ItemResultDTO.builder()
                 .itemId(item.getId())
                 .itemName(item.getName())
@@ -31,7 +31,7 @@ public class ItemConverter {
                 .schoolName(item.getMember().getSchool() == null ? null : item.getMember().getSchool().getName())
                 .introduce(item.getIntroduce())
                 .memberProfileImageUrl(item.getMember().getProfileImageUrl())
-                .itemImageUrl(itemImageUrl)
+                .itemImageUrl(item.getItemProfileImageUrl())
                 .updatedAt(item.getUpdatedAt().toLocalDate())
                 .recruitStatus(item.isProjectStatus())
                 .viewCount(item.getViewCount())

--- a/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
@@ -130,13 +130,7 @@ public class ItemRequestDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ItemSearchRequestDTO {
-        private String category;
-        private Long positionId;
+    public static class ItemRegionSearchRequestDTO {
         private List<CollaborationRegionRequestDTO> itemRegions;
-        @Positive
-        private Long page;
-        @Positive
-        private Long limit;
     }
 }

--- a/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemRequestDTO.java
@@ -1,12 +1,8 @@
 package umc.lightup.item.dto;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.Setter;
+import jakarta.validation.constraints.*;
+import lombok.*;
 import umc.lightup.position.validation.annotation.ExistPosition;
 import umc.lightup.region.validation.annotation.ExistSiDo;
 import umc.lightup.region.validation.annotation.ExistSiGunGu;
@@ -66,6 +62,7 @@ public class ItemRequestDTO {
 
     @Getter
     @Setter
+    @Builder
     public static class CollaborationRegionRequestDTO {
         @NotBlank
         @ExistSiDo
@@ -126,5 +123,20 @@ public class ItemRequestDTO {
     public static class ItemCommentRequestDTO {
         @NotBlank
         private String content;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemSearchRequestDTO {
+        private String category;
+        private Long positionId;
+        private List<CollaborationRegionRequestDTO> itemRegions;
+        @Positive
+        private Long page;
+        @Positive
+        private Long limit;
     }
 }

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -212,4 +212,13 @@ public class ItemResponseDTO {
         private List<RecruitPositionResultDTO> recruitPositions;
         private LocalDateTime updatedAt;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemInfoListDTO {
+        List<ItemResponseDTO.ItemResultDTO> items;
+        long numOfTotalResults;
+    }
 }

--- a/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
+++ b/src/main/java/umc/lightup/item/dto/ItemResponseDTO.java
@@ -43,11 +43,11 @@ public class ItemResponseDTO {
         private String memberName;
         private String memberProfileImageUrl;
         private String itemImageUrl;
-        private LocalDate updatedAt;
-        private boolean recruitStatus;
+        private LocalDateTime updatedAt;
+        private Boolean recruitStatus;
         private Long viewCount;
-        private int commentCount;
-        private boolean likedByCurrentUser;
+        private Long commentCount;
+        private Boolean likedByCurrentUser;
     }
 
     @Getter

--- a/src/main/java/umc/lightup/item/repository/ItemRepository.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepository.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface ItemRepository extends JpaRepository<Item, Long> {
+public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositoryCustom {
     List<Item> findByMember(Member member);
 
     @Query("select distinct i from Item i left join fetch i.itemComments ic left join fetch ic.commentMember where i.id = :itemId")

--- a/src/main/java/umc/lightup/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepositoryCustom.java
@@ -6,6 +6,5 @@ import org.springframework.data.domain.Pageable;
 import umc.lightup.item.dto.ItemRequestDTO;
 
 public interface ItemRepositoryCustom {
-
     Page<Tuple> searchItems(Pageable pageable, String category, Long positionId, ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs, String sort);
 }

--- a/src/main/java/umc/lightup/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepositoryCustom.java
@@ -11,5 +11,5 @@ public interface ItemRepositoryCustom {
     ItemResponseDTO.ItemInfoListDTO getItemInfos
             (Member currentMember, ItemRequestDTO.ItemSearchRequestDTO options);
 
-    Page<Tuple> searchItems(Pageable pageable, String category, String sort);
+    Page<Tuple> searchItems(Pageable pageable, String category, Long positionId, String sort);
 }

--- a/src/main/java/umc/lightup/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepositoryCustom.java
@@ -1,0 +1,15 @@
+package umc.lightup.item.repository;
+
+import com.querydsl.core.Tuple;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import umc.lightup.item.dto.ItemRequestDTO;
+import umc.lightup.item.dto.ItemResponseDTO;
+import umc.lightup.member.domain.Member;
+
+public interface ItemRepositoryCustom {
+    ItemResponseDTO.ItemInfoListDTO getItemInfos
+            (Member currentMember, ItemRequestDTO.ItemSearchRequestDTO options);
+
+    Page<Tuple> searchItems(Pageable pageable, String category, String sort);
+}

--- a/src/main/java/umc/lightup/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepositoryCustom.java
@@ -4,12 +4,8 @@ import com.querydsl.core.Tuple;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import umc.lightup.item.dto.ItemRequestDTO;
-import umc.lightup.item.dto.ItemResponseDTO;
-import umc.lightup.member.domain.Member;
 
 public interface ItemRepositoryCustom {
-    ItemResponseDTO.ItemInfoListDTO getItemInfos
-            (Member currentMember, ItemRequestDTO.ItemSearchRequestDTO options);
 
-    Page<Tuple> searchItems(Pageable pageable, String category, Long positionId, String sort);
+    Page<Tuple> searchItems(Pageable pageable, String category, Long positionId, ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs, String sort);
 }

--- a/src/main/java/umc/lightup/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepositoryCustom.java
@@ -1,10 +1,18 @@
 package umc.lightup.item.repository;
 
-import com.querydsl.core.Tuple;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import umc.lightup.item.dto.ItemRequestDTO;
+import umc.lightup.item.dto.ItemResponseDTO;
+import umc.lightup.member.domain.Member;
+
+import java.util.List;
 
 public interface ItemRepositoryCustom {
-    Page<Tuple> searchItems(Pageable pageable, String category, Long positionId, ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs, String sort);
+    List<ItemResponseDTO.ItemResultDTO> searchItems(Member requestedMember,
+                                                    Pageable pageable,
+                                                    String category,
+                                                    Long positionId,
+                                                    ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs,
+                                                    Boolean onlyLiked,
+                                                    String sort);
 }

--- a/src/main/java/umc/lightup/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepositoryImpl.java
@@ -142,7 +142,7 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom{
     }
 
     @Override
-    public Page<Tuple> searchItems(Pageable pageable, String category, String sort) {
+    public Page<Tuple> searchItems(Pageable pageable, String category, Long positionId, String sort) {
         BooleanBuilder predicate = new BooleanBuilder();
 
         // 1) CategoryType 필터
@@ -159,6 +159,20 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom{
                     .exists();
 
             predicate.and(categoryCondition);
+        }
+
+        // 2) Position 필터
+        if (positionId != null) {
+            BooleanExpression positionCondition = JPAExpressions
+                    .selectOne()
+                    .from(recruitPosition)
+                    .where(
+                            recruitPosition.item.eq(item),
+                            recruitPosition.position.id.eq(positionId)
+                    )
+                    .exists();
+
+            predicate.and(positionCondition);
         }
 
         OrderSpecifier<?> orderSpecifier;

--- a/src/main/java/umc/lightup/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepositoryImpl.java
@@ -3,7 +3,6 @@ package umc.lightup.item.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -14,9 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import umc.lightup.item.domain.*;
 import umc.lightup.item.dto.ItemRequestDTO;
-import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.item.enums.CategoryType;
-import umc.lightup.member.domain.Member;
 import umc.lightup.member.domain.QMember;
 import umc.lightup.school.domain.QSchool;
 
@@ -36,113 +33,11 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom{
     private final QSchool school = QSchool.school;
 
     @Override
-    public ItemResponseDTO.ItemInfoListDTO getItemInfos(Member currentMember,
-                                                        ItemRequestDTO.ItemSearchRequestDTO options) {
-        BooleanBuilder predicate = new BooleanBuilder();
-
-        // 1) CategoryType 필터
-        if (options.getCategory() != null && !options.getCategory().isEmpty()) {
-            CategoryType categoryType = CategoryType.toCategoryType(options.getCategory());
-
-            BooleanExpression categoryCondition = JPAExpressions
-                    .selectOne()
-                    .from(itemCategory)
-                    .where(
-                        itemCategory.item.eq(item),
-                        itemCategory.categoryType.eq(categoryType)
-                    )
-                    .exists();
-
-            predicate.and(categoryCondition);
-        }
-
-        // 2) Region 필터
-        if (options.getItemRegions() != null && !options.getItemRegions().isEmpty()) {
-            BooleanBuilder regionBuilder = new BooleanBuilder();
-            for (ItemRequestDTO.CollaborationRegionRequestDTO cond : options.getItemRegions()) {
-                if (cond.getSiGunGu() != null)
-                    regionBuilder.or(
-                            JPAExpressions
-                                    .selectOne()
-                                    .from(itemRegion)
-                                    .where(
-                                        itemRegion.item.eq(item),
-                                        itemRegion.siDo.eq(cond.getSiDo()),
-                                        itemRegion.siGunGu.eq(cond.getSiGunGu())
-                                    )
-                                    .exists()
-                    );
-                else regionBuilder.or(
-                        JPAExpressions
-                                .selectOne()
-                                .from(itemRegion)
-                                .where(
-                                    itemRegion.item.eq(item),
-                                    itemRegion.siDo.eq(cond.getSiDo())
-                                )
-                                .exists()
-                );
-            }
-            predicate.and(regionBuilder);
-        }
-
-        // 3) Position 필터링
-        if (options.getPositionId() != null) {
-            Long positionId = options.getPositionId();
-
-            BooleanExpression positionCondition = JPAExpressions
-                    .selectOne()
-                    .from(recruitPosition)
-                    .where(
-                            recruitPosition.item.eq(item),
-                            recruitPosition.position.id.eq(positionId)
-                    )
-                    .exists();
-
-            predicate.and(positionCondition);
-        }
-
-        List<ItemResponseDTO.ItemResultDTO> itemResultDTOList = jpaQueryFactory
-                .select(Projections.constructor(
-                        ItemResponseDTO.ItemResultDTO.class,
-                        item.id,
-                        item.name,
-                        school.name,
-                        item.introduce,
-                        member.name,
-                        member.profileImageUrl,
-                        item.itemProfileImageUrl,
-                        item.updatedAt,
-                        item.projectStatus,
-                        item.viewCount,
-                        // 프로젝트 댓글 개수
-                        JPAExpressions
-                                .select(itemComment.count())
-                                .from(itemComment)
-                                .where(itemComment.item.eq(item)),
-                        // 프로젝트 좋아요 여부
-                        JPAExpressions
-                                .selectOne()
-                                .from(itemLike)
-                                .where(
-                                        itemLike.item.eq(item),
-                                        itemLike.member.id.eq(currentMember.getId())
-                                )
-                                .exists()
-                ))
-                .from(item)
-                .join(item.member, member)
-                .join(item.member.school, school)
-                .where(predicate)
-                .fetch();
-
-        return ItemResponseDTO.ItemInfoListDTO.builder()
-                .items(itemResultDTOList)
-                .build();
-    }
-
-    @Override
-    public Page<Tuple> searchItems(Pageable pageable, String category, Long positionId, String sort) {
+    public Page<Tuple> searchItems(Pageable pageable,
+                                   String category,
+                                   Long positionId,
+                                   ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs,
+                                   String sort) {
         BooleanBuilder predicate = new BooleanBuilder();
 
         // 1) CategoryType 필터
@@ -173,6 +68,36 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom{
                     .exists();
 
             predicate.and(positionCondition);
+        }
+
+        // 3) Region 필터
+        if (itemRegionDTOs.getItemRegions() != null && !itemRegionDTOs.getItemRegions().isEmpty()) {
+            BooleanBuilder regionBuilder = new BooleanBuilder();
+            for (ItemRequestDTO.CollaborationRegionRequestDTO cond : itemRegionDTOs.getItemRegions()) {
+                if (cond.getSiGunGu() != null)
+                    regionBuilder.or(
+                            JPAExpressions
+                                    .selectOne()
+                                    .from(itemRegion)
+                                    .where(
+                                            itemRegion.item.eq(item),
+                                            itemRegion.siDo.eq(cond.getSiDo()),
+                                            itemRegion.siGunGu.eq(cond.getSiGunGu())
+                                    )
+                                    .exists()
+                    );
+                else regionBuilder.or(
+                        JPAExpressions
+                                .selectOne()
+                                .from(itemRegion)
+                                .where(
+                                        itemRegion.item.eq(item),
+                                        itemRegion.siDo.eq(cond.getSiDo())
+                                )
+                                .exists()
+                );
+            }
+            predicate.and(regionBuilder);
         }
 
         OrderSpecifier<?> orderSpecifier;

--- a/src/main/java/umc/lightup/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepositoryImpl.java
@@ -1,0 +1,193 @@
+package umc.lightup.item.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import umc.lightup.item.domain.*;
+import umc.lightup.item.dto.ItemRequestDTO;
+import umc.lightup.item.dto.ItemResponseDTO;
+import umc.lightup.item.enums.CategoryType;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.QMember;
+import umc.lightup.school.domain.QSchool;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ItemRepositoryImpl implements ItemRepositoryCustom{
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QItem item = QItem.item;
+    private final QMember member = QMember.member;
+    private final QItemCategory itemCategory = QItemCategory.itemCategory;
+    private final QRecruitPosition recruitPosition = QRecruitPosition.recruitPosition;
+    private final QItemRegion itemRegion = QItemRegion.itemRegion;
+    private final QItemComment itemComment = QItemComment.itemComment;
+    private final QItemLike itemLike = QItemLike.itemLike;
+    private final QSchool school = QSchool.school;
+
+    @Override
+    public ItemResponseDTO.ItemInfoListDTO getItemInfos(Member currentMember,
+                                                        ItemRequestDTO.ItemSearchRequestDTO options) {
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        // 1) CategoryType 필터
+        if (options.getCategory() != null && !options.getCategory().isEmpty()) {
+            CategoryType categoryType = CategoryType.toCategoryType(options.getCategory());
+
+            BooleanExpression categoryCondition = JPAExpressions
+                    .selectOne()
+                    .from(itemCategory)
+                    .where(
+                        itemCategory.item.eq(item),
+                        itemCategory.categoryType.eq(categoryType)
+                    )
+                    .exists();
+
+            predicate.and(categoryCondition);
+        }
+
+        // 2) Region 필터
+        if (options.getItemRegions() != null && !options.getItemRegions().isEmpty()) {
+            BooleanBuilder regionBuilder = new BooleanBuilder();
+            for (ItemRequestDTO.CollaborationRegionRequestDTO cond : options.getItemRegions()) {
+                if (cond.getSiGunGu() != null)
+                    regionBuilder.or(
+                            JPAExpressions
+                                    .selectOne()
+                                    .from(itemRegion)
+                                    .where(
+                                        itemRegion.item.eq(item),
+                                        itemRegion.siDo.eq(cond.getSiDo()),
+                                        itemRegion.siGunGu.eq(cond.getSiGunGu())
+                                    )
+                                    .exists()
+                    );
+                else regionBuilder.or(
+                        JPAExpressions
+                                .selectOne()
+                                .from(itemRegion)
+                                .where(
+                                    itemRegion.item.eq(item),
+                                    itemRegion.siDo.eq(cond.getSiDo())
+                                )
+                                .exists()
+                );
+            }
+            predicate.and(regionBuilder);
+        }
+
+        // 3) Position 필터링
+        if (options.getPositionId() != null) {
+            Long positionId = options.getPositionId();
+
+            BooleanExpression positionCondition = JPAExpressions
+                    .selectOne()
+                    .from(recruitPosition)
+                    .where(
+                            recruitPosition.item.eq(item),
+                            recruitPosition.position.id.eq(positionId)
+                    )
+                    .exists();
+
+            predicate.and(positionCondition);
+        }
+
+        List<ItemResponseDTO.ItemResultDTO> itemResultDTOList = jpaQueryFactory
+                .select(Projections.constructor(
+                        ItemResponseDTO.ItemResultDTO.class,
+                        item.id,
+                        item.name,
+                        school.name,
+                        item.introduce,
+                        member.name,
+                        member.profileImageUrl,
+                        item.itemProfileImageUrl,
+                        item.updatedAt,
+                        item.projectStatus,
+                        item.viewCount,
+                        // 프로젝트 댓글 개수
+                        JPAExpressions
+                                .select(itemComment.count())
+                                .from(itemComment)
+                                .where(itemComment.item.eq(item)),
+                        // 프로젝트 좋아요 여부
+                        JPAExpressions
+                                .selectOne()
+                                .from(itemLike)
+                                .where(
+                                        itemLike.item.eq(item),
+                                        itemLike.member.id.eq(currentMember.getId())
+                                )
+                                .exists()
+                ))
+                .from(item)
+                .join(item.member, member)
+                .join(item.member.school, school)
+                .where(predicate)
+                .fetch();
+
+        return ItemResponseDTO.ItemInfoListDTO.builder()
+                .items(itemResultDTOList)
+                .build();
+    }
+
+    @Override
+    public Page<Tuple> searchItems(Pageable pageable, String category, String sort) {
+        BooleanBuilder predicate = new BooleanBuilder();
+
+        // 1) CategoryType 필터
+        if (category != null) {
+            CategoryType categoryType = CategoryType.toCategoryType(category);
+
+            BooleanExpression categoryCondition = JPAExpressions
+                    .selectOne()
+                    .from(itemCategory)
+                    .where(
+                            itemCategory.item.eq(item),
+                            itemCategory.categoryType.eq(categoryType)
+                    )
+                    .exists();
+
+            predicate.and(categoryCondition);
+        }
+
+        OrderSpecifier<?> orderSpecifier;
+
+        if ("popular".equals(sort)) {
+            orderSpecifier = item.viewCount.desc();
+        } else {
+            orderSpecifier = item.createdAt.desc();
+        }
+
+        // 프로젝트 댓글 수와 같이 가져오기
+        List<Tuple> results = jpaQueryFactory
+                .select(item, itemComment.id.count())
+                .from(item)
+                .leftJoin(itemComment).on(itemComment.item.eq(item))
+                .where(predicate)
+                .groupBy(item.id)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(orderSpecifier)
+                .fetch();
+
+        long total = jpaQueryFactory
+                .select(item.count())
+                .from(item)
+                .where(predicate)
+                .fetchOne();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+}
+

--- a/src/main/java/umc/lightup/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepositoryImpl.java
@@ -14,8 +14,6 @@ import org.springframework.stereotype.Repository;
 import umc.lightup.item.domain.*;
 import umc.lightup.item.dto.ItemRequestDTO;
 import umc.lightup.item.enums.CategoryType;
-import umc.lightup.member.domain.QMember;
-import umc.lightup.school.domain.QSchool;
 
 import java.util.List;
 
@@ -24,13 +22,10 @@ import java.util.List;
 public class ItemRepositoryImpl implements ItemRepositoryCustom{
     private final JPAQueryFactory jpaQueryFactory;
     private final QItem item = QItem.item;
-    private final QMember member = QMember.member;
     private final QItemCategory itemCategory = QItemCategory.itemCategory;
     private final QRecruitPosition recruitPosition = QRecruitPosition.recruitPosition;
     private final QItemRegion itemRegion = QItemRegion.itemRegion;
     private final QItemComment itemComment = QItemComment.itemComment;
-    private final QItemLike itemLike = QItemLike.itemLike;
-    private final QSchool school = QSchool.school;
 
     @Override
     public Page<Tuple> searchItems(Pageable pageable,

--- a/src/main/java/umc/lightup/item/repository/ItemRepositoryImpl.java
+++ b/src/main/java/umc/lightup/item/repository/ItemRepositoryImpl.java
@@ -1,19 +1,22 @@
 package umc.lightup.item.repository;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import umc.lightup.item.domain.*;
 import umc.lightup.item.dto.ItemRequestDTO;
+import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.item.enums.CategoryType;
+import umc.lightup.member.domain.Member;
+import umc.lightup.member.domain.QMember;
+import umc.lightup.school.domain.QSchool;
 
 import java.util.List;
 
@@ -22,17 +25,22 @@ import java.util.List;
 public class ItemRepositoryImpl implements ItemRepositoryCustom{
     private final JPAQueryFactory jpaQueryFactory;
     private final QItem item = QItem.item;
+    private final QMember member = QMember.member;
     private final QItemCategory itemCategory = QItemCategory.itemCategory;
     private final QRecruitPosition recruitPosition = QRecruitPosition.recruitPosition;
     private final QItemRegion itemRegion = QItemRegion.itemRegion;
     private final QItemComment itemComment = QItemComment.itemComment;
+    private final QItemLike itemLike = QItemLike.itemLike;
+    private final QSchool school = QSchool.school;
 
     @Override
-    public Page<Tuple> searchItems(Pageable pageable,
-                                   String category,
-                                   Long positionId,
-                                   ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs,
-                                   String sort) {
+    public List<ItemResponseDTO.ItemResultDTO> searchItems(Member requestedMember,
+                                                           Pageable pageable,
+                                                           String category,
+                                                           Long positionId,
+                                                           ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs,
+                                                           Boolean onlyLiked,
+                                                           String sort) {
         BooleanBuilder predicate = new BooleanBuilder();
 
         // 1) CategoryType 필터
@@ -95,6 +103,15 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom{
             predicate.and(regionBuilder);
         }
 
+        // 4) ItemLike(좋아요) 필터
+        if (requestedMember != null && onlyLiked != null && onlyLiked) {
+            predicate.and(getLikedCondition(requestedMember));
+        }
+
+        BooleanExpression likedCondition;
+        if (requestedMember == null) likedCondition = Expressions.FALSE;
+        else likedCondition = getLikedCondition(requestedMember);
+
         OrderSpecifier<?> orderSpecifier;
 
         if ("popular".equals(sort)) {
@@ -103,25 +120,47 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom{
             orderSpecifier = item.createdAt.desc();
         }
 
-        // 프로젝트 댓글 수와 같이 가져오기
-        List<Tuple> results = jpaQueryFactory
-                .select(item, itemComment.id.count())
+        return jpaQueryFactory
+                .select(Projections.constructor(ItemResponseDTO.ItemResultDTO.class,
+                        item.id,
+                        item.name,
+                        school.name,
+                        item.introduce,
+                        member.name,
+                        member.profileImageUrl,
+                        item.itemProfileImageUrl,
+                        item.updatedAt,
+                        item.projectStatus,
+                        item.viewCount,
+
+                        // 댓글 개수
+                        JPAExpressions
+                                .select(itemComment.count())
+                                .from(itemComment)
+                                .where(itemComment.item.eq(item)),
+
+                        // 좋아요 여부
+                        likedCondition
+                ))
                 .from(item)
-                .leftJoin(itemComment).on(itemComment.item.eq(item))
+                .leftJoin(item.member, member)
+                .leftJoin(member.school, school)
                 .where(predicate)
-                .groupBy(item.id)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(orderSpecifier)
                 .fetch();
+    }
 
-        long total = jpaQueryFactory
-                .select(item.count())
-                .from(item)
-                .where(predicate)
-                .fetchOne();
-
-        return new PageImpl<>(results, pageable, total);
+    private BooleanExpression getLikedCondition(Member requestedMember) {
+        return JPAExpressions
+                .selectOne()
+                .from(itemLike)
+                .where(
+                        itemLike.item.eq(item),
+                        itemLike.member.eq(requestedMember)
+                )
+                .exists();
     }
 }
 

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -54,5 +54,9 @@ public interface ItemCommandService {
 
     List<ItemResponseDTO.ItemCommentResultDTO> getItemComments(Item item);
 
-    List<ItemResponseDTO.ItemResultDTO> searchItems(Pageable pageable, @Nullable Set<Long> likedItemIds, @Nullable String category, String sort);
+    List<ItemResponseDTO.ItemResultDTO> searchItems(Pageable pageable,
+                                                    @Nullable Set<Long> likedItemIds,
+                                                    @Nullable String category,
+                                                    @Nullable Long positionId,
+                                                    String sort);
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -58,5 +58,6 @@ public interface ItemCommandService {
                                                     @Nullable Set<Long> likedItemIds,
                                                     @Nullable String category,
                                                     @Nullable Long positionId,
+                                                    @Nullable ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs,
                                                     String sort);
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -2,8 +2,6 @@ package umc.lightup.item.service;
 
 import jakarta.annotation.Nullable;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.web.multipart.MultipartFile;
 import umc.lightup.item.domain.Item;
 import umc.lightup.item.domain.ItemApply;
@@ -13,7 +11,6 @@ import umc.lightup.item.dto.ItemResponseDTO;
 import umc.lightup.member.domain.Member;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 public interface ItemCommandService {

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -54,5 +54,5 @@ public interface ItemCommandService {
 
     List<ItemResponseDTO.ItemCommentResultDTO> getItemComments(Item item);
 
-//    ItemResponseDTO.ItemInfoListDTO searchItems(Member member, ItemRequestDTO.ItemSearchRequestDTO request);
+    List<ItemResponseDTO.ItemResultDTO> searchItems(Pageable pageable, @Nullable Set<Long> likedItemIds, @Nullable String category, String sort);
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandService.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandService.java
@@ -34,12 +34,12 @@ public interface ItemCommandService {
                          ItemRequestDTO.AcceptItemOfferRequestDTO acceptItemOfferRequestDTO);
     ItemComment createItemComment(Member member, Long itemId, ItemRequestDTO.ItemCommentRequestDTO request);
     void removeItemComment(Member member, Long commentId);
-    Set<Long> findItemLikes(long memberId);
+//    Set<Long> findItemLikes(long memberId);
     int countComments(Long itemId);
 
-    List<ItemResponseDTO.ItemResultDTO> getAllItems(Pageable pageable,
+/*    List<ItemResponseDTO.ItemResultDTO> getAllItems(Pageable pageable,
                                                     @Nullable Set<Long> likedItemIds,
-                                                    @Nullable String category);
+                                                    @Nullable String category);*/
 
     List<ItemResponseDTO.MyItemResultDTO> getMyItems(Member member);
 
@@ -51,10 +51,11 @@ public interface ItemCommandService {
 
     List<ItemResponseDTO.ItemCommentResultDTO> getItemComments(Item item);
 
-    List<ItemResponseDTO.ItemResultDTO> searchItems(Pageable pageable,
-                                                    @Nullable Set<Long> likedItemIds,
+    List<ItemResponseDTO.ItemResultDTO> searchItems(Member requestedMember,
+                                                    Pageable pageable,
                                                     @Nullable String category,
                                                     @Nullable Long positionId,
                                                     @Nullable ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs,
+                                                    @Nullable Boolean onlyLiked,
                                                     String sort);
 }

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -581,9 +581,14 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
     @Override
     public List<ItemResponseDTO.ItemResultDTO> searchItems(
-            Pageable pageable, Set<Long> likedItemIds, String category, Long positionId, String sort) {
+            Pageable pageable,
+            Set<Long> likedItemIds,
+            String category,
+            Long positionId,
+            ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs,
+            String sort) {
 
-        Page<Tuple> tuples = itemRepository.searchItems(pageable, category, positionId, sort);
+        Page<Tuple> tuples = itemRepository.searchItems(pageable, category, positionId, itemRegionDTOs, sort);
 
         return tuples.stream()
                 .map(t -> {

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package umc.lightup.item.service;
 
+import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -217,7 +218,9 @@ public class ItemCommandServiceImpl implements ItemCommandService {
     }
 
     @Override
-    public List<ItemResponseDTO.ItemResultDTO> getAllItems(Pageable pageable, Set<Long> likedItemIds, String category) {
+    public List<ItemResponseDTO.ItemResultDTO> getAllItems(
+            Pageable pageable, Set<Long> likedItemIds, String category) {
+
         Page<Item> itemPage;
 
         if (category == null || category.isBlank()) {
@@ -229,11 +232,10 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
         return itemPage.stream()
                 .map(item -> {
-                    String itemImageUrl = item.getItemProfileImageUrl();
                     boolean liked = likedItemIds != null && likedItemIds.contains(item.getId());
                     int commentCount = itemCommentRepository.countByItemId(item.getId());
 
-                    return ItemConverter.toItemResultDTO(item, itemImageUrl, commentCount, liked);
+                    return ItemConverter.toItemResultDTO(item, commentCount, liked);
                 }).toList();
     }
 
@@ -577,13 +579,25 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                 .toList();
     }
 
-/*    @Override
-    public ItemResponseDTO.ItemInfoListDTO searchItems(
-            Member member,
-            ItemRequestDTO.ItemSearchRequestDTO options) {
-        if (options.getItemRegions() == null) options.setItemRegions(List.of());
-        return itemRepository.getItemInfos(member, options);
-    }*/
+    @Override
+    public List<ItemResponseDTO.ItemResultDTO> searchItems(
+            Pageable pageable, Set<Long> likedItemIds, String category, String sort) {
+
+        Page<Tuple> tuples = itemRepository.searchItems(pageable, category, sort);
+
+        return tuples.stream()
+                .map(t -> {
+                    Item item = t.get(QItem.item);
+                    long itemCommentCount = t.get(QItemComment.itemComment.id.count());
+                    boolean liked = likedItemIds != null && likedItemIds.contains(Objects.requireNonNull(item).getId());
+                    if (item == null) {
+                        throw new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND);
+                    }
+
+                    return ItemConverter.toItemResultDTO(item, (int) itemCommentCount, liked);
+                })
+                .toList();
+    }
 
     private boolean checkItemApply(Member member, Item item, boolean isFromOwnerExpected) {
         return itemApplyRepository.findByMemberAndItem(member, item)

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -212,7 +212,7 @@ public class ItemCommandServiceImpl implements ItemCommandService {
         }
     }
 
-    @Override
+/*    @Override
     public Set<Long> findItemLikes(long memberId) {
         return itemLikeRepository.findItemIdsLikedByMemberId(memberId);
     }
@@ -237,7 +237,7 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
                     return ItemConverter.toItemResultDTO(item, commentCount, liked);
                 }).toList();
-    }
+    }*/
 
     @Override
     public List<ItemResponseDTO.MyItemResultDTO> getMyItems(Member member) {
@@ -581,27 +581,14 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
     @Override
     public List<ItemResponseDTO.ItemResultDTO> searchItems(
+            Member requestedMember,
             Pageable pageable,
-            Set<Long> likedItemIds,
             String category,
             Long positionId,
             ItemRequestDTO.ItemRegionSearchRequestDTO itemRegionDTOs,
+            Boolean onlyLiked,
             String sort) {
-
-        Page<Tuple> tuples = itemRepository.searchItems(pageable, category, positionId, itemRegionDTOs, sort);
-
-        return tuples.stream()
-                .map(t -> {
-                    Item item = t.get(QItem.item);
-                    long itemCommentCount = t.get(QItemComment.itemComment.id.count());
-                    boolean liked = likedItemIds != null && likedItemIds.contains(Objects.requireNonNull(item).getId());
-                    if (item == null) {
-                        throw new GeneralHandler(ErrorStatus.ITEM_NOT_FOUND);
-                    }
-
-                    return ItemConverter.toItemResultDTO(item, (int) itemCommentCount, liked);
-                })
-                .toList();
+        return itemRepository.searchItems(requestedMember, pageable, category, positionId, itemRegionDTOs, onlyLiked, sort);
     }
 
     private boolean checkItemApply(Member member, Item item, boolean isFromOwnerExpected) {

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -581,9 +581,9 @@ public class ItemCommandServiceImpl implements ItemCommandService {
 
     @Override
     public List<ItemResponseDTO.ItemResultDTO> searchItems(
-            Pageable pageable, Set<Long> likedItemIds, String category, String sort) {
+            Pageable pageable, Set<Long> likedItemIds, String category, Long positionId, String sort) {
 
-        Page<Tuple> tuples = itemRepository.searchItems(pageable, category, sort);
+        Page<Tuple> tuples = itemRepository.searchItems(pageable, category, positionId, sort);
 
         return tuples.stream()
                 .map(t -> {


### PR DESCRIPTION
## 💫 PR 제목
- [Item] 프로젝트 필터링 기능 구현

---

## 🔧 작업 내용 요약
- 프로젝트 필터링 기능 추가
- 모집 포지션별 필터링, 프로젝트 협업 지역별 필터링 추가
- 필터링 항목이 늘어남에 따라 QueryDSL 도입
- 기존 프로젝트 댓글 수를 가져오던 로직에서 N + 1 문제 발생 위험이 있어 프로젝트를 가져올때 댓글 수 카운팅까지 같이 가져오도록 변경


---

## 🔍 중점적으로 리뷰받고 싶은 부분
- QueryDSL 부분 로직이 적절한지

---

## 🔗 관련 이슈
- closes #118 

---

## 📝 기타 참고 사항
- 
