### PR TITLE
[Notification] 알림 목록 응답 데이터 수정

### DIFF
--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -1,8 +1,6 @@
 package umc.lightup.item.service;
 
-import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +22,6 @@ import umc.lightup.member.repository.MemberRepository;
 import umc.lightup.notification.dto.NotificationEventRequestDTO;
 import umc.lightup.notification.enums.NotificationType;
 import umc.lightup.notification.enums.ReferenceType;
-import umc.lightup.notification.service.NotificationCommandService;
 import umc.lightup.notification.utli.NotificationEventSender;
 import umc.lightup.position.domain.Position;
 import umc.lightup.position.repository.PositionRepository;
@@ -50,7 +47,6 @@ public class ItemCommandServiceImpl implements ItemCommandService {
     private final MemberRepository memberRepository;
 
     private final NotificationEventSender notificationEventSender;
-    private final NotificationCommandService notificationCommandService;
     private final AmazonS3Manager s3Manager;
     private final UuidRepository uuidRepository;
     private final ItemCategoryRepository itemCategoryRepository;
@@ -387,7 +383,6 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                         .referenceType(ReferenceType.MEMBER)
                         .referenceId(member.getId())
                         .build();
-        notificationCommandService.saveNotification(eventDTO);
         notificationEventSender.send(eventDTO);
 
         return itemApplyRepository.save(ItemApply.builder()
@@ -441,7 +436,6 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                         .referenceType(ReferenceType.ITEM)
                         .referenceId(itemApply.getItem().getId())
                         .build();
-        notificationCommandService.saveNotification(eventDTO);
         notificationEventSender.send(eventDTO);
     }
 
@@ -491,7 +485,6 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                         .referenceType(ReferenceType.ITEM)
                         .referenceId(item.getId())
                         .build();
-        notificationCommandService.saveNotification(eventDTO);
         notificationEventSender.send(eventDTO);
 
         return itemApplyRepository.save(ItemApply.builder()
@@ -533,7 +526,6 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                         .referenceType(ReferenceType.MEMBER)
                         .referenceId(offeredMember.getId())
                         .build();
-        notificationCommandService.saveNotification(eventDTO);
         notificationEventSender.send(eventDTO);
     }
 

--- a/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
+++ b/src/main/java/umc/lightup/item/service/ItemCommandServiceImpl.java
@@ -384,8 +384,8 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                                 "님에게서 " +
                                 item.getName() +
                                 "에 지원했어요!")
-                        .referenceType(ReferenceType.ITEM)
-                        .referenceId(item.getId())
+                        .referenceType(ReferenceType.MEMBER)
+                        .referenceId(member.getId())
                         .build();
         notificationCommandService.saveNotification(eventDTO);
         notificationEventSender.send(eventDTO);
@@ -530,8 +530,8 @@ public class ItemCommandServiceImpl implements ItemCommandService {
                                 // 그렇다고 알림에서부터 수락/거절 사실을 통보하면 마음아플 것 같음...
                                 // 취업준비할 때 거절은 이를 돌려 말하는 것처럼...
                         )
-                        .referenceType(ReferenceType.ITEM)
-                        .referenceId(itemApply.getItem().getId())
+                        .referenceType(ReferenceType.MEMBER)
+                        .referenceId(offeredMember.getId())
                         .build();
         notificationCommandService.saveNotification(eventDTO);
         notificationEventSender.send(eventDTO);

--- a/src/main/java/umc/lightup/notification/converter/NotificationConverter.java
+++ b/src/main/java/umc/lightup/notification/converter/NotificationConverter.java
@@ -19,6 +19,7 @@ public class NotificationConverter {
             .notificationType(String.valueOf(notification.getType()))
             .isRead(notification.getIsRead())
             .referenceId(notification.getReferenceId())
+            .createdAt(notification.getCreatedAt())
             .build();
   }
 

--- a/src/main/java/umc/lightup/notification/converter/NotificationConverter.java
+++ b/src/main/java/umc/lightup/notification/converter/NotificationConverter.java
@@ -16,8 +16,9 @@ public class NotificationConverter {
     return NotificationResponseDTO.NotificationDTO.builder()
             .notificationId(notification.getId())
             .message(notification.getMessage())
-            .notificationType(String.valueOf(notification.getType()))
+            .notificationType(notification.getType())
             .isRead(notification.getIsRead())
+            .referenceType(notification.getReferenceType())
             .referenceId(notification.getReferenceId())
             .createdAt(notification.getCreatedAt())
             .build();

--- a/src/main/java/umc/lightup/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/umc/lightup/notification/dto/NotificationResponseDTO.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.lightup.notification.enums.NotificationType;
+import umc.lightup.notification.enums.ReferenceType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,8 +31,9 @@ public class NotificationResponseDTO {
   public static class NotificationDTO {
     Long notificationId;  // 알림 Id
     String message;       // 알림 메시지 내용
-    String notificationType;  // 알림 종류
+    NotificationType notificationType; // 알림 종류(프론트에게 전송 시 자동으로 String으로 변환됨)
     Boolean isRead;           // 알림 읽음 여부
+    ReferenceType referenceType; // 래퍼런스 종류(프론트에게 전송 시 자동으로 String으로 변환됨)
     Long referenceId;         // 래퍼런스 아이디
     LocalDateTime createdAt;  // 만들어진 시간
   }

--- a/src/main/java/umc/lightup/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/umc/lightup/notification/dto/NotificationResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class NotificationResponseDTO {
@@ -31,6 +32,7 @@ public class NotificationResponseDTO {
     String notificationType;  // 알림 종류
     Boolean isRead;           // 알림 읽음 여부
     Long referenceId;         // 래퍼런스 아이디
+    LocalDateTime createdAt;  // 만들어진 시간
   }
 
   @Builder


### PR DESCRIPTION
## 💫 PR 제목
- [Notification] 알림 목록 응답 데이터 수정

---

## 🔧 작업 내용 요약
- 알림 목록 응답에 createdAt, referenceType 추가
- 프로젝트 지원, 제안 수락/거절 시 reference를 Member에 걸도록 수정
- 알림이 2회 저장되는 문제 수정

---

## 🔍 중점적으로 리뷰받고 싶은 부분
- 로직이 적절한지
- NotificationDTO에서 Enum 반환이 적절한지(단 프론트에게는 똑같이 String으로 전송됨)

---

## 🔗 관련 이슈
- 이슈 없이 진행

---

## 📝 기타 참고 사항
- 알림을 보내기만 해도 내역 저장이 되나 보네요. 알림 저장을 따로 수행했더니 동일한 내용의 알림이 2회 저장된다는 걸 방금 확인해 수정했습니다.