### PR TITLE
[Member] 카카오 회원가입 필드 값 수정

### DIFF
--- a/src/main/java/umc/lightup/member/controller/MemberCommonRestController.java
+++ b/src/main/java/umc/lightup/member/controller/MemberCommonRestController.java
@@ -3,6 +3,7 @@ package umc.lightup.member.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -64,6 +65,21 @@ public class MemberCommonRestController {
                                                                      @RequestBody @Valid MemberRequestDTO.BasicChangeDto request) {
         String email = authentication.getName();
         return ApiResponse.onSuccess(MemberConverter.toMyInfoDTO(memberCommandService.putMemberBasic(email, request)));
+    }
+
+    @GetMapping("/nickname/exist")
+    @Operation(
+            summary = "닉네임 중복 확인 API",
+            description = "닉네임 중복을 확인할 수 있는 API입니다. 자기 자신의 닉네임을 넣으면 null이 반환됩니다.",
+            security = {@SecurityRequirement(name = "JWT TOKEN")}
+    )
+    public ApiResponse<MemberResponseDTO.NicknameExistResultDTO> checkNicknameDuplicate(Authentication authentication,
+                                                                                        @RequestParam("value") @NotBlank String value) {
+        if (authentication != null &&
+                value.equals(memberCommandService.getMember(authentication.getName()).getNickname()))
+            return ApiResponse.onSuccess(new MemberResponseDTO.NicknameExistResultDTO(null));
+        else return ApiResponse.onSuccess(new MemberResponseDTO.NicknameExistResultDTO
+                (memberCommandService.isNicknameExist(value)));
     }
 
     @GetMapping("/{memberId}")

--- a/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
+++ b/src/main/java/umc/lightup/member/dto/MemberResponseDTO.java
@@ -201,6 +201,14 @@ public class MemberResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class NicknameExistResultDTO{
+        Boolean exist;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ProfileImageSaveResultDTO {
         String profileImageUrl;
     }

--- a/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
+++ b/src/main/java/umc/lightup/member/service/CredentialQueryServiceImpl.java
@@ -169,12 +169,12 @@ public class CredentialQueryServiceImpl implements CredentialQueryService {
         if (userinfo.getEmail() == null || memberCommandService.isEmailExist(userinfo.getEmail()))
             throw new GeneralHandler(ErrorStatus.ALREADY_SIGNED_IN_EMAIL);
 
-        String nickname = userinfo.getKakao_account().getProfile().getNickname();
-        if (memberCommandService.isNicknameExist(nickname)) nickname = null;
+        String name = userinfo.getKakao_account().getProfile().getNickname();
+        // if (memberCommandService.isNicknameExist(nickname)) nickname = null;
 
         Member member = Member.builder()
                 .email(userinfo.getEmail())
-                .nickname(nickname)
+                .name(name)
                 .profileImageUrl(userinfo.getKakao_account().getProfile().getProfile_image_url())
                 .role(Role.PROVISION)
                 .build();


### PR DESCRIPTION
## 💫 PR 제목
- [Member] 카카오 회원가입 필드 값 수정

---

## 🔧 작업 내용 요약
- 카카오 소셜로그인으로 회원가입 시 기존에 nickname에 채워지던 값을 name에 채워지도록 설정 (프론트엔드 요구사항)
- 닉네임 중복 확인 기능 구현 (프론트엔드 요구사항)

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 로직이 적절한지(특히 백엔드 단독으로는 테스트를 진행할 수 없는 소셜로그인 부분)

---

## 🔗 관련 이슈
- 이슈 없이 진행

---

## 📝 기타 참고 사항
- 없음